### PR TITLE
bugfix: [link-checker] ignore all links of github and some others

### DIFF
--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -1,4 +1,15 @@
 {
+  "ignorePatterns": [
+    {
+      "pattern": ["^/img/"]
+    },
+    {
+      "pattern": ["^http://localhost"]
+    },
+    {
+      "pattern": ["^https://github.com"]
+    }
+  ],
   "retryOn429": true,
   "aliveStatusCodes":[200, 206, 400, 0]
 }


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What problem does this PR solve?
fix #998 

### What is changed and how does it work?

It seems both new filters in #999 failed.

I'm thinking to use this to filter out what we don't need:
```
{
  "ignorePatterns": [
    {
      "pattern": ["^/img/"]
    },
    {
      "pattern": ["^http://localhost"]
    },
    {
      "pattern": ["^https://github.com"]
    }
  ]
}
```
The first two are acceptable, but with the third one we'll definitely over-filter some broken links of github to avoid 429 error.
The good news is I made tests that most of github links work well, but still I don't know if that would be acceptable.

_Originally posted by @Yiyiyimu in https://github.com/chaos-mesh/chaos-mesh/issues/998#issuecomment-701154563_

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
