### PR TITLE
pkg/fusedev: fix the call order.

### DIFF
--- a/pkg/fusedev/fusedev_linux.go
+++ b/pkg/fusedev/fusedev_linux.go
@@ -36,9 +36,6 @@ func GrantAccess() error {
 	cgroupScanner := bufio.NewScanner(cgroupFile)
 	var deviceCgroupPath string
 	for cgroupScanner.Scan() {
-		if err := cgroupScanner.Err(); err != nil {
-			return err
-		}
 		var (
 			text  = cgroupScanner.Text()
 			parts = strings.SplitN(text, ":", 3)
@@ -50,6 +47,10 @@ func GrantAccess() error {
 		if parts[1] == "devices" {
 			deviceCgroupPath = parts[2]
 		}
+	}
+
+	if err := cgroupScanner.Err(); err != nil {
+		return err
 	}
 
 	if len(deviceCgroupPath) == 0 {


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Existing `scanner.Err()` won't be called and this will cause errors to be missed.

> Scan advances the Scanner to the next token, which will then be available through the Bytes or Text method. It returns false when the scan stops, either by reaching the end of the input or an error. **After Scan returns false, the Err method will return any error that occurred during scanning, except that if it was io.EOF, Err will return nil**. Scan panics if the split function returns too many empty tokens without advancing the input. This is a common error mode for scanners.

### What is changed and how does it work?

Move `scanner.Err()` after for loop block.

Before
```go
for scanner.Scan() {
     ...
     scanner.Err()
     ...
}
```

After
```go
for scanner.Scan() {
     ...
}
scanner.Err()
```

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

> The standard library has instructions that adding anomaly path testing should not be necessary

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
