### PR TITLE
Support container-wise StressChaos injection

### DIFF
--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -79,6 +79,7 @@ type StressChaosSpec struct {
 	// +optional
 	StressngStressors string `json:"stressngStressors,omitempty"`
 
+	// ContainerName indicates the target container to inject stress in
 	// +optional
 	ContainerName *string `json:"containerName,omitempty"`
 

--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -79,6 +79,9 @@ type StressChaosSpec struct {
 	// +optional
 	StressngStressors string `json:"stressngStressors,omitempty"`
 
+	// +optional
+	ContainerName *string `json:"containerName"`
+
 	// Duration represents the duration of the chaos action
 	// +optional
 	Duration *string `json:"duration,omitempty"`

--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -80,7 +80,7 @@ type StressChaosSpec struct {
 	StressngStressors string `json:"stressngStressors,omitempty"`
 
 	// +optional
-	ContainerName *string `json:"containerName"`
+	ContainerName *string `json:"containerName,omitempty"`
 
 	// Duration represents the duration of the chaos action
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -897,6 +897,11 @@ func (in *StressChaosSpec) DeepCopyInto(out *StressChaosSpec) {
 		*out = new(Stressors)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerName != nil {
+		in, out := &in.ContainerName, &out.ContainerName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
 		*out = new(string)

--- a/config/crd/bases/chaos-mesh.org_stresschaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_stresschaos.yaml
@@ -34,6 +34,8 @@ spec:
         spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
+            containerName:
+              type: string
             duration:
               description: Duration represents the duration of the chaos action
               type: string

--- a/config/crd/bases/chaos-mesh.org_stresschaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_stresschaos.yaml
@@ -35,6 +35,8 @@ spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
             containerName:
+              description: ContainerName indicates the target container to inject
+                stress in
               type: string
             duration:
               description: Duration represents the duration of the chaos action

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1242,6 +1242,8 @@ spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
             containerName:
+              description: ContainerName indicates the target container to inject
+                stress in
               type: string
             duration:
               description: Duration represents the duration of the chaos action

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1241,6 +1241,8 @@ spec:
         spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
+            containerName:
+              type: string
             duration:
               description: Duration represents the duration of the chaos action
               type: string


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Fix #755 

Support container wise injection and run stress-ng in container's cgroup in default. 

### What is changed and how does it work?

### Check List

Tests

- Manual test

Code changes

- Has Go code change


