### PR TITLE
Fix some bugs about io.

### DIFF
--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -213,9 +213,6 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 		s       = bufio.NewScanner(r)
 	)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
 		var (
 			text  = s.Text()
 			parts = strings.SplitN(text, ":", 3)
@@ -229,6 +226,11 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 			}
 		}
 	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
 	return cgroups, nil
 }
 
@@ -242,15 +244,15 @@ func getCgroupDestination(pid int, subsystem string) (string, error) {
 	defer f.Close()
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return "", err
-		}
 		fields := strings.Fields(s.Text())
 		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
 			if opt == subsystem {
 				return fields[3], nil
 			}
 		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
 	}
 	return "", fmt.Errorf("never found desct for %s", subsystem)
 }

--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -224,6 +224,7 @@ func ReadCommName(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
@@ -269,6 +270,7 @@ func GetChildProcesses(ppid uint32) ([]uint32, error) {
 					log.Error(err, "read status file error", "path", statusPath)
 					return
 				}
+				defer reader.Close()
 
 				var (
 					pid    uint32

--- a/pkg/fusedev/fusedev_linux.go
+++ b/pkg/fusedev/fusedev_linux.go
@@ -31,6 +31,7 @@ func GrantAccess() error {
 	if err != nil {
 		return err
 	}
+	defer cgroupFile.Close()
 
 	// TODO: encapsulate these logic with chaos-daemon StressChaos part
 	cgroupScanner := bufio.NewScanner(cgroupFile)
@@ -62,6 +63,8 @@ func GrantAccess() error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
+
 	// 10, 229 according to https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
 	content := "c 10:229 rwm"
 	_, err = f.WriteString(content)

--- a/test/pkg/timer/timer.go
+++ b/test/pkg/timer/timer.go
@@ -76,6 +76,11 @@ func StartTimer() (*Timer, error) {
 				Time: &t,
 			}
 		}
+		if err := stdoutScanner.Err(); err != nil {
+			output <- TimeResult{
+				Error: err,
+			}
+		}
 	}()
 
 	stdin, err := process.StdinPipe()


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

There are two types of bugs, both about io

* Close `os.File` after use.
* `bufio.Scanner` Error Location

### What is changed and how does it work?

* call `f.Close()`
* move the `Scanner.Err()` after for loop block.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
