### PR TITLE
fix: pod deletion caused twophase phase=Failed chaos.

### DIFF
--- a/controllers/networkchaos/partition/types.go
+++ b/controllers/networkchaos/partition/types.go
@@ -73,6 +73,7 @@ func NewCommonReconciler(c client.Client, reader client.Reader, log logr.Logger,
 	return common.NewReconciler(r, r.Client, r.Reader, r.Log)
 }
 
+// Reconciler is networkchaos reconciler
 type Reconciler struct {
 	client.Client
 	client.Reader
@@ -196,6 +197,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 
 	err = m.Commit(ctx)
 	if err != nil {
+		// if pod is not found or not ready, wait next time.
+		if err == podnetworkmanager.ErrPodNotFound || err == podnetworkmanager.ErrPodNotRunning {
+			return err
+		}
 		r.Log.Error(err, "fail to commit")
 		return err
 	}
@@ -288,7 +293,8 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, networkchaos
 		}
 
 		err = m.Commit(ctx)
-		if err != nil {
+		// if pod not found or not running, directly return and giveup recover.
+		if err != nil && err != podnetworkmanager.ErrPodNotFound && err != podnetworkmanager.ErrPodNotRunning {
 			r.Log.Error(err, "fail to commit")
 		}
 

--- a/controllers/networkchaos/trafficcontrol/types.go
+++ b/controllers/networkchaos/trafficcontrol/types.go
@@ -146,6 +146,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 
 	err = m.Commit(ctx)
 	if err != nil {
+		// if pod is not found or not running, wait next time.
+		if err == podnetworkmanager.ErrPodNotFound || err == podnetworkmanager.ErrPodNotRunning {
+			return err
+		}
 		r.Log.Error(err, "fail to commit")
 		return err
 	}
@@ -205,7 +209,8 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, networkchaos
 		})
 
 		err = m.Commit(ctx)
-		if err != nil {
+		// if pod not found or not running, directly return and giveup recover.
+		if err != nil && err != podnetworkmanager.ErrPodNotFound && err != podnetworkmanager.ErrPodNotRunning {
 			r.Log.Error(err, "fail to commit")
 		}
 


### PR DESCRIPTION
### What problem does this PR solve?
Fixed #944 , addressed by [the issue comment](https://github.com/chaos-mesh/chaos-mesh/issues/944#issuecomment-697242197).

### What is changed and how does it work?
If networkchaos is Failed phase, it may need retry apply, and this PR help it come true!

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
No

```release-note
NONE
```
