### PR TITLE
fix bugs introduced by hash ipset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ kubectl delete -f pod-kill-example.yaml
 
 #### Chaos Dashboard
 
-Chaos dashboard can be used to visualize chaos events. However, it **only** supports tidb now. To install dashboard with `chaos-mesh`:
+Chaos dashboard can be used to visualize chaos events. However, it **only** supports tidb now (so it isn't installed by default). To install dashboard with `chaos-mesh`:
 
 ```
 helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set dashboard.create=true

--- a/controllers/twophase/types.go
+++ b/controllers/twophase/types.go
@@ -65,7 +65,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var err error
 	now := time.Now()
 
-	r.Log.Info("reconciling a two phase chaos")
+	r.Log.Info("reconciling a two phase chaos", "name", req.Name, "namespace", req.Namespace)
 	ctx := context.Background()
 
 	chaos := r.Object()


### PR DESCRIPTION
Previous PR #55 doesn't replace every ipset name with new one. Especially "target" and "tgt", "source" and "src"...

This exposed another bug: if ipset name is wrong, the grpc request will blocked forever. But I haven't found the reason. This will be fixed in chaos-daemon these days.

Signed-off-by: Yang Keao <keao.yang@yahoo.com>