### PR TITLE
fix: remove unused stressor in StressChaos

### DIFF
--- a/ui/src/components/NewExperiment/Stepper/Target/Stress.tsx
+++ b/ui/src/components/NewExperiment/Stepper/Target/Stress.tsx
@@ -1,18 +1,48 @@
 import { Box, TextField as MUITextField, MenuItem, Typography } from '@material-ui/core'
 import { LabelField, TextField } from 'components/FormField'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import AdvancedOptions from 'components/AdvancedOptions'
 import { StepperFormTargetProps } from 'components/NewExperiment/types'
+import { defaultExperimentSchema } from 'components/NewExperiment/constants'
+import { getIn } from 'formik'
 import { resetOtherChaos } from 'lib/formikhelpers'
 
 const actions = ['CPU', 'Memory', 'Mixed']
 
 export default function Stress(props: StepperFormTargetProps) {
-  const [action, setAction] = useState('')
+  const { values, setFieldValue } = props
+
+  const actionRef = useRef('')
+  const [action, _setAction] = useState('')
+  const setAction = (newVal: string) => {
+    actionRef.current = newVal
+    _setAction(newVal)
+  }
 
   useEffect(() => {
     resetOtherChaos(props, 'StressChaos', false)
+
+    if (getIn(values, 'target.stress_chaos.stressors.cpu') === null) {
+      setFieldValue('target.stress_chaos.stressors.cpu', defaultExperimentSchema.target.stress_chaos.stressors.cpu)
+    }
+
+    if (getIn(values, 'target.stress_chaos.stressors.memory') === null) {
+      setFieldValue(
+        'target.stress_chaos.stressors.memory',
+        defaultExperimentSchema.target.stress_chaos.stressors.memory
+      )
+    }
+
+    // Remove another when choosing a single action
+    return () => {
+      if (actionRef.current === 'CPU') {
+        // Because LabelField will set value when before unmount, it's needed to wrap setFieldValue into setTimeout
+        setTimeout(() => setFieldValue('target.stress_chaos.stressors.memory', null))
+      } else if (actionRef.current === 'Memory') {
+        setTimeout(() => setFieldValue('target.stress_chaos.stressors.cpu', null))
+      }
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/ui/src/components/NewExperiment/types.ts
+++ b/ui/src/components/NewExperiment/types.ts
@@ -100,12 +100,12 @@ export interface ExperimentTargetStress {
       workers: number
       load: number
       options: string[]
-    }
+    } | null
     memory: {
       workers: number
       size: string
       options: string[]
-    }
+    } | null
   }
 }
 

--- a/ui/src/lib/hooks.ts
+++ b/ui/src/lib/hooks.ts
@@ -5,7 +5,7 @@ export function usePrevious<T>(value: T) {
 
   useEffect(() => {
     ref.current = value
-  })
+  }, [value])
 
   return ref.current
 }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

This PR will remove another unused stressor(CPU or Memory) when the user selects a single action(not Mixed).

If without this operation, the create `StressChaos` API will always complain that another stressor is empty.