### PR TITLE
feat: add hostNetwork option for controller-manager and update doc accordingly

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -20,6 +20,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `rbac.create` |  | `true`                                                |
 | `timezone` | The timezone where controller-manager, chaos-daemon and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
 | `enableProfiling` | A flag to enable pprof in controller-manager and chaos-daemon  | `true` |
+| `controllerManager.hostNetwork` | running chaos-controller-manager on host network | `false` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |
 | `controllerManager.replicaCount` | Replicas for chaos-controller-manager | `1` |
 | `controllerManager.image` | docker image for chaos-controller-manager  | `pingcap/chaos-mesh:latest` |
@@ -38,6 +39,8 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `chaosDaemon.imagePullPolicy` | image pull policy | `Always` |
 | `chaosDaemon.grpcPort` | The port which grpc server listens on | `31767` |
 | `chaosDaemon.httpPort` | The port which http server listens on | `31766` |
+| `chaosDaemon.env` | chaosDaemon envs | `{}` |
+| `chaosDaemon.hostNetwork` | running chaosDaemon on host network | `false` |
 | `chaosDaemon.podAnnotations` | Pod annotations of chaos-daemon | `{}` |
 | `chaosDaemon.runtime` | Runtime specifies which container runtime to use. Currently we only supports docker and containerd. | `docker` |
 | `chaosDaemon.socketPath` | Specifies the container runtime socket | `/var/run/docker.sock` |

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -28,6 +28,9 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     spec:
+    {{- if .Values.controllerManager.hostNetwork }}
+      hostNetwork: true
+    {{- end }}
     {{- if .Values.controllerManager.serviceAccount }}
       serviceAccount: {{ .Values.controllerManager.serviceAccount }}
     {{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -24,6 +24,7 @@ enableProfiling: true
 kubectlImage: bitnami/kubectl:latest
 
 controllerManager:
+  hostNetwork: false
   serviceAccount: chaos-controller-manager
 
   replicaCount: 1
@@ -154,7 +155,6 @@ dashboard:
     # Useful if the volume's root directory is not empty
     #
     subPath: ""
-
 
   # The keys within the "env" map are mounted as environment variables on the Chaos Dashboard pod.
   env:


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
In our helm chart, the controller-manager didn't support `hostNetwork=true`, and for me, it's quite need, so I proposed this PR.

### What is changed and how does it work?
Updated the `controller-manager-deployment.yaml` and add hostNetwork option support, by default, it's false, so there is nothing changed if we're keep using the original values.

```release-note
NONE
```
