### PR TITLE
Set network namespace though `nsenter`

### DIFF
--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -2,10 +2,8 @@ package chaosdaemon
 
 import (
 	"fmt"
-	"net"
-	"sync"
-
 	"github.com/juju/errors"
+	"net"
 
 	pb "github.com/pingcap/chaos-operator/pkg/chaosdaemon/pb"
 
@@ -21,8 +19,7 @@ var log = ctrl.Log.WithName("chaos-daemon-server")
 
 // Server represents an HTTP server for tc daemon
 type Server struct {
-	crClient             ContainerRuntimeInfoClient
-	networkNamespaceLock sync.Mutex
+	crClient ContainerRuntimeInfoClient
 }
 
 func newServer() (*Server, error) {

--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -3,6 +3,7 @@ package chaosdaemon
 import (
 	"context"
 	"fmt"
+	"os/exec"
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/juju/errors"
@@ -56,4 +57,11 @@ func CreateContainerRuntimeInfoClient() (ContainerRuntimeInfoClient, error) {
 // GetNetnsPath returns network namespace path
 func GenNetnsPath(pid uint32) string {
 	return fmt.Sprintf("%s/%d/ns/net", defaultProcPrefix, pid)
+}
+
+func withNetNS(ctx context.Context, nsPath string, cmd string, args ...string) *exec.Cmd {
+	// BusyBox's nsenter is very confusing. This usage is found by several attempts
+	args = append([]string{"-n" + nsPath, "--", cmd}, args...)
+
+	return exec.CommandContext(ctx, "nsenter", args...)
 }


### PR DESCRIPTION
Some bugs related with network namespace has been found in production environment. Some `ipset` and `iptables` commands are leaked outside of container network namespace and are set in daemon network namespace.

As the go runtime will create a new OS thread for scheduling goroutine (especially before calling expensive syscall). It very complicate to analysis and set network namespace on all goroutine.

I have to believe there is no way to work with namespace safely in go process. So I have to use `nsenter` to spawn new process in other namespace. 

@cwen0 PTAL

Signed-off-by: Yang Keao <keao.yang@yahoo.com>