### PR TITLE
Support k3s in install.sh

### DIFF
--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -26,6 +26,12 @@ curl -sSL https://mirrors.chaos-mesh.org/latest/install.sh | bash
 The above command install all the CRDs, required service account configuration, and all components.
 Before you start running a chaos experiment, verify if Chaos Mesh is installed correctly.
 
+If you are using k3s or k3d, please also specify `--k3s` flag.
+
+```bash
+curl -sSL https://mirrors.chaos-mesh.org/latest/install.sh --k3s | bash
+```
+
 ### Verify your installation
 
 Verify if the chaos mesh is running (For the use of *kubectl*, you can refer to the [documentation](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands).)


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

K3s is widely used now and actually I saw some problems reported about k3s installation recently. 

This pr support k3s in the install script so that k3s users can easily onboard chaos mesh.

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
