### PR TITLE
fix: fetch pods after namespaces changed

### DIFF
--- a/ui/src/components/NewExperimentNext/form/Scope.tsx
+++ b/ui/src/components/NewExperimentNext/form/Scope.tsx
@@ -73,6 +73,12 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope', pods
 
   useEffect(() => {
     if (currentNamespaces.length) {
+      dispatch(
+        getPodsByNamespaces({
+          namespace_selectors: currentNamespaces,
+        })
+      )
+
       dispatch(getLabels(currentNamespaces))
       dispatch(getAnnotations(currentNamespaces))
     }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

As the title. Now can fetch pods after namespaces selector changed.

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
