### PR TITLE
Add a flag to control the version of Chaos Mesh in install.sh

### DIFF
--- a/hack/update_install_script.sh
+++ b/hack/update_install_script.sh
@@ -28,6 +28,9 @@ sed -i.bak 's/caBundle:.*/caBundle: \"\$\{CA_BUNDLE\}\"/g' $tmp_file
 sed -i.bak 's/mountPath: \/var\/run\/docker.sock/mountPath: \$\{mountPath\}/g' $tmp_file
 sed -i.bak 's/path: \/var\/run\/docker.sock/path: \$\{socketPath\}/g' $tmp_file
 sed -i.bak 's/- docker/- $\{runtime\}/g' $tmp_file
+sed -i.bak 's/pingcap\/chaos-mesh:.*/pingcap\/chaos-mesh:\$\{VERSION_TAG\}/g' $tmp_file
+sed -i.bak 's/pingcap\/chaos-daemon:.*/pingcap\/chaos-daemon:\$\{VERSION_TAG\}/g' $tmp_file
+sed -i.bak 's/pingcap\/chaos-dashboard:.*/pingcap\/chaos-dashboard:\$\{VERSION_TAG\}/g' $tmp_file
 mv $tmp_file $tmp_file.bak
 
 cat <<EOF > $tmp_file

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ OPTIONS:
     -l, --local [kind]       Choose a way to run a local kubernetes cluster, supported value: kind,
                              If this value is not set and the Kubernetes is not installed, this script will exit with 1.
     -n, --name               Name of Kubernetes cluster, default value: kind
-    -c  --crd                The URL of the crd files, default value: https://mirrors.chaos-mesh.org/latest/crd.yaml
+    -c  --crd                The path of the crd files. Get the crd file from "https://mirrors.chaos-mesh.org" if the crd path is empty.
     -r  --runtime            Runtime specifies which container runtime to use. Currently we only supports docker and containerd. default value: docker
         --kind-version       Version of the Kind tool, default value: v0.7.0
         --node-num           The count of the cluster nodes,default value: 3
@@ -72,7 +72,7 @@ main() {
     local docker_mirror=false
     local volume_provisioner=false
     local local_registry=false
-    local crd="https://mirrors.chaos-mesh.org/latest/crd.yaml"
+    local crd=""
     local runtime="docker"
     local template=false
     local install_dependency_only=false
@@ -216,9 +216,13 @@ main() {
         runtime="containerd"
     fi
 
+    if [ "${crd}" == "" ]; then
+        crd="https://mirrors.chaos-mesh.org/${cm_version}/crd.yaml"
+    fi
+
     if $template; then
         ensure gen_crd_manifests "${crd}"
-        ensure gen_chaos_mesh_manifests "${runtime}" "${k3s}"
+        ensure gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${cm_version}"
         exit 0
     fi
 
@@ -240,7 +244,7 @@ main() {
 
     check_kubernetes
 
-    install_chaos_mesh "${release_name}" "${namespace}" "${local_kube}" ${force_chaos_mesh} ${docker_mirror} "${crd}" "${runtime}" "${k3s}"
+    install_chaos_mesh "${release_name}" "${namespace}" "${local_kube}" ${force_chaos_mesh} ${docker_mirror} "${crd}" "${runtime}" "${k3s}" "${cm_version}"
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=controller-manager" 100
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=chaos-daemon" 100
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=chaos-dashboard" 100
@@ -594,23 +598,27 @@ install_chaos_mesh() {
     local crd=$6
     local runtime=$7
     local k3s=$8
+    local version=$9
 
     printf "Install Chaos Mesh %s\n" "${release_name}"
 
-    local chaos_mesh_image="pingcap/chaos-mesh:latest"
-    local chaos_daemon_image="pingcap/chaos-daemon:latest"
+    local chaos_mesh_image="pingcap/chaos-mesh:${version}"
+    local chaos_daemon_image="pingcap/chaos-daemon:${version}"
+    local chaos_dashboard_image="pingcap/chaos-dashboard:${version}"
 
     if [ "$docker_mirror" == "true" ]; then
         azk8spull "${chaos_mesh_image}" || true
         azk8spull "${chaos_daemon_image}" || true
+        azk8spull "${chaos_dashboard_image}" || true
         if [ "${local_kube}" == "kind" ]; then
             kind load docker-image "${chaos_mesh_image}" > /dev/null 2>&1 || true
             kind load docker-image "${chaos_daemon_image}" > /dev/null 2>&1 || true
+            kind load docker-image "${chaos_dashboard_image}" > /dev/null 2>&1 || true
         fi
     fi
 
     gen_crd_manifests "${crd}" | kubectl apply -f - || exit 1
-    gen_chaos_mesh_manifests "${runtime}" "${k3s}" | kubectl apply -f - || exit 1
+    gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${version}" | kubectl apply -f - || exit 1
 }
 
 version_lt() {
@@ -780,10 +788,6 @@ gen_crd_manifests() {
         return
     fi
 
-    if [ "$crd" == "" ]; then
-        crd="manifests/crd.yaml"
-    fi
-
     ensure cat "$crd"
 }
 
@@ -800,6 +804,7 @@ check_url() {
 gen_chaos_mesh_manifests() {
     local runtime=$1
     local k3s=$2
+    local version=$3
 
     local socketPath="/var/run/docker.sock"
     local mountPath="/var/run/docker.sock"
@@ -819,6 +824,7 @@ gen_chaos_mesh_manifests() {
 
     K8S_SERVICE="chaos-mesh-controller-manager"
     K8S_NAMESPACE="chaos-testing"
+    VERSION_TAG="${version}"
     tmpdir=$(mktemp -d)
 
     ensure openssl genrsa -out ${tmpdir}/ca.key 2048 > /dev/null 2>&1
@@ -1051,7 +1057,7 @@ spec:
       hostPID: true
       containers:
         - name: chaos-daemon
-          image: pingcap/chaos-daemon:latest
+          image: pingcap/chaos-daemon:${VERSION_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/chaos-daemon
@@ -1116,7 +1122,7 @@ spec:
       serviceAccount: chaos-controller-manager
       containers:
         - name: chaos-dashboard
-          image: pingcap/chaos-dashboard:latest
+          image: pingcap/chaos-dashboard:${VERSION_TAG}
           imagePullPolicy: IfNotPresent
           resources:
             limits: {}
@@ -1176,7 +1182,7 @@ spec:
       serviceAccount: chaos-controller-manager
       containers:
       - name: chaos-mesh
-        image: pingcap/chaos-mesh:latest
+        image: pingcap/chaos-mesh:${VERSION_TAG}
         imagePullPolicy: IfNotPresent
         resources:
             limits: {}


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

Add a flag `-v` to control the version of Chaos Mesh in `install.sh`. 

### What is changed and how does it work? 

```bash
install.sh -v v0.9.1
```

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
