### PR TITLE
requeue when facing select error

### DIFF
--- a/controllers/podchaos/podkill/types.go
+++ b/controllers/podchaos/podkill/types.go
@@ -60,19 +60,19 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		pods, err := utils.SelectPods(ctx, r.Client, podchaos.Spec.Selector)
 		if err != nil {
 			r.Log.Error(err, "fail to get selected pods")
-			return ctrl.Result{}, nil
+			return ctrl.Result{requeue: true}, nil
 		}
 
 		if len(pods) == 0 {
 			err = errors.New("no pod is selected")
 			r.Log.Error(err, "no pod is selected")
-			return ctrl.Result{}, nil
+			return ctrl.Result{requeue: true}, nil
 		}
 
 		filteredPod, err := utils.GeneratePods(pods, podchaos.Spec.Mode, podchaos.Spec.Value)
 		if err != nil {
 			r.Log.Error(err, "fail to generate pods")
-			return ctrl.Result{}, nil
+			return ctrl.Result{requeue: true}, nil
 		}
 
 		g := errgroup.Group{}


### PR DESCRIPTION
Selecting error is relatively common in pod-kill chaos. If the former kill has not been resumed, this pod-kill chaos is very likely to select no pods. After several attempts, this error will be fixed automatically (after enough pods resumed)

So we should requeue this reconcile request, or this chaos will never resume from stop in the future.

Signed-off-by: Yang Keao <keao.yang@yahoo.com>