### PR TITLE
upgrade toda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache curl tar
 
 WORKDIR /bin
 
-RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.1/toda-linux-amd64.tar.gz | tar -xz
+RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.2/toda-linux-amd64.tar.gz | tar -xz
 
 COPY ./scripts /scripts
 COPY --from=go_build /src/bin /bin


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Don't override attributes for `lookup` operation.

Override `ino` or other attributes for `lookup` operation may cause an error in many situations, because kernel will use this `ino` to open a file. Overriding the result of `getattr` is enough, because the user can only get ino through `stat` syscall, which will lead to a `getattr` operation.