### PR TITLE
Fix version script

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -21,20 +21,9 @@ set -euo pipefail
 #
 #    GIT_COMMIT - The git commit id corresponding to this
 #          source code.
-#    GIT_TREE_STATE - "clean" indicates no changes since the git commit id
-#        "dirty" indicates source code changes after the git commit id
-#        "archive" indicates the tree was produced by 'git archive'
 #    GIT_VERSION - "vX.Y" used to indicate the last release version.
 function chaos_mesh::version::get_version_vars() {
   if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
-    if [[ -z ${GIT_TREE_STATE-} ]]; then
-      # Check if the tree is dirty.  default to dirty
-      if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
-        GIT_TREE_STATE="clean"
-      else
-        GIT_TREE_STATE="dirty"
-      fi
-    fi
 
     # Use git describe to find the version based on tags.
     if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
@@ -51,20 +40,6 @@ function chaos_mesh::version::get_version_vars() {
       elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
         # We have distance to base tag (v1.1.0-1-gCommitHash)
         GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
-      fi
-      if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
-        # git describe --dirty only considers changes to existing files, but
-        # that is problematic since new untracked .go files affect the build,
-        # so use our idea of "dirty" from git status instead.
-        GIT_VERSION+="-dirty"
-      fi
-
-
-      # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
-      if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-        echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
-        echo "Please see more details here: https://semver.org"
-        exit 1
       fi
     fi
   fi
@@ -86,7 +61,6 @@ function chaos_mesh::version::ldflags() {
   local -a ldflags=($(chaos_mesh::version::ldflag "buildDate" "$(date ${buildDate} -u +'%Y-%m-%dT%H:%M:%SZ')"))
   if [[ -n ${GIT_COMMIT-} ]]; then
     ldflags+=($(chaos_mesh::version::ldflag "gitCommit" "${GIT_COMMIT}"))
-    ldflags+=($(chaos_mesh::version::ldflag "gitTreeState" "${GIT_TREE_STATE}"))
   fi
 
   if [[ -n ${GIT_VERSION-} ]]; then

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -15,24 +15,11 @@
 
 set -euo pipefail
 
-# -----------------------------------------------------------------------------
-# Version management helpers.  These functions help to set the
-# following variables:
-#
-#    GIT_COMMIT - The git commit id corresponding to this
-#          source code.
-#    GIT_VERSION - "vX.Y" used to indicate the last release version.
 function chaos_mesh::version::get_version_vars() {
   if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
 
     # Use git describe to find the version based on tags.
     if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
-      # This translates the "git describe" to an actual semver.org
-      # compatible semantic version that looks something like this:
-      #   v1.0.0-beta.0.10+4c183422345d8f
-      #
-      # TODO: We continue calling this "git version" because so many
-      # downstream consumers are expecting it there.
       DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
       if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
         # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)

--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -15,12 +15,12 @@ package version
 
 // Info contains versioning information.
 type Info struct {
-	GitVersion   string `json:"gitVersion"`
-	GitCommit    string `json:"gitCommit"`
-	BuildDate    string `json:"buildDate"`
-	GoVersion    string `json:"goVersion"`
-	Compiler     string `json:"compiler"`
-	Platform     string `json:"platform"`
+	GitVersion string `json:"gitVersion"`
+	GitCommit  string `json:"gitCommit"`
+	BuildDate  string `json:"buildDate"`
+	GoVersion  string `json:"goVersion"`
+	Compiler   string `json:"compiler"`
+	Platform   string `json:"platform"`
 }
 
 // String returns info as a human-friendly version string.

--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -17,7 +17,6 @@ package version
 type Info struct {
 	GitVersion   string `json:"gitVersion"`
 	GitCommit    string `json:"gitCommit"`
-	GitTreeState string `json:"gitTreeState"`
 	BuildDate    string `json:"buildDate"`
 	GoVersion    string `json:"goVersion"`
 	Compiler     string `json:"compiler"`

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,7 +21,6 @@ import (
 var (
 	gitVersion   = "v0.0.0-master+$Format:%h$"
 	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
 
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
@@ -38,7 +37,6 @@ func Get() Info {
 	return Info{
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
-		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,
 		GoVersion:    runtime.Version(),
 		Compiler:     runtime.Compiler,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	gitVersion   = "v0.0.0-master+$Format:%h$"
-	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitVersion = "v0.0.0-master+$Format:%h$"
+	gitCommit  = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
@@ -35,11 +35,11 @@ func PrintVersionInfo(name string) {
 func Get() Info {
 	// These variables typically come from -ldflags settings and in
 	return Info{
-		GitVersion:   gitVersion,
-		GitCommit:    gitCommit,
-		BuildDate:    buildDate,
-		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
-		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		GitVersion: gitVersion,
+		GitCommit:  gitCommit,
+		BuildDate:  buildDate,
+		GoVersion:  runtime.Version(),
+		Compiler:   runtime.Compiler,
+		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

At present, we use `chart-*` tag to release chart file, so we remove the `semver.org` checker and `GitTreeState`

