### PR TITLE
fix: correct the broken links for get started doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The current implementation supports six types of CRD objects for fault injection
 
 ## Quick start
 
-- [Get Started on kind](https://chaos-mesh.org/docs/installation/get_started_on_kind)
-- [Get Started on minikube](https://chaos-mesh.org/docs/installation/get_started_on_minikube)
+- [Get Started on kind](https://chaos-mesh.org/docs/get_started/get_started_on_kind)
+- [Get Started on minikube](https://chaos-mesh.org/docs/get_started/get_started_on_minikube)
 
 ## Deploy and use
 


### PR DESCRIPTION
Signed-off-by: colstuwjx <colstuwjx@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
Fixed #1067 .

### What is changed and how does it work?
I've been checked the PR history, this issue was introduced by PR #1010 , and the docs has been reconstituted since PR #924 . I wonder the root cause should be #885 , since we're **NOT** showing the latest document in our website, our users may misunderstand the content.

As a result, I suggest we push for fixing #885, make it "I could see what has changed in website immediately". A good example should be [k/website](https://github.com/kubernetes/website), see its [netlify config](https://github.com/kubernetes/website/blob/master/netlify.toml), and it always show the latest content on [its website](https://kubernetes.io/), just "I could see what has changed in website immediately".

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
