### PR TITLE
fix: footer get started link address

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,7 +49,7 @@ module.exports = {
           items: [
             {
               label: 'Getting Started',
-              to: 'docs/get_started/installation',
+              to: 'docs/installation/installation',
             },
             {
               label: 'User Guides',


### PR DESCRIPTION
### What problem does this PR solve?
Invalid footer link.

### What is changed and how does it work?
It changed the docusaurus.config.js footer section of links, which correct the link.

### Checklist

Tests
- [x] Manual test


### Does this PR introduce a user-facing change?

```release-note
NONE
```
