### PR TITLE
fix grpc timeout

### DIFF
--- a/controllers/podchaos/containerkill/types.go
+++ b/controllers/podchaos/containerkill/types.go
@@ -92,7 +92,9 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, obj v1alpha1.I
 				g.Go(func() error {
 					err = r.KillContainer(ctx, pod, containerID)
 					if err != nil {
-						r.Log.Error(err, "failed to kill container")
+						r.Log.Error(err, fmt.Sprintf(
+							"failed to kill container: %s, pod: %s, namespace: %s",
+							containerName, pod.Name, pod.Namespace))
 					}
 					return err
 				})

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -18,8 +18,8 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 |--------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `clusterScoped`                            | whether chaos-mesh should manage kubernetes cluster wide chaos.Also see rbac.create and controllerManager.serviceAccount | `true` |
 | `rbac.create` |  | `true`                                                |
-| `timezone` | The timezone where controller-manager and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
-| `enableProfiling` | A flag to enable pprof in controller-manager and chaos-daemon  | `false` |
+| `timezone` | The timezone where controller-manager, chaos-daemon and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
+| `enableProfiling` | A flag to enable pprof in controller-manager and chaos-daemon  | `true` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |
 | `controllerManager.replicaCount` | Replicas for chaos-controller-manager | `1` |
 | `controllerManager.image` | docker image for chaos-controller-manager  | `pingcap/chaos-mesh:latest` |

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -50,6 +50,15 @@ spec:
           {{- if .Values.enableProfiling }}
             - --pprof
           {{- end }}
+          env:
+            {{- range $envKey, $envVal := .Values.chaosDaemon.env }}
+            - name: {{ $envKey | upper }}
+              value: {{ $envVal | quote }}
+            {{- end }}
+            {{- if not .Values.chaosDaemon.env.TZ }}
+            - name: TZ
+              value: {{ .Values.timezone | default "UTC" }}
+            {{- end }}
           securityContext:
             privileged: true
             capabilities:

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -44,9 +44,7 @@ spec:
             - name: {{ $envKey | upper }}
               value: {{ $envVal | quote }}
             {{- end }}
-            {{- if .Values.dashboard.env.TZ }}
-            # do nothing
-            {{- else }}
+            {{- if not .Values.dashboard.env.TZ }}
             - name: TZ
               value: {{ .Values.timezone | default "UTC" }}
             {{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -10,7 +10,7 @@ clusterScoped: true
 rbac:
   create: true
 
-# timezone is the timezone where controller-manager and dashboard uses.
+# timezone is the timezone where controller-manager, chaos-daemon and dashboard uses.
 # For example: "UTC" or "Asia/Shanghai"
 # This value will be set on controller-manager and dashboard container's
 # environment variable TZ.
@@ -19,7 +19,7 @@ rbac:
 timezone: "UTC"
 
 # enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon.
-enableProfiling: false
+enableProfiling: true
 
 kubectlImage: bitnami/kubectl:latest
 
@@ -65,7 +65,7 @@ chaosDaemon:
   imagePullPolicy: Always
   grpcPort: 31767
   httpPort: 31766
-
+  env: {}
   hostNetwork: false
 
   podAnnotations: {}

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -56,7 +56,7 @@ func CreateGrpcConnection(ctx context.Context, c client.Client, pod *v1.Pod, por
 // TimeoutClientInterceptor wraps the RPC with a timeout.
 func TimeoutClientInterceptor(ctx context.Context, method string, req, reply interface{},
 	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(RPCTimeout)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 	return invoker(ctx, method, req, reply, cc, opts...)
 }


### PR DESCRIPTION
### What problem does this PR solve?

grpc client timeout was set to a very large value, so that it impossible to get a timeout. For example, the rpc call has hung above 8 minutes:
```
goroutine 611 [select, 8 minutes]:
google.golang.org/grpc/internal/transport.(*Stream).waitOnHeader(0xc001e02f00)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/internal/transport/transport.go:318 +0xcc
google.golang.org/grpc/internal/transport.(*Stream).RecvCompress(...)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/internal/transport/transport.go:333
google.golang.org/grpc.(*csAttempt).recvMsg(0xc001b7d000, 0x15efc00, 0xc001e29620, 0x0, 0x5, 0xc0005ff1d0)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/stream.go:871 +0x753
google.golang.org/grpc.(*clientStream).RecvMsg.func1(0xc001b7d000, 0x4d, 0x4d)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/stream.go:736 +0x46
google.golang.org/grpc.(*clientStream).withRetry(0xc001e58240, 0xc00210db60, 0xc00210db30, 0xc001e1bfb0, 0xc001e09cf0)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/stream.go:594 +0x9c
google.golang.org/grpc.(*clientStream).RecvMsg(0xc001e58240, 0x15efc00, 0xc001e29620, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/stream.go:735 +0x103
google.golang.org/grpc.invoke(0x1914580, 0xc000027b00, 0x16f9cdd, 0x26, 0x15fca00, 0xc001b45e80, 0x15efc00, 0xc001e29620, 0xc000b39180, 0x0, ...)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/call.go:73 +0x13b
github.com/chaos-mesh/chaos-mesh/pkg/utils.TimeoutClientInterceptor(0x1914500, 0xc001b45300, 0x16f9cdd, 0x26, 0x15fca00, 0xc001b45e80, 0x15efc00, 0xc001e29620, 0xc000b39180, 0x1780768, ...)
	/src/pkg/utils/grpc.go:61 +0x12d
google.golang.org/grpc.(*ClientConn).Invoke(0xc000b39180, 0x1914500, 0xc001b45300, 0x16f9cdd, 0x26, 0x15fca00, 0xc001b45e80, 0x15efc00, 0xc001e29620, 0x0, ...)
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/call.go:35 +0x109
github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb.(*chaosDaemonClient).ContainerKill(0xc00089eb98, 0x1914500, 0xc001b45300, 0xc001b45e80, 0x0, 0x0, 0x0, 0x15c35e0, 0xc000b39101, 0xc001e1bf50)
	/src/pkg/chaosdaemon/pb/chaosdaemon.pb.go:1489 +0xcf
github.com/chaos-mesh/chaos-mesh/controllers/podchaos/containerkill.(*Reconciler).KillContainer(0xc001dec0f0, 0x1914500, 0xc001b45300, 0xc001e56000, 0xc001808280, 0x49, 0x0, 0x0)
```

### What is changed and how does it work?
1. fix the timeout duration to use the right timeout.
2. chaos-daemon also use global timezone to make it easier to search for log

### Check List

Tests

- Manual test (add detailed scripts or steps below)
The timeout parameter is trivial, and I have not tested that.
The helm template has been tested manually.


Code changes

- Has Go code change
- Has CI related scripts change
- Has Terraform scripts change

Side effects

- Breaking backward compatibility

Related changes

- Need to update the documentation
YES
### Does this PR introduce a user-facing change?
NO