### PR TITLE
fix website: only one daemon is created by default

### DIFF
--- a/website/docs/installation/get_started_on_kind.md
+++ b/website/docs/installation/get_started_on_kind.md
@@ -37,8 +37,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/docs/installation/get_started_on_minikube.md
+++ b/website/docs/installation/get_started_on_minikube.md
@@ -63,8 +63,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -48,8 +48,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.0/installation/get_started_on_kind.md
+++ b/website/versioned_docs/version-0.9.0/installation/get_started_on_kind.md
@@ -37,8 +37,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.0/installation/get_started_on_minikube.md
+++ b/website/versioned_docs/version-0.9.0/installation/get_started_on_minikube.md
@@ -63,8 +63,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.0/installation/installation.md
+++ b/website/versioned_docs/version-0.9.0/installation/installation.md
@@ -48,8 +48,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.1/installation/get_started_on_kind.md
+++ b/website/versioned_docs/version-0.9.1/installation/get_started_on_kind.md
@@ -37,8 +37,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.1/installation/get_started_on_minikube.md
+++ b/website/versioned_docs/version-0.9.1/installation/get_started_on_minikube.md
@@ -63,8 +63,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-0.9.1/installation/installation.md
+++ b/website/versioned_docs/version-0.9.1/installation/installation.md
@@ -48,8 +48,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-1.0.0/installation/get_started_on_kind.md
+++ b/website/versioned_docs/version-1.0.0/installation/get_started_on_kind.md
@@ -37,8 +37,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-1.0.0/installation/get_started_on_minikube.md
+++ b/website/versioned_docs/version-1.0.0/installation/get_started_on_minikube.md
@@ -63,8 +63,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 

--- a/website/versioned_docs/version-1.0.0/installation/installation.md
+++ b/website/versioned_docs/version-1.0.0/installation/installation.md
@@ -48,8 +48,6 @@ Expected output:
 NAME                                        READY   STATUS    RESTARTS   AGE
 chaos-controller-manager-6d6d95cd94-kl8gs   1/1     Running   0          3m40s
 chaos-daemon-5shkv                          1/1     Running   0          3m40s
-chaos-daemon-jpqhd                          1/1     Running   0          3m40s
-chaos-daemon-n6mfq                          1/1     Running   0          3m40s
 chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 ```
 


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What problem does this PR solve?
fix #980 

### What is changed and how does it work?

On the website, three daemons are shown running, while actually there is only one.
Make test on v1.0.0 and v0.9.1, both the same. Since the change from v0.9.0 to v0.9.1 is not related to the duplication of chaos-daemons, I also modify doc of v0.9.0, plz correct me if I'm wrong.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
