### PR TITLE
fix: make restart watcher log level down to info.

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -258,7 +258,8 @@ func watchConfig(configWatcher *watcher.K8sConfigMapWatcher, cfg *config.Config,
 				if err := configWatcher.Watch(sigChan, stopCh); err != nil {
 					switch err {
 					case watcher.ErrWatchChannelClosed:
-						setupLog.Error(err, "watcher got error, try to restart watcher")
+						// known issue: https://github.com/kubernetes/client-go/issues/334
+						setupLog.Info("watcher channel has closed, restart watcher")
 					default:
 						setupLog.Error(err, "unable to watch new ConfigMaps")
 						os.Exit(1)

--- a/pkg/webhook/config/watcher/watcher.go
+++ b/pkg/webhook/config/watcher/watcher.go
@@ -146,7 +146,7 @@ func (c *K8sConfigMapWatcher) Watch(notifyMe chan<- interface{}, stopCh <-chan s
 			// channel may closed caused by HTTP timeout, should restart watcher
 			// detail at https://github.com/kubernetes/client-go/issues/334
 			if !ok {
-				log.Error(nil, "channel has closed, should restart watcher")
+				log.V(5).Info("channel has closed, will restart watcher")
 				return ErrWatchChannelClosed
 			}
 			if e.Type == watch.Error {
@@ -170,7 +170,7 @@ func (c *K8sConfigMapWatcher) Watch(notifyMe chan<- interface{}, stopCh <-chan s
 			// channel may closed caused by HTTP timeout, should restart watcher
 			// detail at https://github.com/kubernetes/client-go/issues/334
 			if !ok {
-				log.Error(nil, "channel has closed, should restart watcher")
+				log.V(5).Info("channel has closed, will restart watcher")
 				return ErrWatchChannelClosed
 			}
 			if e.Type == watch.Error {
@@ -204,7 +204,7 @@ func mapStringStringToLabelSelector(m map[string]string) string {
 	return labels.Set(m).String()
 }
 
-// Get fetches all matching ConfigMaps
+// GetInjectionConfigs fetches all matching ConfigMaps
 func (c *K8sConfigMapWatcher) GetInjectionConfigs() (map[string][]*config.InjectionConfig, error) {
 	templates, err := c.GetTemplates()
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?
Fixed #910 

### What is changed and how does it work?
Changed the restart watcher log level, so we don't see such duplicate logs inside controller-manager anymore..

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
