### PR TITLE
fix: scope selectors

### DIFF
--- a/ui/src/components/NewExperiment/Stepper/Scope.tsx
+++ b/ui/src/components/NewExperiment/Stepper/Scope.tsx
@@ -1,6 +1,6 @@
 import { AutocompleteMultipleField, SelectField, TextField } from 'components/FormField'
 import { Box, Divider, InputAdornment, MenuItem, Typography } from '@material-ui/core'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { RootState, useStoreDispatch } from 'store'
 import { arrToObjBySep, joinObjKVs, toTitleCase } from 'lib/utils'
 import { getAnnotations, getLabels, getPodsByNamespaces } from 'slices/experiments'
@@ -37,6 +37,9 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope' }) =>
   const labelKVs = useMemo(() => joinObjKVs(labels, ': ', labelFilters), [labels])
   const annotationKVs = useMemo(() => joinObjKVs(annotations, ': '), [annotations])
 
+  const [currentLabels, setCurrentLabels] = useState<string[]>([])
+  const [currentAnnotations, setCurrentAnnotations] = useState<string[]>([])
+
   const handleNamespaceSelectorsChangeCallback = (labels: string[]) => {
     const _labels = labels.length !== 0 ? labels : namespaces
 
@@ -45,23 +48,8 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope' }) =>
     storeDispatch(getPodsByNamespaces({ namespace_selectors: _labels }))
   }
 
-  const handleLabelSelectorsChangeCallback = (labels: string[]) =>
-    storeDispatch(
-      getPodsByNamespaces({
-        namespace_selectors: namespaces,
-        label_selectors: arrToObjBySep(labels, ': '),
-        annotation_selectors: annotations,
-      })
-    )
-
-  const handleAnnotationSelectorsChangeCallback = (labels: string[]) =>
-    storeDispatch(
-      getPodsByNamespaces({
-        namespace_selectors: namespaces,
-        label_selectors: labels,
-        annotation_selectors: arrToObjBySep(labels, ': '),
-      })
-    )
+  const handleLabelSelectorsChangeCallback = (labels: string[]) => setCurrentLabels(labels)
+  const handleAnnotationSelectorsChangeCallback = (labels: string[]) => setCurrentAnnotations(labels)
 
   const handleChangeIncludeAll = (id: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
     const lastValues = id.split('.').reduce((acc, cur) => acc[cur], values as any)
@@ -77,6 +65,17 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope' }) =>
 
     handleChange(e)
   }
+
+  useEffect(() => {
+    storeDispatch(
+      getPodsByNamespaces({
+        namespace_selectors: namespaces,
+        label_selectors: arrToObjBySep(currentLabels, ': '),
+        annotation_selectors: arrToObjBySep(currentAnnotations, ': '),
+      })
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentLabels, currentAnnotations])
 
   return (
     <>


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

This PR fixes the selectors problem in `new experiments scope`. Now the select fields will pass correct selectors in request params.

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
