### PR TITLE
fix get network ns path

### DIFF
--- a/pkg/chaosdaemon/netem.go
+++ b/pkg/chaosdaemon/netem.go
@@ -12,15 +12,11 @@ import (
 	pb "github.com/pingcap/chaos-operator/pkg/chaosdaemon/pb"
 )
 
-const (
-	defaultProcPrefix = "/mnt/proc"
-)
-
 // Apply applies a netem on eth0 in pid related namespace
 func Apply(netem *pb.Netem, pid uint32) error {
 	glog.Infof("Apply netem on PID: %d", pid)
-	nsPath := fmt.Sprintf("%s/%d/ns/net", defaultProcPrefix, pid)
-	ns, err := netns.GetFromPath(nsPath)
+
+	ns, err := netns.GetFromPid(int(pid))
 	if err != nil {
 		glog.Errorf("error while finding network namespace %s", nsPath)
 		return errors.Trace(err)


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com> 

fix get network ns path
error log: 
```
2019-11-22T05:53:23.747Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "networkchaos", "request": "chaos-testing/network-delay-example", "error": "rpc error: code = Internal desc = netem apply error: no such file or directory"}
```