### PR TITLE
fix: some minor problems

### DIFF
--- a/ui/src/api/events.type.ts
+++ b/ui/src/api/events.type.ts
@@ -4,19 +4,16 @@ export interface EventsParams {
 
 export interface EventPod {
   id: string
-  delete_at: string | null
-  event_id: number
   pod_ip: string
   pod_name: string
   namespace: string
-  message: string
   action: string
+  message: string
 }
 
 export interface Event {
   id: number
   experiment_id: uuid
-  deleted_at: string | null
   experiment: string
   namespace: string
   kind: string

--- a/ui/src/components/AffectedPods/index.tsx
+++ b/ui/src/components/AffectedPods/index.tsx
@@ -17,8 +17,8 @@ const AffectedPods: React.FC<{ pods: EventPod[] }> = ({ pods }) => (
       </TableHead>
       <TableBody>
         {pods &&
-          pods.map((pod) => (
-            <TableRow key={pod.id}>
+          pods.map((pod, i) => (
+            <TableRow key={i}>
               <TableCell>{pod.pod_ip}</TableCell>
               <TableCell>{pod.pod_name}</TableCell>
               <TableCell>{pod.namespace}</TableCell>

--- a/ui/src/components/EventsTable/index.tsx
+++ b/ui/src/components/EventsTable/index.tsx
@@ -82,8 +82,8 @@ function stableSort<T>(data: T[], comparator: (a: T, b: T) => number) {
   return indexed.map((el) => el[0])
 }
 
-type SortedEvent = Omit<Event, 'deleted_at' | 'pods'>
-type SortedEventWithPods = Omit<Event, 'deleted_at'>
+type SortedEvent = Omit<Event, 'pods'>
+type SortedEventWithPods = Event
 
 const headCells: { id: keyof SortedEvent; label: string }[] = [
   { id: 'experiment', label: 'Experiment' },

--- a/ui/src/components/EventsTable/index.tsx
+++ b/ui/src/components/EventsTable/index.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   IconButton,
   InputAdornment,
+  Paper,
   Table,
   TableBody,
   TableCell,
@@ -14,16 +15,18 @@ import {
   TableSortLabel,
   TextField,
 } from '@material-ui/core'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useImperativeHandle, useState } from 'react'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import { dayComparator, format } from 'lib/dayjs'
 
+import CloseIcon from '@material-ui/icons/Close'
 import { Event } from 'api/events.type'
+import EventDetail from 'components/EventDetail'
 import FirstPageIcon from '@material-ui/icons/FirstPage'
 import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft'
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
 import LastPageIcon from '@material-ui/icons/LastPage'
-import { Link } from 'react-router-dom'
+import Loading from 'components/Loading'
 import PaperTop from 'components/PaperTop'
 import SearchIcon from '@material-ui/icons/Search'
 import _debounce from 'lodash.debounce'
@@ -35,6 +38,14 @@ const useStyles = makeStyles(() =>
   createStyles({
     tableContainer: {
       maxHeight: 768,
+    },
+    eventDetailPaper: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      overflowY: 'scroll',
     },
   })
 )
@@ -171,9 +182,10 @@ const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({ count, 
 interface EventsTableRowProps {
   event: SortedEventWithPods
   detailed: boolean
+  onSelectEvent: (e: Event) => () => void
 }
 
-const EventsTableRow: React.FC<EventsTableRowProps> = ({ event: e, detailed }) => {
+const EventsTableRow: React.FC<EventsTableRowProps> = ({ event: e, detailed, onSelectEvent }) => {
   const runningLabel = useRunningLabelStyles()
 
   return (
@@ -189,13 +201,7 @@ const EventsTableRow: React.FC<EventsTableRowProps> = ({ event: e, detailed }) =
         </TableCell>
         {detailed && (
           <TableCell>
-            <Button
-              component={Link}
-              to={`/experiments/${e.experiment_id}?name=${e.experiment}&event=${e.id}`}
-              variant="outlined"
-              size="small"
-              color="primary"
-            >
+            <Button variant="outlined" size="small" color="primary" onClick={onSelectEvent(e)}>
               Detail
             </Button>
           </TableCell>
@@ -205,19 +211,21 @@ const EventsTableRow: React.FC<EventsTableRowProps> = ({ event: e, detailed }) =
   )
 }
 
-export interface EventsTableProps {
+export interface EventsTableHandles {
+  onSelectEvent: (e: Event) => () => void
+}
+
+interface EventsTableProps {
   title?: string
   events: Event[]
   detailed?: boolean
   hasSearch?: boolean
 }
 
-const EventsTable: React.FC<EventsTableProps> = ({
-  title = 'Events',
-  events: allEvents,
-  detailed = false,
-  hasSearch = true,
-}) => {
+const EventsTable: React.ForwardRefRenderFunction<EventsTableHandles, EventsTableProps> = (
+  { title = 'Events', events: allEvents, detailed = false, hasSearch = true },
+  ref
+) => {
   const classes = useStyles()
 
   const [events, setEvents] = useState(allEvents)
@@ -227,6 +235,22 @@ const EventsTable: React.FC<EventsTableProps> = ({
   const [rowsPerPage, setRowsPerPage] = useState(5)
   const [search, setSearch] = useState('')
   const previousSearch = usePrevious(search)
+
+  const [selectedEvent, setSelectedEvent] = useState<Event>()
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [eventDetailOpen, setEventDetailOpen] = useState(false)
+
+  const onSelectEvent = (e: Event) => () => {
+    setDetailLoading(true)
+    setSelectedEvent(e)
+    setEventDetailOpen(true)
+    setTimeout(() => setDetailLoading(false), 500)
+  }
+  // Methods exposed to the parent
+  useImperativeHandle(ref, () => ({
+    onSelectEvent,
+  }))
+  const closeEventDetail = () => setEventDetailOpen(false)
 
   const handleSortEvents = (_: React.MouseEvent<unknown>, k: keyof SortedEvent) => {
     const isAsc = orderBy === k && order === 'asc'
@@ -257,61 +281,86 @@ const EventsTable: React.FC<EventsTableProps> = ({
   }, [search])
 
   return (
-    <>
-      <PaperTop title={title}>
-        {hasSearch && (
-          <TextField
-            style={{ width: '200px', minWidth: '30%', margin: 0 }}
-            margin="dense"
-            placeholder="Search events ..."
-            disabled={!allEvents}
-            variant="outlined"
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon color="primary" />
-                </InputAdornment>
-              ),
-            }}
-            inputProps={{
-              style: { paddingTop: 8, paddingBottom: 8 },
-            }}
-            onChange={handleSearchChange}
-          />
-        )}
-      </PaperTop>
-      <TableContainer className={classes.tableContainer}>
-        <Table stickyHeader>
-          <EventsTableHead order={order} orderBy={orderBy} onSort={handleSortEvents} detailed={detailed} />
+    <Box position="relative">
+      <Paper variant="outlined">
+        <PaperTop title={title}>
+          {hasSearch && (
+            <TextField
+              style={{ width: '200px', minWidth: '30%', margin: 0 }}
+              margin="dense"
+              placeholder="Search events ..."
+              disabled={!allEvents}
+              variant="outlined"
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon color="primary" />
+                  </InputAdornment>
+                ),
+              }}
+              inputProps={{
+                style: { paddingTop: 8, paddingBottom: 8 },
+              }}
+              onChange={handleSearchChange}
+            />
+          )}
+        </PaperTop>
+        <TableContainer className={classes.tableContainer}>
+          <Table stickyHeader>
+            <EventsTableHead order={order} orderBy={orderBy} onSort={handleSortEvents} detailed={detailed} />
 
-          <TableBody>
-            {events &&
-              stableSort<SortedEvent>(events, getComparator(order, orderBy))
-                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map((e) => <EventsTableRow key={e.id} event={e as SortedEventWithPods} detailed={detailed} />)}
-          </TableBody>
+            <TableBody>
+              {events &&
+                stableSort<SortedEvent>(events, getComparator(order, orderBy))
+                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                  .map((e) => (
+                    <EventsTableRow
+                      key={e.id}
+                      event={e as SortedEventWithPods}
+                      detailed={detailed}
+                      onSelectEvent={onSelectEvent}
+                    />
+                  ))}
+            </TableBody>
 
-          <TableFooter>
-            <TableRow>
-              {events && (
-                <TablePagination
-                  count={events.length}
-                  page={page}
-                  rowsPerPageOptions={[5, 10, 25]}
-                  rowsPerPage={rowsPerPage}
-                  onChangePage={handleChangePage}
-                  onChangeRowsPerPage={handleChangeRowsPerPage}
-                  ActionsComponent={TablePaginationActions as any}
-                  labelDisplayedRows={({ from, to, count }) => `${from} - ${to} of ${count}`}
-                  labelRowsPerPage="Events per page"
-                />
-              )}
-            </TableRow>
-          </TableFooter>
-        </Table>
-      </TableContainer>
-    </>
+            <TableFooter>
+              <TableRow>
+                {events && (
+                  <TablePagination
+                    count={events.length}
+                    page={page}
+                    rowsPerPageOptions={[5, 10, 25]}
+                    rowsPerPage={rowsPerPage}
+                    onChangePage={handleChangePage}
+                    onChangeRowsPerPage={handleChangeRowsPerPage}
+                    ActionsComponent={TablePaginationActions as any}
+                    labelDisplayedRows={({ from, to, count }) => `${from} - ${to} of ${count}`}
+                    labelRowsPerPage="Events per page"
+                  />
+                )}
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </TableContainer>
+      </Paper>
+      {eventDetailOpen && (
+        <Paper
+          variant="outlined"
+          className={classes.eventDetailPaper}
+          style={{
+            zIndex: 3, // .MuiTableCell-stickyHeader z-index: 2
+          }}
+        >
+          <PaperTop title="Event Detail">
+            <IconButton color="primary" onClick={closeEventDetail}>
+              <CloseIcon />
+            </IconButton>
+          </PaperTop>
+          {selectedEvent && !detailLoading ? <EventDetail event={selectedEvent} /> : <Loading />}
+        </Paper>
+      )}
+    </Box>
   )
 }
 
-export default EventsTable
+export default React.forwardRef(EventsTable)

--- a/ui/src/components/ExperimentPaper/index.tsx
+++ b/ui/src/components/ExperimentPaper/index.tsx
@@ -100,9 +100,11 @@ const ExperimentPaper: React.FC<ExperimentPaperProps> = ({
 
   const Actions = () => (
     <Box display="flex" justifyContent="flex-end" alignItems="center" className={classes.marginRight}>
+      <Typography variant="body2">
+        Created {day(isArchive ? (e as Archive).start_time : (e as Experiment).created).fromNow()}
+      </Typography>
       {!isArchive && (
         <>
-          <Typography variant="body2">Created {day((e as Experiment).created).fromNow()}</Typography>
           {(e as Experiment).status === 'Paused' ? (
             <IconButton
               color="primary"

--- a/ui/src/lib/d3/eventsChart.ts
+++ b/ui/src/lib/d3/eventsChart.ts
@@ -15,11 +15,11 @@ const margin = {
 export default function gen({
   root,
   events,
-  selectEvent,
+  onSelectEvent,
 }: {
   root: HTMLElement
   events: Event[]
-  selectEvent?: (e: Event) => void
+  onSelectEvent?: (e: Event) => () => void
 }) {
   let width = root.offsetWidth
   const height = root.offsetHeight
@@ -180,8 +180,8 @@ export default function gen({
 
   rects
     .on('click', function (d) {
-      if (typeof selectEvent === 'function') {
-        selectEvent(d)
+      if (typeof onSelectEvent === 'function') {
+        onSelectEvent(d)()
       }
 
       svg

--- a/ui/src/pages/ArchiveReport/index.tsx
+++ b/ui/src/pages/ArchiveReport/index.tsx
@@ -84,9 +84,7 @@ const ArchiveReport: React.FC = () => {
               </Grid>
 
               <Grid item xs={12}>
-                <Paper variant="outlined">
-                  {events.length > 0 && <EventsTable events={events} hasSearch={false} />}
-                </Paper>
+                {events.length > 0 && <EventsTable events={events} hasSearch={false} detailed />}
               </Grid>
             </>
           )}

--- a/ui/src/pages/ArchiveReport/index.tsx
+++ b/ui/src/pages/ArchiveReport/index.tsx
@@ -1,11 +1,11 @@
 import { Box, Grid, Grow, Paper } from '@material-ui/core'
+import { Event, EventPod } from 'api/events.type'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import AffectedPods from 'components/AffectedPods'
 import { ArchiveDetail } from 'api/archives.type'
 import ArchiveDuration from 'components/ArchiveDuration'
 import ArchiveNumberOf from 'components/ArchiveNumberOf'
-import { Event } from 'api/events.type'
 import EventsTable from 'components/EventsTable'
 import ExperimentConfiguration from 'components/ExperimentConfiguration'
 import Loading from 'components/Loading'
@@ -21,7 +21,24 @@ const ArchiveReport: React.FC = () => {
   const [report, setReport] = useState<{ events: Event[] }>({ events: [] })
 
   const events = report.events
-  const affectedPods = useMemo(() => [...new Set(events.reduce<any[]>((acc, e) => acc.concat(e.pods!), []))], [events])
+  const affectedPods = useMemo(
+    () =>
+      [
+        ...new Set(
+          events
+            .reduce<EventPod[]>((acc, e) => acc.concat(e.pods!), [])
+            .map((d) => ({
+              pod_ip: d.pod_ip,
+              pod_name: d.pod_name,
+              namespace: d.namespace,
+              action: d.action,
+              message: d.message,
+            }))
+            .map((d) => JSON.stringify(d))
+        ),
+      ].map((d) => JSON.parse(d)),
+    [events]
+  )
 
   const fetchDetail = () => api.archives.detail(uuid).then(({ data }) => setDetail(data))
   const fetchReport = () => api.archives.report(uuid).then(({ data }) => setReport(data))

--- a/ui/src/pages/Events/index.tsx
+++ b/ui/src/pages/Events/index.tsx
@@ -4,7 +4,7 @@ import { Theme, createStyles, makeStyles } from '@material-ui/core/styles'
 
 import BlurLinearIcon from '@material-ui/icons/BlurLinear'
 import { Event } from 'api/events.type'
-import EventsTable from 'components/EventsTable'
+import EventsTable, { EventsTableHandles } from 'components/EventsTable'
 import Loading from 'components/Loading'
 import PaperTop from 'components/PaperTop'
 import api from 'api'
@@ -26,6 +26,8 @@ export default function Events() {
   const classes = useStyles()
 
   const chartRef = useRef<HTMLDivElement>(null)
+  const eventsTableRef = useRef<EventsTableHandles>(null)
+
   const [loading, setLoading] = useState(false)
   const [events, setEvents] = useState<Event[] | null>(null)
 
@@ -50,6 +52,7 @@ export default function Events() {
       genEventsChart({
         root: chart,
         events,
+        onSelectEvent: eventsTableRef.current!.onSelectEvent,
       })
     }
   }, [events])
@@ -63,9 +66,7 @@ export default function Events() {
               <PaperTop title="Timeline" />
               <div ref={chartRef} className={classes.eventsChart} />
             </Paper>
-            <Paper variant="outlined">
-              <EventsTable events={events} detailed />
-            </Paper>
+            <EventsTable ref={eventsTableRef} events={events} detailed />
           </Box>
         </Grow>
       )}

--- a/ui/src/pages/Experiments/index.tsx
+++ b/ui/src/pages/Experiments/index.tsx
@@ -41,7 +41,7 @@ export default function Experiments() {
 
   const fetchEvents = (experiments: Experiment[]) => {
     api.events
-      .dryEvents({ limit: 10 })
+      .dryEvents()
       .then(({ data }) => {
         if (data.length) {
           setExperiments(


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

This PR fixes some minor problems, includes:

- Unique affected pods in the archives page
- Remove limit param in `EventsPreview` to prevent the latest event not found
- Add relative time in the archive item list

Patch fe425c2:

Refactor the `EventDetail` to let all `EventsTable` parents can be access the `onSelectEvent` function.