### PR TITLE
bugfix: fix config path of check-link & fix broken links

### DIFF
--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -13,4 +13,4 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
-        config-file: 'checklink_config.json'
+        config-file: '.github/workflows/checklink_config.json'

--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -9,7 +9,5 @@
     {
       "pattern": ["^https://github.com"]
     }
-  ],
-  "retryOn429": true,
-  "aliveStatusCodes":[200, 206, 400, 0]
+  ]
 }

--- a/website/docs/use_cases/multi_data_centers.md
+++ b/website/docs/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](get_started/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../get_started/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash
@@ -70,7 +70,7 @@ basic-tikv-6                       1/1     Running   0          29m
 
 ### Design injection rules
 
-Chaos Mesh provides [`NetworkChaos`](chaos_experiments/network_chaos.md) to inject network latency,
+Chaos Mesh provides [`NetworkChaos`](../chaos_experiments/network_chaos.md) to inject network latency,
 so we can use it to simulate the latency between three data centers.
 
 At present, `NetworkChaos` has a limitation that each target pod only has one configuration of `netem` in effect.

--- a/website/docs/use_cases/multi_data_centers.md
+++ b/website/docs/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../get_started/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiDB cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../get_started/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash

--- a/website/versioned_docs/version-0.9.1/use_cases/multi_data_centers.md
+++ b/website/versioned_docs/version-0.9.1/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](installation/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash
@@ -70,7 +70,7 @@ basic-tikv-6                       1/1     Running   0          29m
 
 ### Design injection rules
 
-Chaos Mesh provides [`NetworkChaos`](user_guides/network_chaos.md) to inject network latency,
+Chaos Mesh provides [`NetworkChaos`](../user_guides/network_chaos.md) to inject network latency,
 so we can use it to simulate the latency between three data centers.
 
 At present, `NetworkChaos` has a limitation that each target pod only has one configuration of `netem` in effect.

--- a/website/versioned_docs/version-0.9.1/use_cases/multi_data_centers.md
+++ b/website/versioned_docs/version-0.9.1/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiDB cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash

--- a/website/versioned_docs/version-0.9.1/user_guides/sidecar_configmap.md
+++ b/website/versioned_docs/version-0.9.1/user_guides/sidecar_configmap.md
@@ -59,7 +59,7 @@ For fields defined in this config, we have some brief descriptions below:
 * **template**: the template config map name used to render the injection config. "chaosfs-sidecar" template is used for injecting fuse-server sidecar.
 * **arguments**: the arguments you should define to be used in the template.
 
-For more sample ConfigMap files, see [examples](https://github.com/chaos-mesh/chaos-mesh/tree/master/examples/chaosfs-configmap).
+For more sample ConfigMap files, see [examples](https://github.com/chaos-mesh/chaos-mesh/tree/release-0.9/examples/chaosfs-configmap).
 
 
 ## Usage

--- a/website/versioned_docs/version-0.9.1/user_guides/sidecar_template.md
+++ b/website/versioned_docs/version-0.9.1/user_guides/sidecar_template.md
@@ -4,7 +4,7 @@ title: Sidecar Template
 sidebar_label: Sidecar Template
 ---
 
-The following content is the common template ConfigMap defined for injecting IOChaos sidecar, you can also find this example [here](https://github.com/chaos-mesh/chaos-mesh/blob/master/manifests/chaosfs-sidecar.yaml):
+The following content is the common template ConfigMap defined for injecting IOChaos sidecar, you can also find this example [here](https://github.com/chaos-mesh/chaos-mesh/blob/release-0.9/manifests/chaosfs-sidecar.yaml):
 
 ## Template ConfigMap
 

--- a/website/versioned_docs/version-1.0.0/use_cases/multi_data_centers.md
+++ b/website/versioned_docs/version-1.0.0/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](installation/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash
@@ -70,7 +70,7 @@ basic-tikv-6                       1/1     Running   0          29m
 
 ### Design injection rules
 
-Chaos Mesh provides [`NetworkChaos`](user_guides/network_chaos.md) to inject network latency,
+Chaos Mesh provides [`NetworkChaos`](../user_guides/network_chaos.md) to inject network latency,
 so we can use it to simulate the latency between three data centers.
 
 At present, `NetworkChaos` has a limitation that each target pod only has one configuration of `netem` in effect.

--- a/website/versioned_docs/version-1.0.0/use_cases/multi_data_centers.md
+++ b/website/versioned_docs/version-1.0.0/use_cases/multi_data_centers.md
@@ -21,7 +21,7 @@ Suppose our application will be deployed in three data centers in a production e
 and these data centers are still under construction. Now we want to test the impact of
 such a deployment topology on the business in advance.
 
-Here we use TiDB cluster as an example. Suppose we already install the [TiBD cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
+Here we use TiDB cluster as an example. Suppose we already install the [TiDB cluster](https://docs.pingcap.com/tidb-in-kubernetes/stable/) and [Chaos Mesh](../installation/installation.md)
 in our Kubernetes environment. In this TiDB cluster, we have three TiDB pods, three PD pods and seven TiKV pods:
 
 ```bash


### PR DESCRIPTION
### What problem does this PR solve?
the complement of #1013 

### What is changed and how does it work?
Need to use absolute path of config file.. 
Since the feature `retryon429` is [still not released](https://github.com/tcort/markdown-link-check/issues/114#issuecomment-705516265), currently ignore all github links.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [x] No code

Passed the test in [personal repo](https://github.com/Yiyiyimu/CheckLinkTmp/runs/1240937823?check_suite_focus=true)

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
