### PR TITLE
Adding PodSecurityPolicy option to helm chart

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -29,6 +29,9 @@ spec:
   {{- if .Values.chaosDaemon.hostNetwork }}
       hostNetwork: true
   {{- end }}
+  {{- if .Values.chaosDaemon.serviceAccount }}
+      serviceAccount: {{ .Values.chaosDaemon.serviceAccount }}
+  {{- end }}
       hostIPC: true
       hostPID: true
       containers:

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.chaosDaemon.serviceAccount }}
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.chaosDaemon.serviceAccount }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.chaosDaemon.serviceAccount }}
+  labels:
+    app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: chaos-daemon
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+{{- end}}
+{{- if .Values.chaosDaemon.podSecurityPolicy }}
+---
+# roles
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}:chaos-daemon-target-namespace
+  namespace: chaos-testing
+  labels:
+    app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: chaos-daemon
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.chaosDaemon.serviceAccount }}
+    # apiGroup: rbac.authorization.k8s.io
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}:chaos-daemon-psp
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}:chaos-daemon-psp
+  labels:
+    app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: chaos-daemon
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+rules:
+- apiGroups:
+  - policy
+  - extensions
+  resourceNames:
+  - {{ .Release.Name }}-chaos-daemon
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# Restricted DEFAULT policy
+# ( Default policy for all new services )
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-chaos-daemon
+  labels:
+    app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: chaos-daemon
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - '*'
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  hostIPC: true
+  hostPID: true
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end }}
+

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -75,6 +75,11 @@ chaosDaemon:
 
   podAnnotations: {}
 
+  serviceAccount: chaos-daemon
+
+  # enable a podSecurityPolicy(psp)
+  podSecurityPolicy: false
+
   # runtime specifies which container runtime to use. Currently
   # we only supports docker and containerd.
   runtime: docker


### PR DESCRIPTION
### What problem does this PR solve?
If someone has pod security policies enabled on their kubernetes cluster, chaos-mesh will not start up.
Adding a service account and psp for chaos-mesh resolves this issue
### What is changed and how does it work?

### Checklist
Tests

- [ ] Unit test
- [ ] E2E test
- [ X] Manual test (add detailed scripts or steps below)
- [ ] No code

I tested with and without the service account and psp enabled


Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
no

```release-note
NONE
```

