### PR TITLE
Use a modified image to run e2e test (#1205)

### DIFF
--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: gcr.io/k8s-testimages/kubekins-e2e:v20200311-1e25827-master
+    image: hub.pingcap.net/yangkeao/chaos-mesh-e2e
     command:
     - runner.sh
     # Clean containers on TERM signal in root process to avoid cgroup leaking.


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

e2e tests failed by "docker pull rate limit" for release-1.0, so cherry-pick this PR to release-1.0