### PR TITLE
ingress uses correct serviceName now

### DIFF
--- a/helm/chaos-mesh/templates/ingress.yaml
+++ b/helm/chaos-mesh/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.dashboard.ingress.enabled -}}
-{{- $name := include "chaos-mesh.name" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -31,7 +30,7 @@ spec:
         {{- range $paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $name }}-chaos-dashboard
+              serviceName: {{ template "chaos-dashboard.svc" . }}
               servicePort: http
         {{- end }}
   {{- end }}


### PR DESCRIPTION
### What problem does this PR solve?
Fixes #992 

### What is changed and how does it work?
The ingress of the helm-chart is now referring to the correct service

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. install the helm chart with ingress & dashboard support (`--set dashboard.create=true --set dashboard.ingress.enabled=true`)
3. access the ingress via browser
4. the dashboard shall show up