### PR TITLE
[update] remove "total" field in experiments/state

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -44,7 +44,6 @@ var log = ctrl.Log.WithName("experiment api")
 
 // ChaosState defines the number of chaos experiments of each phase
 type ChaosState struct {
-	Total    int `json:"Total"`
 	Running  int `json:"Running"`
 	Waiting  int `json:"Waiting"`
 	Paused   int `json:"Paused"`
@@ -827,7 +826,6 @@ func (s *Service) state(c *gin.Context) {
 				case string(v1alpha1.ExperimentPhaseFinished):
 					data.Finished++
 				}
-				data.Total++
 			}
 			m.Unlock()
 			return nil


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

### What problem does this PR solve?
Now the "total" field is useless (and the front end can get "total" from other fields).
However, the existence of the "total" field will affect the front-end type detection, so remove it.

### What is changed and how does it work?
remove "total" field in experiments/state

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
