### PR TITLE
add pod status to iochaos event

### DIFF
--- a/controllers/iochaos/types.go
+++ b/controllers/iochaos/types.go
@@ -103,6 +103,19 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 		r.Log.Error(err, "fail to commit")
 		return err
 	}
+
+	iochaos.Status.Experiment.PodRecords = make([]v1alpha1.PodStatus, 0, len(pods))
+	for _, pod := range pods {
+		ps := v1alpha1.PodStatus{
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+			HostIP:    pod.Status.HostIP,
+			PodIP:     pod.Status.PodIP,
+			Action:    string(iochaos.Spec.Action),
+		}
+
+		iochaos.Status.Experiment.PodRecords = append(iochaos.Status.Experiment.PodRecords, ps)
+	}
 	r.Event(iochaos, v1.EventTypeNormal, utils.EventChaosInjected, "")
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Add pod status to iochaos event, so that we can see the detail in the dashboard

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests

- [x] Manual test
