### PR TITLE
Fix invalid usage of cgo/unsafe pointer in TimeChaos

### DIFF
--- a/pkg/ptrace/ptrace_linux.go
+++ b/pkg/ptrace/ptrace_linux.go
@@ -13,7 +13,13 @@
 
 package ptrace
 
-// #include <sys/uio.h>
+/*
+#include <stdint.h>
+struct iovec {
+	intptr_t iov_base;
+	size_t iov_len;
+};
+*/
 import "C"
 
 import (
@@ -308,12 +314,12 @@ func (p *TracedProgram) ReadSlice(addr uint64, size uint64) (*[]byte, error) {
 	buffer := make([]byte, size)
 
 	localIov := C.struct_iovec{
-		iov_base: unsafe.Pointer(&buffer[0]),
+		iov_base: C.long(uintptr(unsafe.Pointer(&buffer[0]))),
 		iov_len:  C.ulong(size),
 	}
 
 	remoteIov := C.struct_iovec{
-		iov_base: unsafe.Pointer(uintptr(addr)),
+		iov_base: C.long(addr),
 		iov_len:  C.ulong(size),
 	}
 
@@ -332,12 +338,12 @@ func (p *TracedProgram) WriteSlice(addr uint64, buffer []byte) error {
 	size := len(buffer)
 
 	localIov := C.struct_iovec{
-		iov_base: unsafe.Pointer(&buffer[0]),
+		iov_base: C.long(uintptr(unsafe.Pointer(&buffer[0]))),
 		iov_len:  C.ulong(size),
 	}
 
 	remoteIov := C.struct_iovec{
-		iov_base: unsafe.Pointer(uintptr(addr)),
+		iov_base: C.long(addr),
 		iov_len:  C.ulong(size),
 	}
 


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Run timechaos with `GODEBUG=cgocheck=2` will give you the detail of the error (and will actually cause GC error in the runtime). In this PR, I minimize the cgo related codes and use `syscall.Syscall6` as a wrapper to call system call.
