### PR TITLE
fix: always parse attr when creating IOChaos

### DIFF
--- a/ui/src/components/NewExperiment/constants.ts
+++ b/ui/src/components/NewExperiment/constants.ts
@@ -54,7 +54,7 @@ export const defaultExperimentSchema: Experiment = {
     io_chaos: {
       action: '',
       delay: '',
-      errno: 0,
+      errno: 1,
       attr: [],
       methods: [],
       path: '',

--- a/ui/src/lib/formikhelpers.ts
+++ b/ui/src/lib/formikhelpers.ts
@@ -90,7 +90,7 @@ export function parseSubmit(e: Experiment) {
     }
   }
 
-  if (kind === 'IoChaos' && values.target.io_chaos.action === 'attrOverride') {
+  if (kind === 'IoChaos') {
     values.target.io_chaos.attr = helper1(values.target.io_chaos.attr as string[], (s: string) => parseInt(s, 10))
   }
 


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

In v1.0.x dashboard, because creating experiments use the entire experiment schema as a request body, it's necessary to parse the `attr` property even creating `io latency` or `io fault`.

### What is changed and how does it work?

Now can create `io latency` and `io fault` normally.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
