### PR TITLE
Fix: ensure pods ready when installing Chaos Mesh by `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -724,9 +724,11 @@ ensure_pods_ready() {
     fi
 
     count=0
-    while [[ "$(kubectl get pods -n "${namespace}" ${labels} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ]];
+    while [ -n "$(kubectl get pods -n "${namespace}" ${labels} --no-headers | grep -v Running)" ];
     do
-        echo "Waiting for pod running" && sleep 20;
+        echo "Waiting for pod running" && sleep 10;
+
+        kubectl get pods -n "${namespace}" ${labels} --no-headers | >&2 grep -v Running || true
 
         ((count=count+1))
         if [ $count -gt $limit ]; then


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

`"$(kubectl get pods -n "${namespace}" ${labels} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True"` only check one pod. When we use this way to check `chaos-daemon`, this script didn't work.

![image](https://user-images.githubusercontent.com/22956341/91118682-12b43580-e6c4-11ea-9793-5fc4369ced66.png)

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
