### PR TITLE
style: add .editorconfig for *.go

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,4 @@ insert_final_newline = true
 
 [*.go]
 indent_style = tab
-indent_size = 4
+indent_size = 8


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

When I view the `*.go` files, due to I have to switch between multiple languages(.go, .js, .ts), it's hard to change the indention automatically.

But the `editorconfig` can solve my problem, so I open this PR. It can connect with `gofmt` seamlessly and the two sides do n't affect each other.

### What is changed and how does it work?

Add `.editorconfig` to make `*.go` with tab width `8`.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
