### PR TITLE
Use a modified image to run e2e test

### DIFF
--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: gcr.io/k8s-testimages/kubekins-e2e:v20200311-1e25827-master
+    image: hub.pingcap.net/yangkeao/chaos-mesh-e2e
     command:
     - runner.sh
     # Clean containers on TERM signal in root process to avoid cgroup leaking.


### PR DESCRIPTION
Modify the e2e test base image to bypass the docker pull limit.

However, we should enable cache for e2e test 😿 , which is the correct way to solve it.

This image was built with:

```
FROM gcr.io/k8s-testimages/kubekins-e2e:v20200311-1e25827-master

RUN echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --registry-mirror=\"https://registry-mirror.pingcap.net\"\"" | \
    tee --append /etc/default/docker
```