### PR TITLE
Fix panic caused by illegal log

### DIFF
--- a/controllers/networkchaos/types.go
+++ b/controllers/networkchaos/types.go
@@ -15,8 +15,6 @@ package networkchaos
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/go-logr/logr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,8 +48,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		reconciler := partition.NewReconciler(r.Client, r.Log.WithValues("action", "partition"), req)
 		return reconciler.Reconcile(req)
 	default:
-		err := fmt.Errorf("unknown action %s", string(networkchaos.Spec.Action))
-		r.Log.Error(err, "unknown action %s", string(networkchaos.Spec.Action))
+		r.Log.Error(nil, "networkchaos action is invalid", "action", networkchaos.Spec.Action)
 
 		return ctrl.Result{}, nil
 	}

--- a/controllers/podchaos/types.go
+++ b/controllers/podchaos/types.go
@@ -15,8 +15,6 @@ package podchaos
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/go-logr/logr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,8 +51,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		reconciler := podfailure.NewReconciler(r.Client, r.Log.WithValues("action", "pod-failure"), req)
 		return reconciler.Reconcile(req)
 	default:
-		err := fmt.Errorf("unknown action %s", string(podchaos.Spec.Action))
-		r.Log.Error(err, "unknown action %s", string(podchaos.Spec.Action))
+		r.Log.Error(nil, "podchaos action is invalid", "action", podchaos.Spec.Action)
 
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com> 

fix panic, panic log: 
```
2019-12-13T10:51:07.167Z        DPANIC  controllers.PodChaos    odd number of arguments passed as key-value pairs for logging   {"reconciler": "podchaos", "ignored key": ""}
github.com/go-logr/zapr.handleFields
        /home/pingcap/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:106
github.com/go-logr/zapr.(*zapLogger).Error
        /home/pingcap/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:129
github.com/pingcap/chaos-operator/controllers/podchaos.(*Reconciler).Reconcile
        /home/pingcap/go/src/github.com/pingcap/chaos-operator/controllers/podchaos/types.go:57
github.com/pingcap/chaos-operator/controllers.(*PodChaosReconciler).Reconcile
        /home/pingcap/go/src/github.com/pingcap/chaos-operator/controllers/podchaos_controller.go:43
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/pingcap/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:256
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
```