### PR TITLE
chaosdaemon: fix the bug of goroutine leak.

### DIFF
--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -43,6 +43,16 @@ type Config struct {
 	Profiling bool
 }
 
+// Get the http address
+func (c *Config) HttpAddr() string {
+	return fmt.Sprintf("%s:%d", c.Host, c.HTTPPort)
+}
+
+// Get the grpc address
+func (c *Config) GrpcAddr() string {
+	return fmt.Sprintf("%s:%d", c.Host, c.GRPCPort)
+}
+
 // Server represents a grpc server for tc daemon
 type daemonServer struct {
 	crClient ContainerRuntimeInfoClient
@@ -95,20 +105,17 @@ type RegisterGatherer interface {
 
 // StartServer starts chaos-daemon.
 func StartServer(conf *Config, reg RegisterGatherer) error {
-	g := errgroup.Group{}
+	g := &errgroup.Group{}
 
-	httpBindAddr := fmt.Sprintf("%s:%d", conf.Host, conf.HTTPPort)
-	srv := newHTTPServerBuilder().Addr(httpBindAddr).Metrics(reg).Profiling(conf.Profiling).Build()
+	httpBindAddr := conf.HttpAddr()
+	httpServer := newHTTPServerBuilder().Addr(httpBindAddr).Metrics(reg).Profiling(conf.Profiling).Build()
 
-	g.Go(func() error {
-		log.Info("Starting http endpoint", "address", httpBindAddr)
-		if err := srv.ListenAndServe(); err != nil {
-			log.Error(err, "failed to start http endpoint")
-			srv.Shutdown(context.Background())
-			return err
-		}
-		return nil
-	})
+	grpcBindAddr := conf.GrpcAddr()
+	grpcListener, err := net.Listen("tcp", grpcBindAddr)
+	if err != nil {
+		log.Error(err, "failed to listen grpc address", "grpcBindAddr", grpcBindAddr)
+		return err
+	}
 
 	grpcServer, err := newGRPCServer(conf.Runtime, reg)
 	if err != nil {
@@ -116,16 +123,19 @@ func StartServer(conf *Config, reg RegisterGatherer) error {
 		return err
 	}
 
-	grpcBindAddr := fmt.Sprintf("%s:%d", conf.Host, conf.GRPCPort)
-	lis, err := net.Listen("tcp", grpcBindAddr)
-	if err != nil {
-		log.Error(err, "failed to listen grpc address")
-		return err
-	}
+	g.Go(func() error {
+		log.Info("Starting http endpoint", "address", httpBindAddr)
+		if err := httpServer.ListenAndServe(); err != nil {
+			log.Error(err, "failed to start http endpoint")
+			httpServer.Shutdown(context.Background())
+			return err
+		}
+		return nil
+	})
 
 	g.Go(func() error {
 		log.Info("Starting grpc endpoint", "address", grpcBindAddr, "runtime", conf.Runtime)
-		if err := grpcServer.Serve(lis); err != nil {
+		if err := grpcServer.Serve(grpcListener); err != nil {
 			log.Error(err, "failed to start grpc endpoint")
 			grpcServer.Stop()
 			return err


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
It's a bug that lead to goroutine leak if an error return before `g.Wait()`

### What is changed and how does it work?

Move the `g.Go()` code to right postion.

### Check List
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- No code

Code changes

- Has Go code change


### Does this PR introduce a user-facing change?

<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
