### PR TITLE
Option to run networkchaos tests on hostNetwork pods

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -66,8 +66,7 @@ var (
 )
 
 var (
-	printVersion            bool
-	allowHostNetworkTesting bool
+	printVersion bool
 )
 
 func init() {
@@ -79,7 +78,6 @@ func init() {
 
 func parseFlags() {
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
-	flag.BoolVar(&allowHostNetworkTesting, "allowhostnetworktesting", false, "allows hostNetwork pods to be affected [DANGEROUS]")
 	flag.Parse()
 }
 
@@ -139,7 +137,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Reader:                  mgr.GetAPIReader(),
 		Log:                     ctrl.Log.WithName("handler").WithName("PodNetworkChaos"),
-		AllowHostNetworkTesting: allowHostNetworkTesting,
+		AllowHostNetworkTesting: common.ControllerCfg.AllowHostNetworkTesting,
 	})
 	if err = (&chaosmeshv1alpha1.PodNetworkChaos{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "PodNetworkChaos")

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -66,7 +66,8 @@ var (
 )
 
 var (
-	printVersion bool
+	printVersion            bool
+	allowHostNetworkTesting bool
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 
 func parseFlags() {
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
+	flag.BoolVar(&allowHostNetworkTesting, "allowhostnetworktesting", false, "allows hostNetwork pods to be affected [DANGEROUS]")
 	flag.Parse()
 }
 
@@ -134,9 +136,10 @@ func main() {
 	// We only setup webhook for podnetworkchaos, and the logic of applying chaos are in the validation
 	// webhook, because we need to get the running result synchronously in network chaos reconciler
 	chaosmeshv1alpha1.RegisterRawPodNetworkHandler(&podnetworkchaos.Handler{
-		Client: mgr.GetClient(),
-		Reader: mgr.GetAPIReader(),
-		Log:    ctrl.Log.WithName("handler").WithName("PodNetworkChaos"),
+		Client:                  mgr.GetClient(),
+		Reader:                  mgr.GetAPIReader(),
+		Log:                     ctrl.Log.WithName("handler").WithName("PodNetworkChaos"),
+		AllowHostNetworkTesting: allowHostNetworkTesting,
 	})
 	if err = (&chaosmeshv1alpha1.PodNetworkChaos{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "PodNetworkChaos")

--- a/controllers/podnetworkchaos/types.go
+++ b/controllers/podnetworkchaos/types.go
@@ -40,7 +40,8 @@ const (
 type Handler struct {
 	client.Client
 	client.Reader
-	Log logr.Logger
+	Log                     logr.Logger
+	AllowHostNetworkTesting bool
 }
 
 // Apply flushes network configuration on pod
@@ -58,9 +59,11 @@ func (h *Handler) Apply(ctx context.Context, chaos *v1alpha1.PodNetworkChaos) er
 		return err
 	}
 
-	if pod.Spec.HostNetwork {
-		err := errors.Errorf("it's dangerous to inject network chaos on a pod(%s/%s) with `hostNetwork`", pod.Namespace, pod.Name)
-		return err
+	if !h.AllowHostNetworkTesting {
+		if pod.Spec.HostNetwork {
+			err := errors.Errorf("it's dangerous to inject network chaos on a pod(%s/%s) with `hostNetwork`", pod.Namespace, pod.Name)
+			return err
+		}
 	}
 
 	err = h.SetIPSets(ctx, pod, chaos)

--- a/controllers/podnetworkchaos/types_test.go
+++ b/controllers/podnetworkchaos/types_test.go
@@ -14,13 +14,98 @@
 package podnetworkchaos
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
+
+func setHostNetwork(objs []runtime.Object) {
+	for _, obj := range objs {
+		if pod, ok := obj.(*v1.Pod); ok {
+			pod.Spec.HostNetwork = true
+		}
+	}
+}
+
+func TestHostNetworkOption(t *testing.T) {
+	defer mock.With("MockChaosDaemonClient", &MockChaosDaemonClient{})()
+
+	testCases := []struct {
+		name                     string
+		enableHostNetworkTesting bool
+		errorEvaluation          func(t *testing.T, err error)
+	}{
+		{
+			name:                     "host networking testing disabled (default)",
+			enableHostNetworkTesting: false,
+			errorEvaluation: func(t *testing.T, err error) {
+				if err == nil {
+					t.Errorf("expected failure on hostNetwork pods")
+				}
+				if err != nil && !strings.Contains(err.Error(), "it's dangerous to inject network chaos on a pod") {
+					t.Errorf("expected failure on hostNetwork pods, but got %v", err)
+				}
+			},
+		},
+		{
+			name:                     "host networking testing enabled",
+			enableHostNetworkTesting: true,
+			errorEvaluation: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("failed to apply hostNetwork chaos got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			objs, _ := GenerateNPods("podchaos-name", 1, v1.PodRunning, "test-namespace", nil, nil, v1.ContainerStatus{
+				ContainerID: "fake-container-id",
+				Name:        "container-name",
+			})
+
+			setHostNetwork(objs)
+
+			chaos := &v1alpha1.PodNetworkChaos{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodChaos",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					Name:      "podchaos-name0",
+				},
+				Spec: v1alpha1.PodNetworkChaosSpec{},
+			}
+
+			var r client.Reader
+			h := &Handler{
+				Client:                  fake.NewFakeClientWithScheme(scheme.Scheme, objs...),
+				Reader:                  r,
+				Log:                     zap.Logger(true),
+				AllowHostNetworkTesting: testCase.enableHostNetworkTesting,
+			}
+
+			testCase.errorEvaluation(t, h.Apply(context.TODO(), chaos))
+		})
+
+	}
+}
 
 func TestMergenetem(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -21,6 +21,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `timezone` | The timezone where controller-manager, chaos-daemon and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
 | `enableProfiling` | A flag to enable pprof in controller-manager and chaos-daemon  | `true` |
 | `controllerManager.hostNetwork` | running chaos-controller-manager on host network | `false` |
+| `controllerManager.allowHostNetworkTesting`   | Allow testing on `hostNetwork` pods | `false` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |
 | `controllerManager.replicaCount` | Replicas for chaos-controller-manager | `1` |
 | `controllerManager.image` | docker image for chaos-controller-manager  | `pingcap/chaos-mesh:latest` |

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -42,9 +42,6 @@ spec:
 {{ toYaml .Values.controllerManager.resources | indent 12 }}
         command:
           - /usr/local/bin/chaos-controller-manager
-        {{- if .Values.controllerManager.allowHostNetworkTesting }}
-          - -allowhostnetworktesting
-        {{- end }}
         env:
           - name: NAMESPACE
             valueFrom:
@@ -54,6 +51,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ALLOW_HOST_NETWORK_TESTING
+            value: "{{ .Values.controllerManager.allowHostNetworkTesting }}"
           - name: TARGET_NAMESPACE
             value: {{ .Values.controllerManager.targetNamespace }}
           - name: CLUSTER_SCOPED

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{ toYaml .Values.controllerManager.resources | indent 12 }}
         command:
           - /usr/local/bin/chaos-controller-manager
+        {{- if .Values.controllerManager.allowHostNetworkTesting }}
+          - -allowhostnetworktesting
+        {{- end }}
         env:
           - name: NAMESPACE
             valueFrom:

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -65,6 +65,9 @@ controllerManager:
 
   podAnnotations: {}
 
+  # This is Dangerous. Run only on temporary clusters.
+  allowHostNetworkTesting: false
+
 chaosDaemon:
   image: pingcap/chaos-daemon:latest
   imagePullPolicy: IfNotPresent

--- a/install.sh
+++ b/install.sh
@@ -1291,6 +1291,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ALLOW_HOST_NETWORK_TESTING
+            value: "false"
           - name: TARGET_NAMESPACE
             value: chaos-testing
           - name: CLUSTER_SCOPED

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -55,6 +55,9 @@ type ChaosControllerConfig struct {
 
 	// Namespace is the namespace which the controller manager run in
 	Namespace string `envconfig:"NAMESPACE" default:""`
+
+	// AllowHostNetworkTesting removes the restriction on chaos testing pods with `hostNetwork` set to true
+	AllowHostNetworkTesting bool `envconfig:"ALLOW_HOST_NETWORK_TESTING" default:"false"`
 }
 
 // EnvironChaosController returns the settings from the environment.


### PR DESCRIPTION
Signed-off-by: svanellewee <stephan.van.ellewee@gmail.com>

### What problem does this PR solve?

This brings back the ability to optionally run chaos testing on pods with `hostNetwork` set to `true`. I realize this is a dangerous option, but our tests depend on this functionality 

We migrated our chaos tests to `v1.0.0` that allowed this, but it seems after v1.0.1 this is no longer allowed.  This is not intended for use on production clusters.

### What is changed and how does it work?
This adds an environment variable `ALLOW_HOST_NETWORK_TESTING` to the chaos controller manager. 

When this is enabled (set to "true") it will allow testing of networkchaos on weave-pods or whatever has `hostNetwork: true`

### Checklist

Tests
No unit tests have been created yet, but I will add them if you are happy with me re-adding this behaviour.

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:
- Install a new kind cluster as per the CONTRIBUTING.md 
- install the chaos-mesh infrastructure `./hack/local-up-chaos-mesh.sh`
- install a NetworkChaos test as follows:
```yaml
apiVersion: chaos-mesh.org/v1alpha1
kind: NetworkChaos
metadata:
  name: network-bandwidth
  namespace: "kube-system"
spec:
  action: bandwidth
  mode: all
  namespaces:
  - "kube-system"
  selector:
    labelSelectors:
      "app": "kindnet"
  bandwidth:
    rate: 10mbps  
    limit: 50000  
    buffer: 50000
  duration: "19s"
  scheduler:
    cron: "@every 20s"
```
- inspect the test. It should complain that running this test is dangerous
- modify the chaos-controller and add the `ALLOW_HOST_NETWORK_TESTING` environment variable:

```yaml
      ....
      containers:
      - command:
        - /usr/local/bin/chaos-controller-manager
      ....
        env:
        - name: ALLOW_HOST_NETWORK_TESTING
          value: "true"
      ...
```
- inspect the test again. Error message should be gone, test should proceed.
- I have also been able to confirm with tc on the node that this test is active:

```sh
root@kind-control-plane:/# tc qdisc  show dev eth0
qdisc tbf 1: root refcnt 2 rate 10485Kbit burst 49998b lat 0us  # ---> success
qdisc prio 2: parent 1: bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
qdisc sfq 4: parent 2:2 limit 127p quantum 1514b depth 127 divisor 1024 
qdisc sfq 5: parent 2:3 limit 127p quantum 1514b depth 127 divisor 1024 
qdisc sfq 3: parent 2:1 limit 127p quantum 1514b depth 127 divisor 1024 
root@kind-control-plane:/# 
```

Side effects

- [ ] Breaking backward compatibility

Related changes

- [x] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
This enables pods using host networking to be tested. Not for production use.
```
