### PR TITLE
alternative: watch pod and issue networkchaos reconcile request.

### DIFF
--- a/api/v1alpha1/httpchaos_types.go
+++ b/api/v1alpha1/httpchaos_types.go
@@ -125,6 +125,16 @@ type HTTPChaos struct {
 	Status HTTPChaosStatus `json:"status,omitempty"`
 }
 
+// GetSourceTargetSpec get httpchaos selector spec
+func (in *HTTPChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
+}
+
+// GetStatus get httpchaos status
 func (in *HTTPChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
@@ -132,6 +142,11 @@ func (in *HTTPChaos) GetStatus() *ChaosStatus {
 // IsDeleted returns whether this resource has been deleted
 func (in *HTTPChaos) IsDeleted() bool {
 	return !in.DeletionTimestamp.IsZero()
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *HTTPChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // IsPaused returns whether this resource has been paused
@@ -229,6 +244,15 @@ func (in *HTTPChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *HTTPChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/v1alpha1/iochaos_types.go
+++ b/api/v1alpha1/iochaos_types.go
@@ -133,8 +133,18 @@ type IoChaos struct {
 	Status IoChaosStatus `json:"status,omitempty"`
 }
 
+// GetStatus get iochaos status
 func (in *IoChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSourceTargetSpec get iochaos selector spec
+func (in *IoChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
 }
 
 // IsDeleted returns whether this resource has been deleted
@@ -148,6 +158,11 @@ func (in *IoChaos) IsPaused() bool {
 		return false
 	}
 	return true
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *IoChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // GetDuration would return the duration for chaos
@@ -239,6 +254,15 @@ func (in *IoChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *IoChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/v1alpha1/kernelchaos_types.go
+++ b/api/v1alpha1/kernelchaos_types.go
@@ -71,17 +71,17 @@ type KernelChaosSpec struct {
 	Scheduler *SchedulerSpec `json:"scheduler,omitempty"`
 }
 
-// GetSelector is a getter for Selector (for implementing SelectSpec)
+// GetSelector is a getter for Selector (for implementing ChaosSelectSpec)
 func (in *KernelChaosSpec) GetSelector() SelectorSpec {
 	return in.Selector
 }
 
-// GetMode is a getter for Mode (for implementing SelectSpec)
+// GetMode is a getter for Mode (for implementing ChaosSelectSpec)
 func (in *KernelChaosSpec) GetMode() PodMode {
 	return in.Mode
 }
 
-// GetValue is a getter for Value (for implementing SelectSpec)
+// GetValue is a getter for Value (for implementing ChaosSelectSpec)
 func (in *KernelChaosSpec) GetValue() string {
 	return in.Value
 }
@@ -214,6 +214,15 @@ func (in *KernelChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
 
+// GetSourceTargetSpec get kernelchaos selector spec
+func (in *KernelChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
+}
+
 // IsDeleted returns whether this resource has been deleted
 func (in *KernelChaos) IsDeleted() bool {
 	return !in.DeletionTimestamp.IsZero()
@@ -225,6 +234,11 @@ func (in *KernelChaos) IsPaused() bool {
 		return false
 	}
 	return true
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *KernelChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // GetChaos returns a chaos instance
@@ -261,6 +275,15 @@ func (in *KernelChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *KernelChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/v1alpha1/podchaos_types.go
+++ b/api/v1alpha1/podchaos_types.go
@@ -57,6 +57,16 @@ type PodChaos struct {
 	Status PodChaosStatus `json:"status"`
 }
 
+// GetSourceTargetSpec get podchaos selector spec
+func (in *PodChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
+}
+
+// GetStatus get podchaos status
 func (in *PodChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
@@ -72,6 +82,11 @@ func (in *PodChaos) IsPaused() bool {
 		return false
 	}
 	return true
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *PodChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // GetDuration would return the duration for chaos
@@ -243,6 +258,15 @@ func (in *PodChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *PodChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -91,17 +91,17 @@ type StressChaosSpec struct {
 	Scheduler *SchedulerSpec `json:"scheduler,omitempty"`
 }
 
-// GetSelector is a getter for Selector (for implementing SelectSpec)
+// GetSelector is a getter for Selector (for implementing ChaosSelectSpec)
 func (in *StressChaosSpec) GetSelector() SelectorSpec {
 	return in.Selector
 }
 
-// GetMode is a getter for Mode (for implementing SelectSpec)
+// GetMode is a getter for Mode (for implementing ChaosSelectSpec)
 func (in *StressChaosSpec) GetMode() PodMode {
 	return in.Mode
 }
 
-// GetValue is a getter for Value (for implementing SelectSpec)
+// GetValue is a getter for Value (for implementing ChaosSelectSpec)
 func (in *StressChaosSpec) GetValue() string {
 	return in.Value
 }
@@ -183,6 +183,15 @@ func (in *StressChaos) GetScheduler() *SchedulerSpec {
 	return in.Spec.Scheduler
 }
 
+// GetSourceTargetSpec get stresschaos selector spec
+func (in *StressChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
+}
+
 // GetStatus returns the status of StressChaos
 func (in *StressChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
@@ -199,6 +208,11 @@ func (in *StressChaos) IsPaused() bool {
 		return false
 	}
 	return true
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *StressChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // GetChaos returns a chaos instance
@@ -302,6 +316,15 @@ func (in *StressChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *StressChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/v1alpha1/timechaos_types.go
+++ b/api/v1alpha1/timechaos_types.go
@@ -96,17 +96,17 @@ func (in *TimeChaosSpec) DefaultClockIds() {
 	}
 }
 
-// GetSelector is a getter for Selector (for implementing SelectSpec)
+// GetSelector is a getter for Selector (for implementing ChaosSelectSpec)
 func (in *TimeChaosSpec) GetSelector() SelectorSpec {
 	return in.Selector
 }
 
-// GetMode is a getter for Mode (for implementing SelectSpec)
+// GetMode is a getter for Mode (for implementing ChaosSelectSpec)
 func (in *TimeChaosSpec) GetMode() PodMode {
 	return in.Mode
 }
 
-// GetValue is a getter for Value (for implementing SelectSpec)
+// GetValue is a getter for Value (for implementing ChaosSelectSpec)
 func (in *TimeChaosSpec) GetValue() string {
 	return in.Value
 }
@@ -175,6 +175,15 @@ func (in *TimeChaos) GetScheduler() *SchedulerSpec {
 	return in.Spec.Scheduler
 }
 
+// GetSourceTargetSpec get timechaos selector spec
+func (in *TimeChaos) GetSourceTargetSpec() *ChaosSourceTargetSpec {
+	return &ChaosSourceTargetSpec{
+		Source:          &in.Spec,
+		Target:          nil,        // no target
+		ExternalTargets: []string{}, // no external targets
+	}
+}
+
 // GetStatus returns the status of TimeChaos
 func (in *TimeChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
@@ -191,6 +200,11 @@ func (in *TimeChaos) IsPaused() bool {
 		return false
 	}
 	return true
+}
+
+// IsRenewed returns whether this resource resolved targets has changed
+func (in *TimeChaos) IsRenewed(tgt *ChaosResolvedTargets) bool {
+	return IsChaosTargetChanged(tgt, in.Status.Experiment.PodRecords)
 }
 
 // GetChaos returns a chaos instance
@@ -227,6 +241,15 @@ func (in *TimeChaosList) ListChaos() []*ChaosInstance {
 	res := make([]*ChaosInstance, 0, len(in.Items))
 	for _, item := range in.Items {
 		res = append(res, item.GetChaos())
+	}
+	return res
+}
+
+// ListItems returns a list of chaos object
+func (in *TimeChaosList) ListItems() []InnerObject {
+	res := make([]InnerObject, 0, len(in.Items))
+	for idx := range in.Items {
+		res = append(res, &in.Items[idx])
 	}
 	return res
 }

--- a/api/webhook/inject.go
+++ b/api/webhook/inject.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/chaos-mesh/chaos-mesh/controllers/common"
 	"github.com/chaos-mesh/chaos-mesh/controllers/metrics"
 	"github.com/chaos-mesh/chaos-mesh/pkg/webhook/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/webhook/inject"
@@ -50,7 +51,7 @@ func (v *PodInjector) Handle(ctx context.Context, req admission.Request) admissi
 	log.Info("Get request from pod:", "pod", pod)
 
 	return admission.Response{
-		AdmissionResponse: *inject.Inject(&req.AdmissionRequest, v.client, v.Config, v.Metrics),
+		AdmissionResponse: *inject.Inject(&req.AdmissionRequest, v.client, v.Config, v.Metrics, common.ControllerCfg.AllowedNamespaces, common.ControllerCfg.IgnoredNamespaces),
 	}
 }
 

--- a/config/crd/bases/chaos-mesh.org_httpchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_httpchaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: httpchaos.chaos-mesh.org
 spec:
@@ -20,37 +20,27 @@ spec:
       description: HTTPChaos is the Schema for the HTTPchaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           properties:
             action:
-              description: 'Action defines the specific pod chaos action. Supported
-                action: delay | abort | mixed Default action: delay'
+              description: 'Action defines the specific pod chaos action. Supported action: delay | abort | mixed Default action: delay'
               enum:
               - delay
               - abort
               - mixed
               type: string
             duration:
-              description: Duration represents the duration of the chaos action. It
-                is required when the action is `PodFailureAction`. A duration string
-                is a possibly signed sequence of decimal numbers, each with optional
-                fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
-                time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+              description: Duration represents the duration of the chaos action. It is required when the action is `PodFailureAction`. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
               type: string
             headers:
-              description: Specifies how the header match will be performed to route
-                the request.
+              description: Specifies how the header match will be performed to route the request.
               items:
                 properties:
                   exact_match:
@@ -76,8 +66,7 @@ spec:
                 type: object
               type: array
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -86,43 +75,34 @@ spec:
               - random-max-percent
               type: string
             percent:
-              description: 'Percent defines the percentage of injection errors and
-                provides a number from 0-100. default: 100.'
+              description: 'Percent defines the percentage of injection errors and provides a number from 0-100. default: 100.'
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about pods.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about pods.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -132,20 +112,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -154,18 +129,11 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
           required:
           - action
@@ -183,21 +151,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_iochaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_iochaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: iochaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: IoChaos is the Schema for the iochaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,8 +31,7 @@ spec:
           description: IoChaosSpec defines the desired state of IoChaos
           properties:
             action:
-              description: 'Action defines the specific pod chaos action. Supported
-                action: latency / fault / attrOverride'
+              description: 'Action defines the specific pod chaos action. Supported action: latency / fault / attrOverride'
               enum:
               - latency
               - fault
@@ -112,32 +107,22 @@ spec:
                   type: integer
               type: object
             delay:
-              description: Delay defines the value of I/O chaos action delay. A delay
-                string is a possibly signed sequence of decimal numbers, each with
-                optional fraction and a unit suffix, such as "300ms". Valid time units
-                are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+              description: Delay defines the value of I/O chaos action delay. A delay string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
               type: string
             duration:
-              description: Duration represents the duration of the chaos action. It
-                is required when the action is `PodFailureAction`. A duration string
-                is a possibly signed sequence of decimal numbers, each with optional
-                fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
-                time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+              description: Duration represents the duration of the chaos action. It is required when the action is `PodFailureAction`. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
               type: string
             errno:
-              description: 'Errno defines the error code that returned by I/O action.
-                refer to: https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html'
+              description: 'Errno defines the error code that returned by I/O action. refer to: https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html'
               format: int32
               type: integer
             methods:
-              description: 'Methods defines the I/O methods for injecting I/O chaos
-                action. default: all I/O methods.'
+              description: 'Methods defines the I/O methods for injecting I/O chaos action. default: all I/O methods.'
               items:
                 type: string
               type: array
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -146,47 +131,37 @@ spec:
               - random-max-percent
               type: string
             path:
-              description: Path defines the path of files for injecting I/O chaos
-                action.
+              description: Path defines the path of files for injecting I/O chaos action.
               type: string
             percent:
-              description: 'Percent defines the percentage of injection errors and
-                provides a number from 0-100. default: 100.'
+              description: 'Percent defines the percentage of injection errors and provides a number from 0-100. default: 100.'
               type: integer
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about pods.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about pods.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -196,20 +171,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -218,18 +188,11 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
             volumePath:
               description: VolumePath represents the mount path of injected volume
@@ -252,21 +215,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_kernelchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_kernelchaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: kernelchaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: KernelChaos is the Schema for the kernelchaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -41,58 +37,34 @@ spec:
               description: FailKernRequest defines the request of kernel injection
               properties:
                 callchain:
-                  description: 'Callchain indicate a special call chain, such as:     ext4_mount       ->
-                    mount_subtree          -> ...             -> should_failslab With
-                    an optional set of predicates and an optional set of parameters,
-                    which used with predicates. You can read call chan and predicate
-                    examples from https://github.com/chaos-mesh/bpfki/tree/develop/examples
-                    to learn more. If no special call chain, just keep Callchain empty,
-                    which means it will fail at any call chain with slab alloc (eg:
-                    kmalloc).'
+                  description: 'Callchain indicate a special call chain, such as:     ext4_mount       -> mount_subtree          -> ...             -> should_failslab With an optional set of predicates and an optional set of parameters, which used with predicates. You can read call chan and predicate examples from https://github.com/chaos-mesh/bpfki/tree/develop/examples to learn more. If no special call chain, just keep Callchain empty, which means it will fail at any call chain with slab alloc (eg: kmalloc).'
                   items:
-                    description: Frame defines the function signature and predicate
-                      in function's body
+                    description: Frame defines the function signature and predicate in function's body
                     properties:
                       funcname:
-                        description: Funcname can be find from kernel source or `/proc/kallsyms`,
-                          such as `ext4_mount`
+                        description: Funcname can be find from kernel source or `/proc/kallsyms`, such as `ext4_mount`
                         type: string
                       parameters:
-                        description: Parameters is used with predicate, for example,
-                          if you want to inject slab error in `d_alloc_parallel(struct
-                          dentry *parent, const struct qstr *name)` with a special
-                          name `bananas`, you need to set it to `struct dentry *parent,
-                          const struct qstr *name` otherwise omit it.
+                        description: Parameters is used with predicate, for example, if you want to inject slab error in `d_alloc_parallel(struct dentry *parent, const struct qstr *name)` with a special name `bananas`, you need to set it to `struct dentry *parent, const struct qstr *name` otherwise omit it.
                         type: string
                       predicate:
-                        description: Predicate will access the arguments of this Frame,
-                          example with Parameters's, you can set it to `STRNCMP(name->name,
-                          "bananas", 8)` to make inject only with it, or omit it to
-                          inject for all d_alloc_parallel call chain.
+                        description: Predicate will access the arguments of this Frame, example with Parameters's, you can set it to `STRNCMP(name->name, "bananas", 8)` to make inject only with it, or omit it to inject for all d_alloc_parallel call chain.
                         type: string
                     type: object
                   type: array
                 failtype:
-                  description: 'FailType indicates what to fail, can be set to ''0''
-                    / ''1'' / ''2'' If `0`, indicates slab to fail (should_failslab)
-                    If `1`, indicates alloc_page to fail (should_fail_alloc_page)
-                    If `2`, indicates bio to fail (should_fail_bio) You can read:   1.
-                    https://www.kernel.org/doc/html/latest/fault-injection/fault-injection.html   2.
-                    http://github.com/iovisor/bcc/blob/master/tools/inject_example.txt
-                    to learn more'
+                  description: 'FailType indicates what to fail, can be set to ''0'' / ''1'' / ''2'' If `0`, indicates slab to fail (should_failslab) If `1`, indicates alloc_page to fail (should_fail_alloc_page) If `2`, indicates bio to fail (should_fail_bio) You can read:   1. https://www.kernel.org/doc/html/latest/fault-injection/fault-injection.html   2. http://github.com/iovisor/bcc/blob/master/tools/inject_example.txt to learn more'
                   format: int32
                   maximum: 2
                   minimum: 0
                   type: integer
                 headers:
-                  description: 'Headers indicates the appropriate kernel headers you
-                    need. Eg: "linux/mmzone.h", "linux/blkdev.h" and so on'
+                  description: 'Headers indicates the appropriate kernel headers you need. Eg: "linux/mmzone.h", "linux/blkdev.h" and so on'
                   items:
                     type: string
                   type: array
                 probability:
-                  description: Probability indicates the fails with probability. If
-                    you want 1%, please set this field with 1.
+                  description: Probability indicates the fails with probability. If you want 1%, please set this field with 1.
                   format: int32
                   maximum: 100
                   minimum: 0
@@ -106,8 +78,7 @@ spec:
               - failtype
               type: object
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -116,39 +87,31 @@ spec:
               - random-max-percent
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about time.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about time.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -158,20 +121,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -180,18 +138,11 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. If `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. If `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
           required:
           - failKernRequest
@@ -210,21 +161,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_networkchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_networkchaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: networkchaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: NetworkChaos is the Schema for the networkchaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,9 +31,7 @@ spec:
           description: Spec defines the behavior of a pod chaos experiment
           properties:
             action:
-              description: 'Action defines the specific network chaos action. Supported
-                action: partition, netem, delay, loss, duplicate, corrupt Default
-                action: delay'
+              description: 'Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay'
               enum:
               - netem
               - delay
@@ -48,40 +42,30 @@ spec:
               - bandwidth
               type: string
             bandwidth:
-              description: Bandwidth represents the detail about bandwidth control
-                action
+              description: Bandwidth represents the detail about bandwidth control action
               properties:
                 buffer:
-                  description: Buffer is the maximum amount of bytes that tokens can
-                    be available for instantaneously.
+                  description: Buffer is the maximum amount of bytes that tokens can be available for instantaneously.
                   format: int32
                   minimum: 1
                   type: integer
                 limit:
-                  description: Limit is the number of bytes that can be queued waiting
-                    for tokens to become available.
+                  description: Limit is the number of bytes that can be queued waiting for tokens to become available.
                   format: int32
                   minimum: 1
                   type: integer
                 minburst:
-                  description: Minburst specifies the size of the peakrate bucket.
-                    For perfect accuracy, should be set to the MTU of the interface.  If
-                    a peakrate is needed, but some burstiness is acceptable, this
-                    size can be raised. A 3000 byte minburst allows around 3mbit/s
-                    of peakrate, given 1000 byte packets.
+                  description: Minburst specifies the size of the peakrate bucket. For perfect accuracy, should be set to the MTU of the interface.  If a peakrate is needed, but some burstiness is acceptable, this size can be raised. A 3000 byte minburst allows around 3mbit/s of peakrate, given 1000 byte packets.
                   format: int32
                   minimum: 0
                   type: integer
                 peakrate:
-                  description: Peakrate is the maximum depletion rate of the bucket.
-                    The peakrate does not need to be set, it is only necessary if
-                    perfect millisecond timescale shaping is required.
+                  description: Peakrate is the maximum depletion rate of the bucket. The peakrate does not need to be set, it is only necessary if perfect millisecond timescale shaping is required.
                   format: int64
                   minimum: 0
                   type: integer
                 rate:
-                  description: Rate is the speed knob. Allows bps, kbps, mbps, gbps,
-                    tbps unit. bps means bytes per second.
+                  description: Rate is the speed knob. Allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second.
                   type: string
               required:
               - buffer
@@ -126,8 +110,7 @@ spec:
               - latency
               type: object
             direction:
-              description: Direction represents the direction, this applies on netem
-                and network partition action
+              description: Direction represents the direction, this applies on netem and network partition action
               enum:
               - to
               - from
@@ -165,8 +148,7 @@ spec:
               - loss
               type: object
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -175,39 +157,31 @@ spec:
               - random-max-percent
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about network.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about network.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -217,20 +191,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -239,14 +208,11 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             target:
-              description: Target represents network target, this applies on netem
-                and network partition action
+              description: Target represents network target, this applies on netem and network partition action
               properties:
                 mode:
                   description: TargetMode defines the target selector mode
@@ -264,44 +230,35 @@ spec:
                     annotationSelectors:
                       additionalProperties:
                         type: string
-                      description: Map of string keys and values that can be used
-                        to select objects. A selector based on annotations.
+                      description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                       type: object
                     fieldSelectors:
                       additionalProperties:
                         type: string
-                      description: Map of string keys and values that can be used
-                        to select objects. A selector based on fields.
+                      description: Map of string keys and values that can be used to select objects. A selector based on fields.
                       type: object
                     labelSelectors:
                       additionalProperties:
                         type: string
-                      description: Map of string keys and values that can be used
-                        to select objects. A selector based on labels.
+                      description: Map of string keys and values that can be used to select objects. A selector based on labels.
                       type: object
                     namespaces:
-                      description: Namespaces is a set of namespace to which objects
-                        belong.
+                      description: Namespaces is a set of namespace to which objects belong.
                       items:
                         type: string
                       type: array
                     nodeSelectors:
                       additionalProperties:
                         type: string
-                      description: Map of string keys and values that can be used
-                        to select nodes. Selector which must match a node's labels,
-                        and objects must belong to these selected nodes.
+                      description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                       type: object
                     nodes:
-                      description: Nodes is a set of node name and objects must belong
-                        to these nodes.
+                      description: Nodes is a set of node name and objects must belong to these nodes.
                       items:
                         type: string
                       type: array
                     podPhaseSelectors:
-                      description: 'PodPhaseSelectors is a set of condition of a pod
-                        at the current time. supported value: Pending / Running /
-                        Succeeded / Failed / Unknown'
+                      description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                       items:
                         type: string
                       type: array
@@ -310,31 +267,18 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Pods is a map of string keys and a set values that
-                        used to select pods. The key defines the namespace which pods
-                        belong, and the each values is a set of pod names.
+                      description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                       type: object
                   type: object
                 value:
-                  description: TargetValue is required when the mode is set to `FixedPodMode`
-                    / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                    provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                    provide a number from 0-100 to specify the percent of pods the
-                    server can do chaos action. If `RandomMaxPercentPodMod`,  provide
-                    a number from 0-100 to specify the max percent of pods to do chaos
-                    action
+                  description: TargetValue is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. If `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
                   type: string
               required:
               - mode
               - selector
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. If `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. If `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
           required:
           - action
@@ -342,8 +286,7 @@ spec:
           - selector
           type: object
         status:
-          description: Most recently observed status of the chaos experiment about
-            pods
+          description: Most recently observed status of the chaos experiment about pods
           properties:
             experiment:
               description: Experiment records the last experiment state.
@@ -354,21 +297,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_podchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_podchaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: podchaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: PodChaos is the control script`s spec.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,35 +31,25 @@ spec:
           description: Spec defines the behavior of a pod chaos experiment
           properties:
             action:
-              description: 'Action defines the specific pod chaos action. Supported
-                action: pod-kill / pod-failure / container-kill Default action: pod-kill'
+              description: 'Action defines the specific pod chaos action. Supported action: pod-kill / pod-failure / container-kill Default action: pod-kill'
               enum:
               - pod-kill
               - pod-failure
               - container-kill
               type: string
             containerName:
-              description: ContainerName indicates the name of the container. Needed
-                in container-kill.
+              description: ContainerName indicates the name of the container. Needed in container-kill.
               type: string
             duration:
-              description: Duration represents the duration of the chaos action. It
-                is required when the action is `PodFailureAction`. A duration string
-                is a possibly signed sequence of decimal numbers, each with optional
-                fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
-                time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+              description: Duration represents the duration of the chaos action. It is required when the action is `PodFailureAction`. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
               type: string
             gracePeriod:
-              description: GracePeriod is used in pod-kill action. It represents the
-                duration in seconds before the pod should be deleted. Value must be
-                non-negative integer. The default value is zero that indicates delete
-                immediately.
+              description: GracePeriod is used in pod-kill action. It represents the duration in seconds before the pod should be deleted. Value must be non-negative integer. The default value is zero that indicates delete immediately.
               format: int64
               minimum: 0
               type: integer
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -72,39 +58,31 @@ spec:
               - random-max-percent
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about pods.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about pods.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -114,20 +92,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -136,18 +109,11 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. IF `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
           required:
           - action
@@ -155,8 +121,7 @@ spec:
           - selector
           type: object
         status:
-          description: Most recently observed status of the chaos experiment about
-            pods
+          description: Most recently observed status of the chaos experiment about pods
           properties:
             experiment:
               description: Experiment records the last experiment state.
@@ -167,21 +132,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_podiochaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_podiochaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: podiochaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: PodIoChaos is the Schema for the podiochaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -71,8 +67,7 @@ spec:
                   faults:
                     description: Faults represents the fault to inject
                     items:
-                      description: IoFault represents the fault to inject and their
-                        weight
+                      description: IoFault represents the fault to inject and their weight
                       properties:
                         errno:
                           format: int32
@@ -98,8 +93,7 @@ spec:
                     description: Latency represents the latency to inject
                     type: string
                   methods:
-                    description: Methods represents the method that the action will
-                      inject in
+                    description: Methods represents the method that the action will inject in
                     items:
                       type: string
                     type: array
@@ -123,8 +117,7 @@ spec:
                     description: Path represents a glob of injecting path
                     type: string
                   percent:
-                    description: Percent represents the percent probability of injecting
-                      this action
+                    description: Percent represents the percent probability of injecting this action
                     type: integer
                   perm:
                     type: integer
@@ -158,10 +151,7 @@ spec:
               format: int64
               type: integer
             volumeMountPath:
-              description: 'VolumeMountPath represents the target mount path It must
-                be a root of mount path now. TODO: search the mount parent of any
-                path automatically. TODO: support multiple different volume mount
-                path in one pod'
+              description: 'VolumeMountPath represents the target mount path It must be a root of mount path now. TODO: search the mount parent of any path automatically. TODO: support multiple different volume mount path in one pod'
               type: string
           required:
           - volumeMountPath

--- a/config/crd/bases/chaos-mesh.org_podnetworkchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_podnetworkchaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: podnetworkchaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: PodNetworkChaos is the Schema for the PodNetworkChaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -58,8 +54,7 @@ spec:
             iptables:
               description: The iptables rules on the pod
               items:
-                description: RawIptables represents the iptables rules on specific
-                  pod
+                description: RawIptables represents the iptables rules on specific pod
                 properties:
                   direction:
                     description: The block direction of this iptables rule
@@ -84,44 +79,33 @@ spec:
             tcs:
               description: The tc rules on the pod
               items:
-                description: RawTrafficControl represents the traffic control chaos
-                  on specific pod
+                description: RawTrafficControl represents the traffic control chaos on specific pod
                 properties:
                   bandwidth:
-                    description: Bandwidth represents the detail about bandwidth control
-                      action
+                    description: Bandwidth represents the detail about bandwidth control action
                     properties:
                       buffer:
-                        description: Buffer is the maximum amount of bytes that tokens
-                          can be available for instantaneously.
+                        description: Buffer is the maximum amount of bytes that tokens can be available for instantaneously.
                         format: int32
                         minimum: 1
                         type: integer
                       limit:
-                        description: Limit is the number of bytes that can be queued
-                          waiting for tokens to become available.
+                        description: Limit is the number of bytes that can be queued waiting for tokens to become available.
                         format: int32
                         minimum: 1
                         type: integer
                       minburst:
-                        description: Minburst specifies the size of the peakrate bucket.
-                          For perfect accuracy, should be set to the MTU of the interface.  If
-                          a peakrate is needed, but some burstiness is acceptable,
-                          this size can be raised. A 3000 byte minburst allows around
-                          3mbit/s of peakrate, given 1000 byte packets.
+                        description: Minburst specifies the size of the peakrate bucket. For perfect accuracy, should be set to the MTU of the interface.  If a peakrate is needed, but some burstiness is acceptable, this size can be raised. A 3000 byte minburst allows around 3mbit/s of peakrate, given 1000 byte packets.
                         format: int32
                         minimum: 0
                         type: integer
                       peakrate:
-                        description: Peakrate is the maximum depletion rate of the
-                          bucket. The peakrate does not need to be set, it is only
-                          necessary if perfect millisecond timescale shaping is required.
+                        description: Peakrate is the maximum depletion rate of the bucket. The peakrate does not need to be set, it is only necessary if perfect millisecond timescale shaping is required.
                         format: int64
                         minimum: 0
                         type: integer
                       rate:
-                        description: Rate is the speed knob. Allows bps, kbps, mbps,
-                          gbps, tbps unit. bps means bytes per second.
+                        description: Rate is the speed knob. Allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second.
                         type: string
                     required:
                     - buffer
@@ -203,8 +187,7 @@ spec:
               type: array
           type: object
         status:
-          description: Most recently observed status of the chaos experiment about
-            pods
+          description: Most recently observed status of the chaos experiment about pods
           properties:
             experiment:
               description: Experiment records the last experiment state.
@@ -215,21 +198,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_stresschaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_stresschaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: stresschaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: StressChaos is the Schema for the stresschaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,50 +31,40 @@ spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
             containerName:
-              description: ContainerName indicates the target container to inject
-                stress in
+              description: ContainerName indicates the target container to inject stress in
               type: string
             duration:
               description: Duration represents the duration of the chaos action
               type: string
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about time.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about time.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -88,20 +74,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -110,33 +91,20 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             stressngStressors:
-              description: StressngStressors defines plenty of stressors just like
-                `Stressors` except that it's an experimental feature and more powerful.
-                You can define stressors in `stress-ng` (see also `man stress-ng`)
-                dialect, however not all of the supported stressors are well tested.
-                It maybe retired in later releases. You should always use `Stressors`
-                to define the stressors and use this only when you want more stressors
-                unsupported by `Stressors`. When both `StressngStressors` and `Stressors`
-                are defined, `StressngStressors` wins.
+              description: StressngStressors defines plenty of stressors just like `Stressors` except that it's an experimental feature and more powerful. You can define stressors in `stress-ng` (see also `man stress-ng`) dialect, however not all of the supported stressors are well tested. It maybe retired in later releases. You should always use `Stressors` to define the stressors and use this only when you want more stressors unsupported by `Stressors`. When both `StressngStressors` and `Stressors` are defined, `StressngStressors` wins.
               type: string
             stressors:
-              description: Stressors defines plenty of stressors supported to stress
-                system components out. You can use one or more of them to make up
-                various kinds of stresses. At least one of the stressors should be
-                specified.
+              description: Stressors defines plenty of stressors supported to stress system components out. You can use one or more of them to make up various kinds of stresses. At least one of the stressors should be specified.
               properties:
                 cpu:
                   description: CPUStressor stresses CPU out
                   properties:
                     load:
-                      description: Load specifies P percent loading per CPU worker.
-                        0 is effectively a sleep (no load) and 100 is full loading.
+                      description: Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100 is full loading.
                       type: integer
                     options:
                       description: extend stress-ng options
@@ -165,12 +133,7 @@ spec:
                   type: object
               type: object
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the max % of pods the server
-                can do chaos action. If `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the % of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the max % of pods the server can do chaos action. If `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the % of pods to do chaos action
               type: string
           required:
           - mode
@@ -188,21 +151,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/chaos-mesh.org_timechaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_timechaos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: timechaos.chaos-mesh.org
 spec:
@@ -20,14 +20,10 @@ spec:
       description: TimeChaos is the Schema for the timechaos API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,16 +31,12 @@ spec:
           description: Spec defines the behavior of a time chaos experiment
           properties:
             clockIds:
-              description: ClockIds defines all affected clock id All available options
-                are ["CLOCK_REALTIME","CLOCK_MONOTONIC","CLOCK_PROCESS_CPUTIME_ID","CLOCK_THREAD_CPUTIME_ID",
-                "CLOCK_MONOTONIC_RAW","CLOCK_REALTIME_COARSE","CLOCK_MONOTONIC_COARSE","CLOCK_BOOTTIME","CLOCK_REALTIME_ALARM",
-                "CLOCK_BOOTTIME_ALARM"] Default value is ["CLOCK_REALTIME"]
+              description: ClockIds defines all affected clock id All available options are ["CLOCK_REALTIME","CLOCK_MONOTONIC","CLOCK_PROCESS_CPUTIME_ID","CLOCK_THREAD_CPUTIME_ID", "CLOCK_MONOTONIC_RAW","CLOCK_REALTIME_COARSE","CLOCK_MONOTONIC_COARSE","CLOCK_BOOTTIME","CLOCK_REALTIME_ALARM", "CLOCK_BOOTTIME_ALARM"] Default value is ["CLOCK_REALTIME"]
               items:
                 type: string
               type: array
             containerNames:
-              description: ContainerName indicates the name of affected container.
-                If not set, all containers will be injected
+              description: ContainerName indicates the name of affected container. If not set, all containers will be injected
               items:
                 type: string
               type: array
@@ -52,8 +44,7 @@ spec:
               description: Duration represents the duration of the chaos action
               type: string
             mode:
-              description: 'Mode defines the mode to run chaos action. Supported mode:
-                one / all / fixed / fixed-percent / random-max-percent'
+              description: 'Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent'
               enum:
               - one
               - all
@@ -62,39 +53,31 @@ spec:
               - random-max-percent
               type: string
             scheduler:
-              description: Scheduler defines some schedule rules to control the running
-                time of the chaos experiment about time.
+              description: Scheduler defines some schedule rules to control the running time of the chaos experiment about time.
               properties:
                 cron:
-                  description: "Cron defines a cron job rule. \n Some rule examples:
-                    \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"
-                    \     means to \"Every hour\" \"@every 1h30m\" means to \"Every
-                    hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
+                  description: "Cron defines a cron job rule. \n Some rule examples: \"0 30 * * * *\" means to \"Every hour on the half hour\" \"@hourly\"      means to \"Every hour\" \"@every 1h30m\" means to \"Every hour thirty\" \n More rule info: https://godoc.org/github.com/robfig/cron"
                   type: string
               required:
               - cron
               type: object
             selector:
-              description: Selector is used to select pods that are used to inject
-                chaos action.
+              description: Selector is used to select pods that are used to inject chaos action.
               properties:
                 annotationSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on annotations.
+                  description: Map of string keys and values that can be used to select objects. A selector based on annotations.
                   type: object
                 fieldSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on fields.
+                  description: Map of string keys and values that can be used to select objects. A selector based on fields.
                   type: object
                 labelSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    objects. A selector based on labels.
+                  description: Map of string keys and values that can be used to select objects. A selector based on labels.
                   type: object
                 namespaces:
                   description: Namespaces is a set of namespace to which objects belong.
@@ -104,20 +87,15 @@ spec:
                 nodeSelectors:
                   additionalProperties:
                     type: string
-                  description: Map of string keys and values that can be used to select
-                    nodes. Selector which must match a node's labels, and objects
-                    must belong to these selected nodes.
+                  description: Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
                   type: object
                 nodes:
-                  description: Nodes is a set of node name and objects must belong
-                    to these nodes.
+                  description: Nodes is a set of node name and objects must belong to these nodes.
                   items:
                     type: string
                   type: array
                 podPhaseSelectors:
-                  description: 'PodPhaseSelectors is a set of condition of a pod at
-                    the current time. supported value: Pending / Running / Succeeded
-                    / Failed / Unknown'
+                  description: 'PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown'
                   items:
                     type: string
                   type: array
@@ -126,24 +104,14 @@ spec:
                     items:
                       type: string
                     type: array
-                  description: Pods is a map of string keys and a set values that
-                    used to select pods. The key defines the namespace which pods
-                    belong, and the each values is a set of pod names.
+                  description: Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
                   type: object
               type: object
             timeOffset:
-              description: TimeOffset defines the delta time of injected program.
-                It's a possibly signed sequence of decimal numbers, such as "300ms",
-                "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms",
-                "s", "m", "h".
+              description: TimeOffset defines the delta time of injected program. It's a possibly signed sequence of decimal numbers, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
               type: string
             value:
-              description: Value is required when the mode is set to `FixedPodMode`
-                / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`,
-                provide an integer of pods to do chaos action. If `FixedPercentPodMod`,
-                provide a number from 0-100 to specify the percent of pods the server
-                can do chaos action. If `RandomMaxPercentPodMod`,  provide a number
-                from 0-100 to specify the max percent of pods to do chaos action
+              description: Value is required when the mode is set to `FixedPodMode` / `FixedPercentPodMod` / `RandomMaxPercentPodMod`. If `FixedPodMode`, provide an integer of pods to do chaos action. If `FixedPercentPodMod`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. If `RandomMaxPercentPodMod`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
               type: string
           required:
           - mode
@@ -162,21 +130,18 @@ spec:
                   format: date-time
                   type: string
                 phase:
-                  description: ExperimentPhase is the current status of chaos experiment.
+                  description: ExperimentPhase is the current phase of chaos experiment.
                   type: string
                 podRecords:
                   items:
-                    description: PodStatus represents information about the status
-                      of a pod in chaos experiment.
+                    description: PodStatus represents information about the status of a pod in chaos experiment.
                     properties:
                       action:
                         type: string
                       hostIP:
                         type: string
                       message:
-                        description: A brief CamelCase message indicating details
-                          about the chaos action. e.g. "delete this pod" or "pause
-                          this pod duration 5m"
+                        description: A brief CamelCase message indicating details about the chaos action. e.g. "delete this pod" or "pause this pod duration 5m"
                         type: string
                       name:
                         type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - chaos-mesh.org
   resources:
   - httpchaos

--- a/controllers/httpchaos/types.go
+++ b/controllers/httpchaos/types.go
@@ -38,7 +38,7 @@ type Reconciler struct {
 	Log logr.Logger
 }
 
-func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error {
+func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject, tgt *v1alpha1.ChaosResolvedTargets) error {
 	httpFaultChaos, ok := chaos.(*v1alpha1.HTTPChaos)
 	if !ok {
 		err := errors.New("chaos is not HttpFaultChaos")
@@ -46,12 +46,8 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 		return err
 	}
 
-	pods, err := utils.SelectAndFilterPods(ctx, r.Client, r.Reader, &httpFaultChaos.Spec)
-	if err != nil {
-		r.Log.Error(err, "failed to select and filter pods")
-		return err
-	}
-	if err = r.applyAllPods(ctx, pods, httpFaultChaos); err != nil {
+	pods := tgt.Sources
+	if err := r.applyAllPods(ctx, pods, httpFaultChaos); err != nil {
 		r.Log.Error(err, "failed to apply chaos on all pods")
 		return err
 	}

--- a/controllers/kernelchaos/types.go
+++ b/controllers/kernelchaos/types.go
@@ -88,7 +88,7 @@ func (r *Reconciler) scheduleKernelChaos(kernelChaos *v1alpha1.KernelChaos, req 
 }
 
 // Apply applies KernelChaos
-func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error {
+func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject, tgt *v1alpha1.ChaosResolvedTargets) error {
 	kernelChaos, ok := chaos.(*v1alpha1.KernelChaos)
 	if !ok {
 		err := errors.New("chaos is not kernelChaos")
@@ -96,13 +96,8 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 		return err
 	}
 
-	pods, err := utils.SelectAndFilterPods(ctx, r.Client, r.Reader, &kernelChaos.Spec)
-	if err != nil {
-		r.Log.Error(err, "failed to select and filter pods")
-		return err
-	}
-
-	if err = r.applyAllPods(ctx, pods, kernelChaos); err != nil {
+	pods := tgt.Sources
+	if err := r.applyAllPods(ctx, pods, kernelChaos); err != nil {
 		r.Log.Error(err, "failed to apply chaos on all pods")
 		return err
 	}

--- a/controllers/networkchaos/trafficcontrol/types_test.go
+++ b/controllers/networkchaos/trafficcontrol/types_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestReconciler_applyNetem(t *testing.T) {
@@ -79,8 +80,12 @@ func TestReconciler_applyNetem(t *testing.T) {
 		})()
 		defer mock.With("MockChaosDaemonClient", &test.MockChaosDaemonClient{})()
 
-		err := r.Apply(context.TODO(), ctrl.Request{}, &networkChaos)
+		ctx := context.TODO()
 
+		tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, networkChaos.GetSourceTargetSpec(), false, "", "", "")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = r.Apply(ctx, ctrl.Request{}, &networkChaos, tgt)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -116,8 +121,12 @@ func TestReconciler_applyNetem(t *testing.T) {
 		})()
 		defer mock.With("MockChaosDaemonClient", &test.MockChaosDaemonClient{})()
 
-		err := r.Apply(context.TODO(), ctrl.Request{}, &networkChaos)
+		ctx := context.TODO()
 
+		tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, networkChaos.GetSourceTargetSpec(), false, "", "", "")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = r.Apply(context.TODO(), ctrl.Request{}, &networkChaos, tgt)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }

--- a/controllers/podchaos/podfailure/podfailure_suite_test.go
+++ b/controllers/podchaos/podfailure/podfailure_suite_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/podchaos/podfailure"
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestPodFailure(t *testing.T) {
@@ -93,12 +94,15 @@ var _ = Describe("PodChaos", func() {
 				return pods
 			})()
 
-			var err error
+			ctx := context.TODO()
 
-			err = r.Apply(context.TODO(), ctrl.Request{}, &podChaos)
+			tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, podChaos.GetSourceTargetSpec(), false, "", "", "")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = r.Recover(context.TODO(), ctrl.Request{}, &podChaos)
+			err = r.Apply(ctx, ctrl.Request{}, &podChaos, tgt)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Recover(ctx, ctrl.Request{}, &podChaos)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/controllers/podchaos/podkill/podkill_suite_test.go
+++ b/controllers/podchaos/podkill/podkill_suite_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/podchaos/podkill"
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestPodKill(t *testing.T) {
@@ -93,13 +94,16 @@ var _ = Describe("PodChaos", func() {
 				return pods
 			})()
 
-			var err error
+			ctx := context.TODO()
 
-			err = r.Apply(context.TODO(), ctrl.Request{}, &podChaos)
+			tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, podChaos.GetSourceTargetSpec(), true, "", "", metav1.NamespaceDefault)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Apply(context.TODO(), ctrl.Request{}, &podChaos, tgt)
 			Expect(err).ToNot(HaveOccurred())
 
 			// pod "p0" already deleted
-			err = r.Apply(context.TODO(), ctrl.Request{}, &podChaos)
+			err = r.Apply(context.TODO(), ctrl.Request{}, &podChaos, tgt)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("pods \"p0\" not found"))
 

--- a/controllers/reconciler/types.go
+++ b/controllers/reconciler/types.go
@@ -25,7 +25,7 @@ import (
 type InnerReconciler interface {
 
 	// Apply means the reconciler perform the chaos action
-	Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error
+	Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject, resolvedTargets *v1alpha1.ChaosResolvedTargets) error
 
 	// Recover means the reconciler recovers the chaos action
 	Recover(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error

--- a/controllers/timechaos/timechaos_suite_test.go
+++ b/controllers/timechaos/timechaos_suite_test.go
@@ -36,6 +36,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	. "github.com/chaos-mesh/chaos-mesh/controllers/timechaos"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestTimechaos(t *testing.T) {
@@ -98,8 +99,12 @@ var _ = Describe("TimeChaos", func() {
 			})()
 			defer mock.With("MockChaosDaemonClient", &MockChaosDaemonClient{})()
 
-			err := r.Apply(context.TODO(), ctrl.Request{}, &timechaos)
+			ctx := context.TODO()
 
+			tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, timechaos.GetSourceTargetSpec(), false, "", "", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Apply(ctx, ctrl.Request{}, &timechaos, tgt)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -110,8 +115,12 @@ var _ = Describe("TimeChaos", func() {
 			defer mock.With("MockChaosDaemonClient", &MockChaosDaemonClient{})()
 			defer mock.With("MockSetTimeOffsetError", errors.New("SetTimeOffsetError"))()
 
-			err := r.Apply(context.TODO(), ctrl.Request{}, &timechaos)
+			ctx := context.TODO()
 
+			tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, timechaos.GetSourceTargetSpec(), false, "", "", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Apply(ctx, ctrl.Request{}, &timechaos, tgt)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("SetTimeOffsetError"))
 
@@ -134,7 +143,12 @@ var _ = Describe("TimeChaos", func() {
 			defer mock.With("MockChaosDaemonClient", &MockChaosDaemonClient{})()
 			defer mock.With("MockRecoverTimeOffsetError", errors.New("RecoverTimeOffsetError"))()
 
-			err := r.Apply(context.TODO(), ctrl.Request{}, &timechaos)
+			ctx := context.TODO()
+
+			tgt, err := utils.ResolveTargets(ctx, r.Client, r.Reader, timechaos.GetSourceTargetSpec(), false, "", "", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Apply(context.TODO(), ctrl.Request{}, &timechaos, tgt)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = r.Recover(context.TODO(), ctrl.Request{}, &timechaos)

--- a/controllers/timechaos/types.go
+++ b/controllers/timechaos/types.go
@@ -78,7 +78,7 @@ func (r *Reconciler) scheduleTimeChaos(timechaos *v1alpha1.TimeChaos, req ctrl.R
 }
 
 // Apply applies time-chaos
-func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error {
+func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject, tgt *v1alpha1.ChaosResolvedTargets) error {
 	timechaos, ok := chaos.(*v1alpha1.TimeChaos)
 	if !ok {
 		err := errors.New("chaos is not timechaos")
@@ -87,15 +87,9 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1
 	}
 
 	timechaos.SetDefaultValue()
+	pods := tgt.Sources
 
-	pods, err := utils.SelectAndFilterPods(ctx, r.Client, r.Reader, &timechaos.Spec)
-
-	if err != nil {
-		r.Log.Error(err, "failed to select and filter pods")
-		return err
-	}
-
-	if err = r.applyAllPods(ctx, pods, timechaos); err != nil {
+	if err := r.applyAllPods(ctx, pods, timechaos); err != nil {
 		r.Log.Error(err, "failed to apply chaos on all pods")
 		return err
 	}

--- a/pkg/apiserver/common/common.go
+++ b/pkg/apiserver/common/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/common"
 	"github.com/chaos-mesh/chaos-mesh/pkg/apiserver/utils"
 	"github.com/chaos-mesh/chaos-mesh/pkg/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/core"
@@ -87,7 +88,7 @@ func (s *Service) listPods(c *gin.Context) {
 		return
 	}
 	ctx := context.TODO()
-	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector())
+	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector(), common.ControllerCfg.ClusterScoped, common.ControllerCfg.AllowedNamespaces, common.ControllerCfg.IgnoredNamespaces, common.ControllerCfg.TargetNamespace)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
@@ -175,7 +176,7 @@ func (s *Service) getLabels(c *gin.Context) {
 	exp.NamespaceSelectors = nsList
 
 	ctx := context.TODO()
-	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector())
+	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector(), common.ControllerCfg.ClusterScoped, common.ControllerCfg.AllowedNamespaces, common.ControllerCfg.IgnoredNamespaces, common.ControllerCfg.TargetNamespace)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
@@ -220,7 +221,7 @@ func (s *Service) getAnnotations(c *gin.Context) {
 	exp.NamespaceSelectors = nsList
 
 	ctx := context.TODO()
-	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector())
+	filteredPods, err := pkgutils.SelectPods(ctx, s.kubeCli, s.reader, exp.ParseSelector(), common.ControllerCfg.ClusterScoped, common.ControllerCfg.AllowedNamespaces, common.ControllerCfg.IgnoredNamespaces, common.ControllerCfg.TargetNamespace)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))

--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-	"github.com/chaos-mesh/chaos-mesh/controllers/common"
+	"github.com/chaos-mesh/chaos-mesh/controllers/podnetworkchaos/netutils"
 	"github.com/chaos-mesh/chaos-mesh/pkg/label"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 
@@ -38,14 +38,40 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type SelectSpec interface {
-	GetSelector() v1alpha1.SelectorSpec
-	GetMode() v1alpha1.PodMode
-	GetValue() string
+// ResolveTargets resolv source/target pods and external cidrs
+func ResolveTargets(ctx context.Context, c client.Client, r client.Reader, selectSpec *v1alpha1.ChaosSourceTargetSpec, clusterScoped bool, allowedNamespaces, ignoredNamespaces, targetNamespace string) (*v1alpha1.ChaosResolvedTargets, error) {
+	tgt := &v1alpha1.ChaosResolvedTargets{}
+
+	sources, err := SelectAndFilterPods(ctx, c, r, selectSpec.Source, clusterScoped, allowedNamespaces, ignoredNamespaces, targetNamespace)
+	if err != nil {
+		return nil, err
+	}
+	tgt.Sources = sources
+
+	var (
+		targets []v1.Pod
+	)
+
+	// We should only apply filter when we specify targets
+	if selectSpec.Target != nil {
+		targets, err = SelectAndFilterPods(ctx, c, r, selectSpec.Target, clusterScoped, allowedNamespaces, ignoredNamespaces, targetNamespace)
+		if err != nil {
+			return nil, err
+		}
+		tgt.Targets = targets
+	}
+
+	externalCidrs, err := netutils.ResolveCidrs(selectSpec.ExternalTargets)
+	if err != nil {
+		return nil, err
+	}
+	tgt.ExternalCidrs = externalCidrs
+
+	return tgt, err
 }
 
 // SelectAndFilterPods returns the list of pods that filtered by selector and PodMode
-func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, spec SelectSpec) ([]v1.Pod, error) {
+func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, spec v1alpha1.InnerSelectSpec, clusterScoped bool, allowedNamespaces, ignoredNamespaces, targetNamespace string) ([]v1.Pod, error) {
 	if pods := mock.On("MockSelectAndFilterPods"); pods != nil {
 		return pods.(func() []v1.Pod)(), nil
 	}
@@ -57,7 +83,7 @@ func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, 
 	mode := spec.GetMode()
 	value := spec.GetValue()
 
-	pods, err := SelectPods(ctx, c, r, selector)
+	pods, err := SelectPods(ctx, c, r, selector, clusterScoped, allowedNamespaces, ignoredNamespaces, targetNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -75,23 +101,34 @@ func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, 
 	return filteredPod, nil
 }
 
+// SelectAndFilterChaosByPod returns the list of chaos that filtered by the pod selectors
+func SelectAndFilterChaosByPod(ctx context.Context, c client.Client, r client.Reader, spec v1alpha1.InnerSelectSpec, list v1alpha1.ChaosList) ([]v1alpha1.InnerObject, error) {
+	// FIXME: from now, we returned all chaos.
+	chaoes, err := SelectChaoes(ctx, c, r, v1alpha1.SelectorSpec{}, list)
+	if err != nil {
+		return nil, err
+	}
+	return chaoes, nil
+}
+
 // SelectPods returns the list of pods that are available for pod chaos action.
 // It returns all pods that match the configured label, annotation and namespace selectors.
 // If pods are specifically specified by `selector.Pods`, it just returns the selector.Pods.
-func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector v1alpha1.SelectorSpec) ([]v1.Pod, error) {
+func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector v1alpha1.SelectorSpec, clusterScoped bool, allowedNamespaces, ignoredNamespaces, targetNamespace string) ([]v1.Pod, error) {
 	// TODO: refactor: make different selectors to replace if-else logics
 	var pods []v1.Pod
 
 	// pods are specifically specified
 	if len(selector.Pods) > 0 {
 		for ns, names := range selector.Pods {
-			if !common.ControllerCfg.ClusterScoped {
-				if common.ControllerCfg.TargetNamespace != ns {
+			if !clusterScoped {
+				if targetNamespace != ns {
 					log.Info("skip namespace because ns is out of scope within namespace scoped mode", "namespace", ns)
 					continue
 				}
 			}
-			if !IsAllowedNamespaces(ns) {
+
+			if !IsAllowedNamespaces(ns, allowedNamespaces, ignoredNamespaces) {
 				log.Info("filter pod by namespaces", "namespace", ns)
 				continue
 			}
@@ -118,11 +155,11 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 		return pods, nil
 	}
 
-	if !common.ControllerCfg.ClusterScoped {
+	if !clusterScoped {
 		if len(selector.Namespaces) > 1 {
 			return nil, fmt.Errorf("could NOT use more than 1 namespace selector within namespace scoped mode")
 		} else if len(selector.Namespaces) == 1 {
-			if selector.Namespaces[0] != common.ControllerCfg.TargetNamespace {
+			if selector.Namespaces[0] != targetNamespace {
 				return nil, fmt.Errorf("could NOT list pods from out of scoped namespace: %s", selector.Namespaces[0])
 			}
 		}
@@ -131,8 +168,8 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 	var podList v1.PodList
 
 	var listOptions = client.ListOptions{}
-	if !common.ControllerCfg.ClusterScoped {
-		listOptions.Namespace = common.ControllerCfg.TargetNamespace
+	if !clusterScoped {
+		listOptions.Namespace = targetNamespace
 	}
 	if len(selector.LabelSelectors) > 0 {
 		listOptions.LabelSelector = labels.SelectorFromSet(selector.LabelSelectors)
@@ -178,7 +215,7 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 		}
 		pods = filterPodByNode(pods, nodes)
 	}
-	pods = filterByNamespaces(pods)
+	pods = filterByNamespaces(pods, allowedNamespaces, ignoredNamespaces)
 
 	namespaceSelector, err := parseSelector(strings.Join(selector.Namespaces, ","))
 	if err != nil {
@@ -205,6 +242,24 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 	}
 
 	return pods, nil
+}
+
+// SelectChaoes returns the list of chaoes that are available for specified pod(src or target).
+// It returns all chaoes that match the configured label, annotation and namespace selectors or selectors.Pods.
+func SelectChaoes(ctx context.Context, c client.Client, r client.Reader, selector v1alpha1.SelectorSpec, list v1alpha1.ChaosList) ([]v1alpha1.InnerObject, error) {
+	chaoes := []v1alpha1.InnerObject{}
+	listOptions := client.ListOptions{}
+
+	// FIXME: from now, we returned all chaos.
+	if err := r.List(ctx, list, &listOptions); err != nil {
+		return nil, err
+	}
+
+	for _, chaos := range list.ListItems() {
+		chaoes = append(chaoes, chaos)
+	}
+
+	return chaoes, nil
 }
 
 // CheckPodMeetSelector checks if this pod meets the selection criteria.
@@ -440,11 +495,11 @@ func filterByPhaseSelector(pods []v1.Pod, phases labels.Selector) ([]v1.Pod, err
 	return filteredList, nil
 }
 
-func filterByNamespaces(pods []v1.Pod) []v1.Pod {
+func filterByNamespaces(pods []v1.Pod, allowedNamespaces, ignoredNamespaces string) []v1.Pod {
 	var filteredList []v1.Pod
 
 	for _, pod := range pods {
-		if IsAllowedNamespaces(pod.Namespace) {
+		if IsAllowedNamespaces(pod.Namespace, allowedNamespaces, ignoredNamespaces) {
 			filteredList = append(filteredList, pod)
 		} else {
 			log.Info("filter pod by namespaces",
@@ -455,17 +510,17 @@ func filterByNamespaces(pods []v1.Pod) []v1.Pod {
 }
 
 // IsAllowedNamespaces returns whether namespace allows the execution of a chaos task
-func IsAllowedNamespaces(namespace string) bool {
-	if common.ControllerCfg.AllowedNamespaces != "" {
-		matched, err := regexp.MatchString(common.ControllerCfg.AllowedNamespaces, namespace)
+func IsAllowedNamespaces(namespace, allowedNamespaces, ignoredNamespaces string) bool {
+	if allowedNamespaces != "" {
+		matched, err := regexp.MatchString(allowedNamespaces, namespace)
 		if err != nil {
 			return false
 		}
 		return matched
 	}
 
-	if common.ControllerCfg.IgnoredNamespaces != "" {
-		matched, err := regexp.MatchString(common.ControllerCfg.IgnoredNamespaces, namespace)
+	if ignoredNamespaces != "" {
+		matched, err := regexp.MatchString(ignoredNamespaces, namespace)
 		if err != nil {
 			return false
 		}

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-	"github.com/chaos-mesh/chaos-mesh/controllers/common"
 	"github.com/chaos-mesh/chaos-mesh/pkg/label"
 
 	v1 "k8s.io/api/core/v1"
@@ -124,7 +123,7 @@ func TestSelectPods(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		filteredPods, err := SelectPods(context.Background(), c, r, tc.selector)
+		filteredPods, err := SelectPods(context.Background(), c, r, tc.selector, true, "", "", "")
 		g.Expect(err).ShouldNot(HaveOccurred(), tc.name)
 		g.Expect(len(filteredPods)).To(Equal(len(tc.expectedPods)), tc.name)
 	}
@@ -485,22 +484,10 @@ func TestIsAllowedNamespaces(t *testing.T) {
 		ignore: "ignore",
 	})
 
-	setRule := func(allow string, ignore string) {
-		common.ControllerCfg.AllowedNamespaces = allow
-		common.ControllerCfg.IgnoredNamespaces = ignore
-	}
-
-	clean := func() {
-		common.ControllerCfg.AllowedNamespaces = ""
-		common.ControllerCfg.IgnoredNamespaces = ""
-	}
-
 	for _, tc := range tcs {
-		setRule(tc.allow, tc.ignore)
 		for index, pod := range tc.pods {
-			g.Expect(IsAllowedNamespaces(pod.Namespace)).Should(Equal(tc.ret[index]))
+			g.Expect(IsAllowedNamespaces(pod.Namespace, tc.allow, tc.ignore)).Should(Equal(tc.ret[index]))
 		}
-		clean()
 	}
 }
 

--- a/pkg/webhook/inject/inject_test.go
+++ b/pkg/webhook/inject/inject_test.go
@@ -32,7 +32,7 @@ var _ = Describe("webhook inject", func() {
 		It("should return unexpected end of JSON input", func() {
 			var testClient client.Client
 			var cfg *config.Config
-			res := Inject(&admissionv1beta1.AdmissionRequest{}, testClient, cfg, nil)
+			res := Inject(&admissionv1beta1.AdmissionRequest{}, testClient, cfg, nil, "", "")
 			Expect(res.Result.Message).To(ContainSubstring("unexpected end of JSON input"))
 		})
 	})
@@ -86,7 +86,7 @@ var _ = Describe("webhook inject", func() {
 			metadata.Namespace = "kube-system"
 			var cli client.Client
 			var cfg config.Config
-			str, flag := injectRequired(&metadata, cli, &cfg)
+			str, flag := injectRequired(&metadata, cli, &cfg, "", "")
 			Expect(str).To(Equal(""))
 			Expect(flag).To(Equal(false))
 		})
@@ -98,7 +98,7 @@ var _ = Describe("webhook inject", func() {
 			var cfg config.Config
 			cfg.AnnotationNamespace = "testNamespace"
 			var cli client.Client
-			str, flag := injectRequired(&metadata, cli, &cfg)
+			str, flag := injectRequired(&metadata, cli, &cfg, "", "")
 			Expect(str).To(Equal(""))
 			Expect(flag).To(Equal(false))
 		})
@@ -110,7 +110,7 @@ var _ = Describe("webhook inject", func() {
 			var cfg config.Config
 			cfg.AnnotationNamespace = "testNamespace"
 			var cli client.Client
-			str, flag := injectRequired(&metadata, cli, &cfg)
+			str, flag := injectRequired(&metadata, cli, &cfg, "", "")
 			Expect(str).To(Equal(""))
 			Expect(flag).To(Equal(false))
 		})
@@ -122,7 +122,7 @@ var _ = Describe("webhook inject", func() {
 			metadata.Namespace = "testNamespace"
 			var cfg config.Config
 			cfg.AnnotationNamespace = "testNamespace"
-			str, flag := injectRequired(&metadata, k8sClient, &cfg)
+			str, flag := injectRequired(&metadata, k8sClient, &cfg, "", "")
 			Expect(str).To(Equal("test"))
 			Expect(flag).To(Equal(true))
 		})
@@ -131,7 +131,7 @@ var _ = Describe("webhook inject", func() {
 			var metadata metav1.ObjectMeta
 			metadata.Annotations = make(map[string]string)
 			var cfg config.Config
-			_, flag := injectRequired(&metadata, k8sClient, &cfg)
+			_, flag := injectRequired(&metadata, k8sClient, &cfg, "", "")
 			Expect(flag).To(Equal(false))
 		})
 	})


### PR DESCRIPTION
### What problem does this PR solve?
Alternative to #908 

### What is changed and how does it work?
1. add pod change watcher and issue relative chaos request;
2. refactor reconcile resolve targets;
3. compare targets change and refresh (recover and re-apply) if need

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
No

```release-note
NONE
```
