### PR TITLE
Optimize local install shell script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in improving the project! This document provides a step-by-step guide for general contributions to Chaos Mesh.
 
-If you want to get yourself some rewards while contributing to the Chaos Mesh project, you can't miss [Hacktoberfest 2020](https://hacktoberfest.digitalocean.com/). It's a month-long (Oct 1 - Oct 31) celebration of open source software organized by DigitalOcean, Intel, and DEV. 
+If you want to get yourself some rewards while contributing to the Chaos Mesh project, you can't miss [Hacktoberfest 2020](https://hacktoberfest.digitalocean.com/). It's a month-long (Oct 1 - Oct 31) celebration of open source software organized by DigitalOcean, Intel, and DEV.
 
 Chaos Mesh project is now participating in this program. We have made an [issue list](https://github.com/chaos-mesh/chaos-mesh/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest) for contributors, covering code enhancement, documentation improvement, and test cases. Come pick the issues and earn your Hacktoberfest tee or tree reward.
 
@@ -121,29 +121,11 @@ $ make test
    ...
    ```
 
-3. Build the image:
+3. Install Chaos Mesh:
 
    ```bash
-   $ make image-chaos-mesh
-   $ make image-chaos-dahsboard
-   $ make image-chaos-daemon
-   # or build all images
-   $ make image
-   ```
-
-4. Load image into Kubernetes nodes:
-
-   ```bash
-   $ kind load docker-image pingcap/chaos-mesh:latest
-   $ kind load docker-image pingcap/chaos-dashboard:latest
-   $ kind load docker-image pingcap/chaos-daemon:latest
-   ```
-
-5. Deploy Chaos Mesh:
-
-   ```bash
-   $ ./install.sh --runtime containerd
-   ```
+   $ ./hack/local-up-operator.sh
+   ``
 
 Now you can test your code update on the deployed cluster.
 

--- a/hack/local-up-operator.sh
+++ b/hack/local-up-operator.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This command runs chaos-mesh in Kubernetes.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+source "${ROOT}/hack/lib.sh"
+
+function usage() {
+    cat <<'EOF'
+This commands run chaos-mesh in Kubernetes.
+
+Usage: hack/local-up-operator.sh [-hd]
+
+    -h      show this message and exit
+    -i      install dependencies only
+
+Environments:
+
+    PROVIDER              Kubernetes provider. Defaults: kind.
+    CLUSTER               the name of e2e cluster. Defaults to kind for kind provider.
+    KUBECONFIG            path to the kubeconfig file, defaults: ~/.kube/config
+    KUBECONTEXT           context in kubeconfig file, defaults to current context
+    NAMESPACE             Kubernetes namespace in which we run our chaos-mesh.
+    DOCKER_REGISTRY       image docker registry
+    IMAGE_TAG             image tag
+    SKIP_IMAGE_BUILD      skip build and push images
+
+EOF
+}
+
+
+installOnly=false
+while getopts "h?i" opt; do
+    case "$opt" in
+    h|\?)
+        usage
+        exit 0
+        ;;
+    i)
+      installOnly=true
+        ;;
+    esac
+done
+
+PROVIDER=${PROVIDER:-kind}
+CLUSTER=${CLUSTER:-}
+KUBECONFIG=${KUBECONFIG:-~/.kube/config}
+KUBECONTEXT=${KUBECONTEXT:-}
+DOCKER_REGISTRY_PREFIX=${DOCKER_REGISTRY_PREFIX:-localhost:5000}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+SKIP_IMAGE_BUILD=${SKIP_IMAGE_BUILD:-}
+NAMESPACE=${NAMESPACE:-chaos-testing}
+
+hack::ensure_kubectl
+hack::ensure_kind
+hack::ensure_helm
+
+if [[ "$installOnly" == "true" ]]; then
+    exit 0
+fi
+
+function hack::cluster_exists() {
+    local c="$1"
+    for n in $($KIND_BIN get clusters); do
+        if [ "$n" == "$c" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [ "$PROVIDER" == "kind" ]; then
+    if [ -z "$CLUSTER" ]; then
+        CLUSTER=kind
+    fi
+    if ! hack::cluster_exists "$CLUSTER"; then
+        echo "error: kind cluster '$CLUSTER' not found, please create it or specify the right cluster name with CLUSTER environment"
+        exit 1
+    fi
+else
+    echo "erorr: only kind PROVIDER is supported"
+    exit 1
+fi
+
+if [ -z "$KUBECONTEXT" ]; then
+    KUBECONTEXT=$(kubectl config current-context)
+    echo "info: KUBECONTEXT is not set, current context $KUBECONTEXT is used"
+fi
+
+if [ -z "$SKIP_IMAGE_BUILD" ]; then
+    echo "info: building docker images"
+    DOCKER_REGISTRY_PREFIX=$DOCKER_REGISTRY_PREFIX IMAGE_TAG=$IMAGE_TAG make image
+else
+    echo "info: skip building docker images"
+fi
+
+echo "info: loading images into cluster"
+images=(
+    $DOCKER_REGISTRY_PREFIX/pingcap/chaos-mesh:${IMAGE_TAG}
+    $DOCKER_REGISTRY_PREFIX/pingcap/chaos-dashboard:${IMAGE_TAG}
+    $DOCKER_REGISTRY_PREFIX/pingcap/chaos-daemon:${IMAGE_TAG}
+)
+for n in ${images[@]}; do
+    echo "info: loading image $n"
+    $KIND_BIN load docker-image --name $CLUSTER $n
+done
+
+$KUBECTL_BIN -n "$NAMESPACE" delete deploy -l app.kubernetes.io/name=chaos-mesh
+$KUBECTL_BIN -n "$NAMESPACE" delete pods -l app.kubernetes.io/name=chaos-mesh
+
+${ROOT}/install.sh --runtime containerd --crd ${ROOT}/manifests/crd.yaml --version ${IMAGE_TAG} --docker-registry ${DOCKER_REGISTRY_PREFIX}

--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,7 @@ main() {
     local template=false
     local install_dependency_only=false
     local k3s=false
+    local docker_registry=""
 
     while [[ $# -gt 0 ]]
     do
@@ -197,6 +198,11 @@ main() {
                 shift
                 shift
                 ;;
+            --docker-registry)
+                docker_registry="$2"
+                shift
+                shift
+                ;;
             *)
                 echo "unknown flag or option $key"
                 usage
@@ -229,7 +235,7 @@ main() {
 
     if $template; then
         ensure gen_crd_manifests "${crd}"
-        ensure gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${cm_version}" "${timezone}"
+        ensure gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${cm_version}" "${timezone}" "${docker_registry}"
         exit 0
     fi
 
@@ -250,8 +256,7 @@ main() {
     fi
 
     check_kubernetes
-
-    install_chaos_mesh "${release_name}" "${namespace}" "${local_kube}" ${force_chaos_mesh} ${docker_mirror} "${crd}" "${runtime}" "${k3s}" "${cm_version}" "${timezone}"
+    install_chaos_mesh "${release_name}" "${namespace}" "${local_kube}" ${force_chaos_mesh} ${docker_mirror} "${crd}" "${runtime}" "${k3s}" "${cm_version}" "${timezone}" "${docker_registry}"
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=controller-manager" 100
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=chaos-daemon" 100
     ensure_pods_ready "${namespace}" "app.kubernetes.io/component=chaos-dashboard" 100
@@ -606,13 +611,14 @@ install_chaos_mesh() {
     local runtime=$7
     local k3s=$8
     local version=$9
-    local timezone=$10
-
+    local timezone=${10}
+    local docker_registry=${11}
+    echo "-------${docker_registry}"
     printf "Install Chaos Mesh %s\n" "${release_name}"
 
-    local chaos_mesh_image="pingcap/chaos-mesh:${version}"
-    local chaos_daemon_image="pingcap/chaos-daemon:${version}"
-    local chaos_dashboard_image="pingcap/chaos-dashboard:${version}"
+    local chaos_mesh_image="${docker_registry}/pingcap/chaos-mesh:${version}"
+    local chaos_daemon_image="${docker_registry}/pingcap/chaos-daemon:${version}"
+    local chaos_dashboard_image="${docker_registry}/pingcap/chaos-dashboard:${version}"
 
     if [ "$docker_mirror" == "true" ]; then
         azk8spull "${chaos_mesh_image}" || true
@@ -626,7 +632,7 @@ install_chaos_mesh() {
     fi
 
     gen_crd_manifests "${crd}" | kubectl apply -f - || exit 1
-    gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${version}" "${timezone}" | kubectl apply -f - || exit 1
+    gen_chaos_mesh_manifests "${runtime}" "${k3s}" "${version}" "${timezone}" "${docker_registry}" | kubectl apply -f - || exit 1
 }
 
 version_lt() {
@@ -814,7 +820,7 @@ gen_chaos_mesh_manifests() {
     local k3s=$2
     local version=$3
     local timezone=$4
-
+    local docker_registry=$5
     local socketPath="/var/run/docker.sock"
     local mountPath="/var/run/docker.sock"
     if [ "${runtime}" == "containerd" ]; then
@@ -834,6 +840,7 @@ gen_chaos_mesh_manifests() {
     K8S_SERVICE="chaos-mesh-controller-manager"
     K8S_NAMESPACE="chaos-testing"
     VERSION_TAG="${version}"
+    DOCKER_REGISTRY_PREFIX="${docker_registry}"
     tmpdir=$(mktemp -d)
 
     ensure openssl genrsa -out ${tmpdir}/ca.key 2048 > /dev/null 2>&1
@@ -1095,7 +1102,7 @@ spec:
       hostPID: true
       containers:
         - name: chaos-daemon
-          image: pingcap/chaos-daemon:${VERSION_TAG}
+          image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-daemon:${VERSION_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/chaos-daemon
@@ -1160,7 +1167,7 @@ spec:
       serviceAccount: chaos-controller-manager
       containers:
         - name: chaos-dashboard
-          image: pingcap/chaos-dashboard:${VERSION_TAG}
+          image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-dashboard:${VERSION_TAG}
           imagePullPolicy: IfNotPresent
           resources:
             limits: {}
@@ -1220,7 +1227,7 @@ spec:
       serviceAccount: chaos-controller-manager
       containers:
       - name: chaos-mesh
-        image: pingcap/chaos-mesh:${VERSION_TAG}
+        image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-mesh:${VERSION_TAG}
         imagePullPolicy: IfNotPresent
         resources:
             limits: {}


### PR DESCRIPTION
Signed-off-by: mike.cwwmy@gmail.com

### What problem does this PR solve?
When local development , i need to execute multiple steps install chaos mesh.
I think we can provide a  script that only install once.

### What is changed and how does it work?
I merge steps below into `local-up-operator.sh` script.
1. Build the image
2.Load image into Kubernetes nodes
3.Deploy Chaos Mesh

User only need to execute `local-up-operator.sh` script when reinstall chaos-mesh.

### Checklist


Tests

- [x] Manual test (add detailed scripts or steps below)

