### PR TITLE
[update] add container-wise StressChaos in dashboard

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -342,6 +342,10 @@ func (s *Service) createStressChaos(exp *core.ExperimentInfo) error {
 		chaos.Spec.Duration = &exp.Scheduler.Duration
 	}
 
+	if exp.Target.StressChaos.ContainerName != nil {
+		chaos.Spec.ContainerName = exp.Target.StressChaos.ContainerName
+	}
+
 	return s.kubeCli.Create(context.Background(), chaos)
 }
 
@@ -706,6 +710,10 @@ func (s *Service) getStressChaosDetail(namespace string, name string) (Experimen
 
 	if chaos.Spec.Duration != nil {
 		info.Scheduler.Duration = *chaos.Spec.Duration
+	}
+
+	if chaos.Spec.ContainerName != nil {
+		info.Target.StressChaos.ContainerName = chaos.Spec.ContainerName
 	}
 
 	return ExperimentDetail{
@@ -1327,6 +1335,10 @@ func (s *Service) updateStressChaos(exp *core.ExperimentInfo) error {
 
 	if exp.Scheduler.Duration != "" {
 		chaos.Spec.Duration = &exp.Scheduler.Duration
+	}
+
+	if exp.Target.StressChaos.ContainerName != nil {
+		chaos.Spec.ContainerName = exp.Target.StressChaos.ContainerName
 	}
 
 	return s.kubeCli.Create(context.Background(), chaos)

--- a/pkg/core/archive_experiment.go
+++ b/pkg/core/archive_experiment.go
@@ -205,6 +205,7 @@ type TimeChaosInfo struct {
 type StressChaosInfo struct {
 	Stressors         *v1alpha1.Stressors `json:"stressors"`
 	StressngStressors string              `json:"stressng_stressors,omitempty"`
+	ContainerName     *string             `json:"container_name,omitempty"`
 }
 
 func (e *ArchiveExperiment) ParsePodChaos() (ExperimentInfo, error) {
@@ -480,6 +481,10 @@ func (e *ArchiveExperiment) ParseStressChaos() (ExperimentInfo, error) {
 
 	if chaos.Spec.Duration != nil {
 		info.Scheduler.Duration = *chaos.Spec.Duration
+	}
+
+	if chaos.Spec.ContainerName != nil {
+		info.Target.StressChaos.ContainerName = chaos.Spec.ContainerName
 	}
 
 	return info, nil

--- a/ui/src/components/NewExperiment/Stepper/Target/Stress.tsx
+++ b/ui/src/components/NewExperiment/Stepper/Target/Stress.tsx
@@ -123,6 +123,12 @@ export default function Stress(props: StepperFormTargetProps) {
       {action !== '' && (
         <AdvancedOptions>
           <TextField
+            id="target.stress_chaos.container_name"
+            name="target.stress_chaos.container_name"
+            label="Container Name"
+            helperText="Optional. Fill the container name you want to inject stress in"
+          />
+          <TextField
             id="target.stress_chaos.stressng_stressors"
             name="target.stress_chaos.stressng_stressors"
             label="Options of stress-ng"

--- a/ui/src/components/NewExperiment/constants.ts
+++ b/ui/src/components/NewExperiment/constants.ts
@@ -87,6 +87,7 @@ export const defaultExperimentSchema: Experiment = {
           options: [],
         },
       },
+      container_name: '',
     },
   },
   scheduler: {

--- a/ui/src/components/NewExperiment/types.ts
+++ b/ui/src/components/NewExperiment/types.ts
@@ -110,6 +110,7 @@ export interface ExperimentTargetStress {
       options: string[]
     } | null
   }
+  container_name: string
 }
 
 export interface ExperimentTarget {


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

### What problem does this PR solve?
After #759 merged, the container name was added to the StressChaos.
This PR adds container name to the dashboard

### What is changed and how does it work?
 add container-wise StressChaos in dashboard

Tests
<!-- At least one of them must be included. -->

- No code

Code changes

- Has Go code change

Side effects

- NO

Related changes

- NO

### Does this PR introduce a user-facing change?

<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
