### PR TITLE
(Manually cherry-pick) make chaos dashboard be compliable with namespace scoped mode (#1110) 

### DIFF
--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -48,6 +48,18 @@ spec:
             - name: TZ
               value: {{ .Values.timezone | default "UTC" }}
             {{- end }}
+            - name: TARGET_NAMESPACE
+              value: {{ .Values.controllerManager.targetNamespace }}
+            - name: CLUSTER_SCOPED
+              value: "{{ .Values.clusterScoped }}"
+            {{- if .Values.controllerManager.allowedNamespaces }}
+            - name: ALLOWED_NAMESPACES
+              value: {{ .Values.controllerManager.allowedNamespaces }}
+            {{- end }}
+            {{- if .Values.controllerManager.ignoredNamespaces }}
+            - name: IGNORED_NAMESPACES
+              value: {{ .Values.controllerManager.ignoredNamespaces }}
+            {{- end }}
           volumeMounts:
             - name: storage-volume
               mountPath: {{ .Values.dashboard.persistentVolume.mountPath }}

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -56,8 +56,10 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources:
-      - namespaces
       - nodes
+{{- if .Values.clusterScoped }}
+      - namespaces
+{{- end }}
     verbs: [ "get", "list", "watch" ]
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -945,8 +945,8 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources:
-      - namespaces
       - nodes
+      - namespaces
     verbs: [ "get", "list", "watch" ]
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
@@ -1192,6 +1192,10 @@ spec:
               value: "2333"
             - name: TZ
               value: ${timezone}
+            - name: TARGET_NAMESPACE
+              value: chaos-testing
+            - name: CLUSTER_SCOPED
+              value: "true"
           volumeMounts:
             - name: storage-volume
               mountPath: /data

--- a/pkg/apiserver/common/common.go
+++ b/pkg/apiserver/common/common.go
@@ -65,7 +65,8 @@ func Register(r *gin.RouterGroup, s *Service) {
 	endpoint := r.Group("/common")
 
 	endpoint.POST("/pods", s.listPods)
-	endpoint.GET("/namespaces", s.getNamespaces)
+	endpoint.GET("/namespaces", s.listNamespaces)
+	endpoint.GET("/chaos-available-namespaces", s.getChaosAvailableNamespaces)
 	endpoint.GET("/kinds", s.getKinds)
 	endpoint.GET("/labels", s.getLabels)
 	endpoint.GET("/annotations", s.getAnnotations)
@@ -108,23 +109,56 @@ func (s *Service) listPods(c *gin.Context) {
 }
 
 // @Summary Get all namespaces from Kubernetes cluster.
-// @Description Get all namespaces from Kubernetes cluster.
+// @Description Get all from Kubernetes cluster.
+// @Deprecated This API only works within cluster scoped mode. Please use /common/chaos-available-namespaces instead.
 // @Tags common
 // @Produce json
 // @Success 200 {array} string
 // @Router /common/namespaces [get]
 // @Failure 500 {object} utils.APIError
-func (s *Service) getNamespaces(c *gin.Context) {
+func (s *Service) listNamespaces(c *gin.Context) {
+
+	var namespaces sort.StringSlice
+
 	var nsList v1.NamespaceList
 	if err := s.kubeCli.List(context.Background(), &nsList); err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
 		return
 	}
-
-	namespaces := make(sort.StringSlice, 0, len(nsList.Items))
+	namespaces = make(sort.StringSlice, 0, len(nsList.Items))
 	for _, ns := range nsList.Items {
 		namespaces = append(namespaces, ns.Name)
+	}
+
+	sort.Sort(namespaces)
+	c.JSON(http.StatusOK, namespaces)
+}
+
+// @Summary Get all namespaces which could inject chaos(explosion scope) from Kubernetes cluster.
+// @Description Get all namespaces which could inject chaos(explosion scope) from Kubernetes cluster.
+// @Tags common
+// @Produce json
+// @Success 200 {array} string
+// @Router /common/chaos-available-namespaces [get]
+// @Failure 500 {object} utils.APIError
+func (s *Service) getChaosAvailableNamespaces(c *gin.Context) {
+
+	var namespaces sort.StringSlice
+
+	if s.conf.ClusterScoped {
+		var nsList v1.NamespaceList
+		if err := s.kubeCli.List(context.Background(), &nsList); err != nil {
+			c.Status(http.StatusInternalServerError)
+			_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
+			return
+		}
+		namespaces = make(sort.StringSlice, 0, len(nsList.Items))
+		for _, ns := range nsList.Items {
+			namespaces = append(namespaces, ns.Name)
+		}
+	} else {
+		namespaces = append(namespaces, s.conf.TargetNamespace)
 	}
 
 	sort.Sort(namespaces)

--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -765,6 +765,11 @@ func (s *Service) listExperiments(c *gin.Context) {
 	ns := c.Query("namespace")
 	status := c.Query("status")
 
+	if !s.conf.ClusterScoped {
+		log.Info("Overwrite namespace within namespace scoped mode", "origin", ns, "new", s.conf.TargetNamespace)
+		ns = s.conf.TargetNamespace
+	}
+
 	data := make([]*Experiment, 0)
 	for key, list := range v1alpha1.AllKinds() {
 		if kind != "" && key != kind {
@@ -956,10 +961,16 @@ func (s *Service) state(c *gin.Context) {
 	g, ctx := errgroup.WithContext(context.Background())
 	m := &sync.Mutex{}
 	kinds := v1alpha1.AllKinds()
+
+	var listOptions []client.ListOption
+	if !s.conf.ClusterScoped {
+		listOptions = append(listOptions, &client.ListOptions{Namespace: s.conf.TargetNamespace})
+	}
+
 	for index := range kinds {
 		list := kinds[index]
 		g.Go(func() error {
-			if err := s.kubeCli.List(ctx, list.ChaosList); err != nil {
+			if err := s.kubeCli.List(ctx, list.ChaosList, listOptions...); err != nil {
 				return err
 			}
 			m.Lock()

--- a/pkg/config/dashboard.go
+++ b/pkg/config/dashboard.go
@@ -29,6 +29,11 @@ type ChaosDashboardConfig struct {
 	EnableLeaderElection bool   `envconfig:"ENABLE_LEADER_ELECTION"`
 	Database             *DatabaseConfig
 	PersistTTL           *PersistTTLConfig
+	// ClusterScoped means control Chaos Object in cluster level(all namespace),
+	ClusterScoped bool `envconfig:"CLUSTER_SCOPED" default:"true"`
+	// TargetNamespace is the target namespace to injecting chaos.
+	// It only works with ClusterScoped is false;
+	TargetNamespace string `envconfig:"TARGET_NAMESPACE" default:""`
 }
 
 // PersistTTLConfig defines the configuration of ttl

--- a/ui/src/api/common.ts
+++ b/ui/src/api/common.ts
@@ -1,7 +1,7 @@
 import { ExperimentScope } from 'components/NewExperiment/types'
 import http from './http'
 
-export const namespaces = () => http.get('/common/namespaces')
+export const chaosAvailableNamespaces = () => http.get('/common/chaos-available-namespaces')
 
 export const labels = (podNamespaceList: string[]) =>
   http.get(`/common/labels?podNamespaceList=${podNamespaceList.join(',')}`)

--- a/ui/src/slices/experiments.ts
+++ b/ui/src/slices/experiments.ts
@@ -19,7 +19,7 @@ export const getStateofExperiments = createAsyncThunk(
   async () => (await api.experiments.state()).data
 )
 
-export const getNamespaces = createAsyncThunk('common/namespaces', async () => (await api.common.namespaces()).data)
+export const getNamespaces = createAsyncThunk('common/chaos-available-namespaces', async () => (await api.common.chaosAvailableNamespaces()).data)
 export const getLabels = createAsyncThunk(
   'common/labels',
   async (podNamespaceList: string[]) => (await api.common.labels(podNamespaceList)).data

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux'
 const middlewares = [...getDefaultMiddleware()]
 const ignoreActions = [
   'experiments/state/pending',
-  'common/namespaces/pending',
+  'common/chaos-available-namespaces/pending',
   'common/labels/pending',
   'common/annotations/pending',
   'common/pods/pending',


### PR DESCRIPTION
Since #1127  has conflict, manually cherry-pick  https://github.com/chaos-mesh/chaos-mesh/pull/1110 to release-1.0.

Here are duplicated code in `pkg/apiserver/experiment/experiment.go` like:

```golang
type Service struct {
	conf    *config.ChaosDashboardConfig
	kubeCli client.Client
	archive core.ExperimentStore
	event   core.EventStore
	conf    *config.ChaosDashboardConfig
}
```
`conf    *config.ChaosDashboardConfig` is duplicated.

Already cleanup manually.

