### PR TITLE
Fix the error in building tc commands

### DIFF
--- a/pkg/chaosdaemon/tc_server.go
+++ b/pkg/chaosdaemon/tc_server.go
@@ -387,9 +387,10 @@ func convertNetemToArgs(netem *pb.Netem) string {
 		args = fmt.Sprintf("delay %d", netem.Time)
 		if netem.Jitter > 0 {
 			args = fmt.Sprintf("%s %d", args, netem.Jitter)
-		}
-		if netem.DelayCorr > 0 {
-			args = fmt.Sprintf("%s %f", args, netem.DelayCorr)
+
+			if netem.DelayCorr > 0 {
+				args = fmt.Sprintf("%s %f", args, netem.DelayCorr)
+			}
 		}
 	}
 
@@ -429,7 +430,15 @@ func convertNetemToArgs(netem *pb.Netem) string {
 		}
 	}
 
-	return args
+	trimedArgs := []string{}
+
+	for _, part := range strings.Split(args, " ") {
+		if len(part) > 0 {
+			trimedArgs = append(trimedArgs, part)
+		}
+	}
+
+	return strings.Join(trimedArgs, " ")
 }
 
 func convertTbfToArgs(tbf *pb.Tbf) string {

--- a/pkg/chaosdaemon/tc_server.go
+++ b/pkg/chaosdaemon/tc_server.go
@@ -392,6 +392,18 @@ func convertNetemToArgs(netem *pb.Netem) string {
 				args = fmt.Sprintf("%s %f", args, netem.DelayCorr)
 			}
 		}
+
+		// reordering not possible without specifying some delay
+		if netem.Reorder > 0 {
+			args = fmt.Sprintf("%s reorder %f", args, netem.Reorder)
+			if netem.ReorderCorr > 0 {
+				args = fmt.Sprintf("%s %f", args, netem.ReorderCorr)
+			}
+
+			if netem.Gap > 0 {
+				args = fmt.Sprintf("%s gap %d", args, netem.Gap)
+			}
+		}
 	}
 
 	if netem.Limit > 0 {
@@ -402,17 +414,6 @@ func convertNetemToArgs(netem *pb.Netem) string {
 		args = fmt.Sprintf("%s loss %f", args, netem.Loss)
 		if netem.LossCorr > 0 {
 			args = fmt.Sprintf("%s %f", args, netem.LossCorr)
-		}
-	}
-
-	if netem.Reorder > 0 {
-		args = fmt.Sprintf("%s reorder %f", args, netem.Reorder)
-		if netem.ReorderCorr > 0 {
-			args = fmt.Sprintf("%s %f", args, netem.ReorderCorr)
-		}
-
-		if netem.Gap > 0 {
-			args = fmt.Sprintf("%s gap %d", args, netem.Gap)
 		}
 	}
 

--- a/pkg/chaosdaemon/tc_server_test.go
+++ b/pkg/chaosdaemon/tc_server_test.go
@@ -244,27 +244,36 @@ func Test_convertNetemToArgs(t *testing.T) {
 			Reorder:     5,
 			ReorderCorr: 10,
 		})
-		g.Expect(args).To(Equal("reorder 5 10"))
+		g.Expect(args).To(Equal(""))
 
 		args = convertNetemToArgs(&pb.Netem{
+			Time:        1000,
+			Jitter:      10000,
+			DelayCorr:   25,
 			Reorder:     5,
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("reorder 5 10 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 10 gap 10"))
 
 		args = convertNetemToArgs(&pb.Netem{
+			Time:        1000,
+			Jitter:      10000,
+			DelayCorr:   25,
 			Reorder:     5,
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("reorder 5 10 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 10 gap 10"))
 
 		args = convertNetemToArgs(&pb.Netem{
-			Reorder: 5,
-			Gap:     10,
+			Time:      1000,
+			Jitter:    10000,
+			DelayCorr: 25,
+			Reorder:   5,
+			Gap:       10,
 		})
-		g.Expect(args).To(Equal("reorder 5 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 gap 10"))
 	})
 
 	t.Run("convert packet duplication", func(t *testing.T) {

--- a/pkg/chaosdaemon/tc_server_test.go
+++ b/pkg/chaosdaemon/tc_server_test.go
@@ -195,3 +195,113 @@ func Test_generateQdiscArgs(t *testing.T) {
 		g.Expect(args).To(Equal([]string{"qdisc", "add", "dev", "eth0", "parent", "1:1", "handle", "10:0", typ}))
 	})
 }
+
+func Test_convertNetemToArgs(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("convert network delay", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Time: 1000,
+		})
+		g.Expect(args).To(Equal("delay 1000"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Time:      1000,
+			DelayCorr: 25,
+		})
+		g.Expect(args).To(Equal("delay 1000"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Time:      1000,
+			Jitter:    10000,
+			DelayCorr: 25,
+		})
+		g.Expect(args).To(Equal("delay 1000 10000 25"))
+	})
+
+	t.Run("convert packet limit", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Limit: 1000,
+		})
+		g.Expect(args).To(Equal("limit 1000"))
+	})
+
+	t.Run("convert packet loss", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Loss: 100,
+		})
+		g.Expect(args).To(Equal("loss 100"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Loss:     50,
+			LossCorr: 12,
+		})
+		g.Expect(args).To(Equal("loss 50 12"))
+	})
+
+	t.Run("convert packet reorder", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Reorder:     5,
+			ReorderCorr: 10,
+		})
+		g.Expect(args).To(Equal("reorder 5 10"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Reorder:     5,
+			ReorderCorr: 10,
+			Gap:         10,
+		})
+		g.Expect(args).To(Equal("reorder 5 10 gap 10"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Reorder:     5,
+			ReorderCorr: 10,
+			Gap:         10,
+		})
+		g.Expect(args).To(Equal("reorder 5 10 gap 10"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Reorder: 5,
+			Gap:     10,
+		})
+		g.Expect(args).To(Equal("reorder 5 gap 10"))
+	})
+
+	t.Run("convert packet duplication", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Duplicate: 10,
+		})
+		g.Expect(args).To(Equal("duplicate 10"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Duplicate:     10,
+			DuplicateCorr: 50,
+		})
+		g.Expect(args).To(Equal("duplicate 10 50"))
+	})
+
+	t.Run("convert packet corrupt", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Corrupt: 10,
+		})
+		g.Expect(args).To(Equal("corrupt 10"))
+
+		args = convertNetemToArgs(&pb.Netem{
+			Corrupt:     10,
+			CorruptCorr: 50,
+		})
+		g.Expect(args).To(Equal("corrupt 10 50"))
+	})
+
+	t.Run("complicate cases", func(t *testing.T) {
+		args := convertNetemToArgs(&pb.Netem{
+			Time:        1000,
+			Jitter:      10000,
+			Reorder:     5,
+			Gap:         10,
+			Corrupt:     10,
+			CorruptCorr: 50,
+		})
+		g.Expect(args).To(Equal("delay 1000 10000 reorder 5 gap 10 corrupt 10 50"))
+	})
+}

--- a/pkg/chaosdaemon/tc_server_test.go
+++ b/pkg/chaosdaemon/tc_server_test.go
@@ -216,7 +216,7 @@ func Test_convertNetemToArgs(t *testing.T) {
 			Jitter:    10000,
 			DelayCorr: 25,
 		})
-		g.Expect(args).To(Equal("delay 1000 10000 25"))
+		g.Expect(args).To(Equal("delay 1000 10000 25.000000"))
 	})
 
 	t.Run("convert packet limit", func(t *testing.T) {
@@ -230,13 +230,13 @@ func Test_convertNetemToArgs(t *testing.T) {
 		args := convertNetemToArgs(&pb.Netem{
 			Loss: 100,
 		})
-		g.Expect(args).To(Equal("loss 100"))
+		g.Expect(args).To(Equal("loss 100.000000"))
 
 		args = convertNetemToArgs(&pb.Netem{
 			Loss:     50,
 			LossCorr: 12,
 		})
-		g.Expect(args).To(Equal("loss 50 12"))
+		g.Expect(args).To(Equal("loss 50.000000 12.000000"))
 	})
 
 	t.Run("convert packet reorder", func(t *testing.T) {
@@ -254,7 +254,7 @@ func Test_convertNetemToArgs(t *testing.T) {
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 10 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25.000000 reorder 5.000000 10.000000 gap 10"))
 
 		args = convertNetemToArgs(&pb.Netem{
 			Time:        1000,
@@ -264,7 +264,7 @@ func Test_convertNetemToArgs(t *testing.T) {
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 10 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25.000000 reorder 5.000000 10.000000 gap 10"))
 
 		args = convertNetemToArgs(&pb.Netem{
 			Time:      1000,
@@ -273,33 +273,33 @@ func Test_convertNetemToArgs(t *testing.T) {
 			Reorder:   5,
 			Gap:       10,
 		})
-		g.Expect(args).To(Equal("delay 1000 10000 25 reorder 5 gap 10"))
+		g.Expect(args).To(Equal("delay 1000 10000 25.000000 reorder 5.000000 gap 10"))
 	})
 
 	t.Run("convert packet duplication", func(t *testing.T) {
 		args := convertNetemToArgs(&pb.Netem{
 			Duplicate: 10,
 		})
-		g.Expect(args).To(Equal("duplicate 10"))
+		g.Expect(args).To(Equal("duplicate 10.000000"))
 
 		args = convertNetemToArgs(&pb.Netem{
 			Duplicate:     10,
 			DuplicateCorr: 50,
 		})
-		g.Expect(args).To(Equal("duplicate 10 50"))
+		g.Expect(args).To(Equal("duplicate 10.000000 50.000000"))
 	})
 
 	t.Run("convert packet corrupt", func(t *testing.T) {
 		args := convertNetemToArgs(&pb.Netem{
 			Corrupt: 10,
 		})
-		g.Expect(args).To(Equal("corrupt 10"))
+		g.Expect(args).To(Equal("corrupt 10.000000"))
 
 		args = convertNetemToArgs(&pb.Netem{
 			Corrupt:     10,
 			CorruptCorr: 50,
 		})
-		g.Expect(args).To(Equal("corrupt 10 50"))
+		g.Expect(args).To(Equal("corrupt 10.000000 50.000000"))
 	})
 
 	t.Run("complicate cases", func(t *testing.T) {
@@ -311,6 +311,6 @@ func Test_convertNetemToArgs(t *testing.T) {
 			Corrupt:     10,
 			CorruptCorr: 50,
 		})
-		g.Expect(args).To(Equal("delay 1000 10000 reorder 5 gap 10 corrupt 10 50"))
+		g.Expect(args).To(Equal("delay 1000 10000 reorder 5.000000 gap 10 corrupt 10.000000 50.000000"))
 	})
 }


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

```
2020-09-02T03:47:24.659Z        INFO    chaos-daemon-server     build command   {"command": "nsenter -n/proc/20669/ns/net -- tc qdisc add dev eth0 parent 1: handle 2: netem  duplicate 80.000000 25.000000"}
2020-09-02T03:47:24.685Z        ERROR   chaos-daemon-server     error while adding tc   {"error": "error code: exit status 1, msg: Illegal \"limit\"\n"}
```

There is an extra space between "netem" and "duplicate" (which will lead to an "" in args).

BTW: What is the best practice of concating command line arguments? Directly working on a `[]string` seems too complicated (as I will need to convert integer/float to string everywhere).

### What is changed and how does it work?

### Checklist

Tests

- [x] Unit test
