### PR TITLE
chore: remove duplicate 'GenerateNPods'

### DIFF
--- a/controllers/networkchaos/trafficcontrol/types_test.go
+++ b/controllers/networkchaos/trafficcontrol/types_test.go
@@ -29,20 +29,13 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	ctx "github.com/chaos-mesh/chaos-mesh/pkg/router/context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestReconciler_applyNetem(t *testing.T) {
 	g := NewWithT(t)
 
-	podObjects, pods := test.GenerateNPods(
-		"p",
-		1,
-		v1.PodRunning,
-		metav1.NamespaceDefault,
-		nil,
-		map[string]string{"l1": "l1"},
-		v1.ContainerStatus{ContainerID: "fake-container-id"},
-	)
+	podObjects, pods := utils.GenerateNPods("p", 1, utils.PodArg{})
 
 	v1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
 

--- a/controllers/podchaos/containerkill/containerkill_suite_test.go
+++ b/controllers/podchaos/containerkill/containerkill_suite_test.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	ctx "github.com/chaos-mesh/chaos-mesh/pkg/router/context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestContainerKill(t *testing.T) {
@@ -59,10 +60,10 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("PodChaos", func() {
 	Context("ContainerKill", func() {
-		objs, _ := GenerateNPods("p", 1, v1.PodRunning, metav1.NamespaceDefault, nil, nil, v1.ContainerStatus{
+		objs, _ := utils.GenerateNPods("p", 1, utils.PodArg{ContainerStatus: v1.ContainerStatus{
 			ContainerID: "fake-container-id",
 			Name:        "container-name",
-		})
+		}})
 
 		podChaos := v1alpha1.PodChaos{
 			TypeMeta: metav1.TypeMeta{

--- a/controllers/podchaos/podfailure/podfailure_suite_test.go
+++ b/controllers/podchaos/podfailure/podfailure_suite_test.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	ctx "github.com/chaos-mesh/chaos-mesh/pkg/router/context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestPodFailure(t *testing.T) {
@@ -59,10 +60,10 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("PodChaos", func() {
 	Context("PodFailure", func() {
-		objs, pods := GenerateNPods("p", 1, v1.PodRunning, metav1.NamespaceDefault, nil, nil, v1.ContainerStatus{
+		objs, pods := utils.GenerateNPods("p", 1, utils.PodArg{ContainerStatus: v1.ContainerStatus{
 			ContainerID: "fake-container-id",
 			Name:        "container-name",
-		})
+		}})
 
 		podChaos := v1alpha1.PodChaos{
 			TypeMeta: metav1.TypeMeta{

--- a/controllers/podchaos/podkill/podkill_suite_test.go
+++ b/controllers/podchaos/podkill/podkill_suite_test.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	ctx "github.com/chaos-mesh/chaos-mesh/pkg/router/context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestPodKill(t *testing.T) {
@@ -59,10 +60,10 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("PodChaos", func() {
 	Context("PodKill", func() {
-		objs, pods := GenerateNPods("p", 1, v1.PodRunning, metav1.NamespaceDefault, nil, nil, v1.ContainerStatus{
+		objs, pods := utils.GenerateNPods("p", 1, utils.PodArg{ContainerStatus: v1.ContainerStatus{
 			ContainerID: "fake-container-id",
 			Name:        "container-name",
-		})
+		}})
 
 		podChaos := v1alpha1.PodChaos{
 			TypeMeta: metav1.TypeMeta{

--- a/controllers/podnetworkchaos/types_test.go
+++ b/controllers/podnetworkchaos/types_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func setHostNetwork(objs []runtime.Object) {
@@ -74,10 +75,7 @@ func TestHostNetworkOption(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			objs, _ := GenerateNPods("podchaos-name", 1, v1.PodRunning, "test-namespace", nil, nil, v1.ContainerStatus{
-				ContainerID: "fake-container-id",
-				Name:        "container-name",
-			})
+			objs, _ := utils.GenerateNPods("p", 1, utils.PodArg{})
 
 			setHostNetwork(objs)
 
@@ -87,8 +85,8 @@ func TestHostNetworkOption(t *testing.T) {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-namespace",
-					Name:      "podchaos-name0",
+					Namespace: metav1.NamespaceDefault,
+					Name:      "p0",
 				},
 				Spec: v1alpha1.PodNetworkChaosSpec{},
 			}

--- a/controllers/test/types.go
+++ b/controllers/test/types.go
@@ -19,9 +19,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	chaosdaemon "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
@@ -92,55 +89,4 @@ func (c *MockChaosDaemonClient) SetTcs(ctx context.Context, in *chaosdaemon.TcsR
 
 func (c *MockChaosDaemonClient) Close() error {
 	return mockError("CloseChaosDaemonClient")
-}
-
-func newPod(
-	name string,
-	status v1.PodPhase,
-	namespace string,
-	ans map[string]string,
-	ls map[string]string,
-	containerStatus v1.ContainerStatus,
-) v1.Pod {
-	return v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      ls,
-			Annotations: ans,
-		},
-		Status: v1.PodStatus{
-			Phase:             status,
-			ContainerStatuses: []v1.ContainerStatus{containerStatus},
-		},
-		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{{Name: "fake-name", Image: "fake-image"}},
-			Containers:     []v1.Container{{Name: "fake-name", Image: "fake-image"}},
-		},
-	}
-}
-
-// GenerateNPods is only for unit testing
-func GenerateNPods(
-	namePrefix string,
-	n int,
-	status v1.PodPhase,
-	ns string,
-	ans map[string]string,
-	ls map[string]string,
-	containerStatus v1.ContainerStatus,
-) ([]runtime.Object, []v1.Pod) {
-	var podObjects []runtime.Object
-	var pods []v1.Pod
-	for i := 0; i < n; i++ {
-		pod := newPod(fmt.Sprintf("%s%d", namePrefix, i), status, ns, ans, ls, containerStatus)
-		podObjects = append(podObjects, &pod)
-		pods = append(pods, pod)
-	}
-
-	return podObjects, pods
 }

--- a/controllers/timechaos/timechaos_suite_test.go
+++ b/controllers/timechaos/timechaos_suite_test.go
@@ -36,6 +36,7 @@ import (
 	. "github.com/chaos-mesh/chaos-mesh/controllers/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	ctx "github.com/chaos-mesh/chaos-mesh/pkg/router/context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/utils"
 )
 
 func TestTimechaos(t *testing.T) {
@@ -59,15 +60,7 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("TimeChaos", func() {
 	Context("TimeChaos", func() {
-		podObjects, pods := GenerateNPods(
-			"p",
-			1,
-			v1.PodRunning,
-			metav1.NamespaceDefault,
-			nil,
-			map[string]string{"l1": "l1"},
-			v1.ContainerStatus{ContainerID: "fake-container-id"},
-		)
+		podObjects, pods := utils.GenerateNPods("p", 1, utils.PodArg{})
 
 		duration := "invalid_duration"
 

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Chaos Mesh Authors.
+// Copyright 2020 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -25,8 +25,8 @@ import (
 // For the others, the default values are empty.
 type PodArg struct {
 	Name            string
-	Status          v1.PodPhase `default:"corev1.PodRunning"`
-	Namespace       string      `default:"metav1.NamespaceDefault"`
+	Status          v1.PodPhase
+	Namespace       string
 	Ans             map[string]string
 	Labels          map[string]string
 	ContainerStatus v1.ContainerStatus

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// PodArg by DEFAULT use `Status=corev1.PodRunning` and `Namespace=metav1.NamespaceDefault`, when they are not specified
 type PodArg struct {
 	Name            string
 	Status          v1.PodPhase

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -24,8 +24,8 @@ import (
 // PodArg by DEFAULT use `Status=corev1.PodRunning` and `Namespace=metav1.NamespaceDefault`, when they are not specified
 type PodArg struct {
 	Name            string
-	Status          v1.PodPhase
-	Namespace       string
+	Status          v1.PodPhase `default: corev1.PodRunning`
+	Namespace       string      `default: metav1.NamespaceDefault`
 	Ans             map[string]string
 	Labels          map[string]string
 	ContainerStatus v1.ContainerStatus

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -25,8 +25,8 @@ import (
 // For the others, the default values are empty.
 type PodArg struct {
 	Name            string
-	Status          v1.PodPhase `default: corev1.PodRunning`
-	Namespace       string      `default: metav1.NamespaceDefault`
+	Status          v1.PodPhase `default:"corev1.PodRunning"`
+	Namespace       string      `default:"metav1.NamespaceDefault"`
 	Ans             map[string]string
 	Labels          map[string]string
 	ContainerStatus v1.ContainerStatus

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type PodArg struct {
+	Name            string
+	Status          v1.PodPhase
+	Namespace       string
+	Ans             map[string]string
+	Labels          map[string]string
+	ContainerStatus v1.ContainerStatus
+	Nodename        string
+}
+
+func newPod(p PodArg) v1.Pod {
+	if p.Status == "" {
+		p.Status = v1.PodRunning
+	}
+	if p.Namespace == "" {
+		p.Namespace = metav1.NamespaceDefault
+	}
+	return v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        p.Name,
+			Namespace:   p.Namespace,
+			Labels:      p.Labels,
+			Annotations: p.Ans,
+		},
+		Spec: v1.PodSpec{
+			NodeName: p.Nodename,
+		},
+		Status: v1.PodStatus{
+			Phase:             p.Status,
+			ContainerStatuses: []v1.ContainerStatus{p.ContainerStatus},
+		},
+	}
+}
+
+func GenerateNPods(
+	namePrefix string,
+	n int,
+	podArg PodArg,
+) ([]runtime.Object, []v1.Pod) {
+	var podObjects []runtime.Object
+	var pods []v1.Pod
+	for i := 0; i < n; i++ {
+		podArg.Name = fmt.Sprintf("%s%d", namePrefix, i)
+		pod := newPod(podArg)
+		podObjects = append(podObjects, &pod)
+		pods = append(pods, pod)
+	}
+
+	return podObjects, pods
+}
+
+func newNode(
+	name string,
+	label map[string]string,
+) v1.Node {
+	return v1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: label,
+		},
+	}
+}
+
+func GenerateNNodes(
+	namePrefix string,
+	n int,
+	label map[string]string,
+) ([]runtime.Object, []v1.Node) {
+	var nodeObjects []runtime.Object
+	var nodes []v1.Node
+
+	for i := 0; i < n; i++ {
+		node := newNode(fmt.Sprintf("%s%d", namePrefix, i), label)
+		nodeObjects = append(nodeObjects, &node)
+		nodes = append(nodes, node)
+	}
+	return nodeObjects, nodes
+}

--- a/pkg/utils/generate.go
+++ b/pkg/utils/generate.go
@@ -21,7 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// PodArg by DEFAULT use `Status=corev1.PodRunning` and `Namespace=metav1.NamespaceDefault`, when they are not specified
+// PodArg by default use `Status=corev1.PodRunning` and `Namespace=metav1.NamespaceDefault`.
+// For the others, the default values are empty.
 type PodArg struct {
 	Name            string
 	Status          v1.PodPhase `default: corev1.PodRunning`

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -15,7 +15,6 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -26,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -35,11 +33,11 @@ import (
 func TestSelectPods(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	objects, pods := generateNPods("p", 5, v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"l1": "l1"}, "az1-node1")
-	objects2, pods2 := generateNPods("s", 2, v1.PodRunning, "test-s", nil, map[string]string{"l2": "l2"}, "az2-node1")
+	objects, pods := GenerateNPods("p", 5, PodArg{Labels: map[string]string{"l1": "l1"}, Nodename: "az1-node1"})
+	objects2, pods2 := GenerateNPods("s", 2, PodArg{Namespace: "test-s", Labels: map[string]string{"l2": "l2"}, Nodename: "az2-node1"})
 
-	objects3, _ := generateNNodes("az1-node", 3, map[string]string{"disktype": "ssd", "zone": "az1"})
-	objects4, _ := generateNNodes("az2-node", 2, map[string]string{"disktype": "hdd", "zone": "az2"})
+	objects3, _ := GenerateNNodes("az1-node", 3, map[string]string{"disktype": "ssd", "zone": "az1"})
+	objects4, _ := GenerateNNodes("az2-node", 2, map[string]string{"disktype": "hdd", "zone": "az2"})
 
 	objects = append(objects, objects2...)
 	objects = append(objects, objects3...)
@@ -149,7 +147,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 	tcs := []TestCase{
 		{
 			name: "meet label",
-			pod:  newPod("t1", v1.PodPending, metav1.NamespaceDefault, nil, map[string]string{"app": "tikv", "ss": "t1"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Status: v1.PodPending, Labels: map[string]string{"app": "tikv", "ss": "t1"}}),
 			selector: v1alpha1.SelectorSpec{
 				LabelSelectors: map[string]string{"app": "tikv"},
 			},
@@ -157,14 +155,15 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "not meet label",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb", "ss": "t1"}, ""), selector: v1alpha1.SelectorSpec{
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb", "ss": "t1"}}),
+			selector: v1alpha1.SelectorSpec{
 				LabelSelectors: map[string]string{"app": "tikv"},
 			},
 			expectedValue: false,
 		},
 		{
 			name: "pod labels is empty",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, nil, ""),
+			pod:  newPod(PodArg{Name: "t1"}),
 			selector: v1alpha1.SelectorSpec{
 				LabelSelectors: map[string]string{"app": "tikv"},
 			},
@@ -172,13 +171,13 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name:          "selector is empty",
-			pod:           newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:           newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector:      v1alpha1.SelectorSpec{},
 			expectedValue: true,
 		},
 		{
 			name: "meet namespace",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, nil, ""),
+			pod:  newPod(PodArg{Name: "t1"}),
 			selector: v1alpha1.SelectorSpec{
 				Namespaces: []string{metav1.NamespaceDefault},
 			},
@@ -186,7 +185,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet namespace and meet labels",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tikv"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tikv"}}),
 			selector: v1alpha1.SelectorSpec{
 				Namespaces:     []string{metav1.NamespaceDefault},
 				LabelSelectors: map[string]string{"app": "tikv"},
@@ -195,7 +194,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet namespace and not meet labels",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Namespaces:     []string{metav1.NamespaceDefault},
 				LabelSelectors: map[string]string{"app": "tikv"},
@@ -204,7 +203,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet pods",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Pods: map[string][]string{
 					metav1.NamespaceDefault: {"t1"},
@@ -214,7 +213,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet annotation",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"an": "n1", "an2": "n2"}, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Ans: map[string]string{"an": "n1", "an2": "n2"}, Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Namespaces: []string{metav1.NamespaceDefault},
 				AnnotationSelectors: map[string]string{
@@ -225,7 +224,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "not meet annotation",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"an": "n1"}, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Ans: map[string]string{"an": "n1"}, Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Namespaces: []string{metav1.NamespaceDefault},
 				AnnotationSelectors: map[string]string{
@@ -236,7 +235,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet pod selector",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Pods: map[string][]string{
 					metav1.NamespaceDefault: {"t1", "t2"},
@@ -246,7 +245,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "not meet pod selector",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Pods: map[string][]string{
 					metav1.NamespaceDefault: {"t2"},
@@ -256,7 +255,7 @@ func TestCheckPodMeetSelector(t *testing.T) {
 		},
 		{
 			name: "meet pod selector and not meet labels",
-			pod:  newPod("t1", v1.PodRunning, metav1.NamespaceDefault, nil, map[string]string{"app": "tidb"}, ""),
+			pod:  newPod(PodArg{Name: "t1", Labels: map[string]string{"app": "tidb"}}),
 			selector: v1alpha1.SelectorSpec{
 				Pods: map[string][]string{
 					metav1.NamespaceDefault: {"t1", "t2"},
@@ -331,10 +330,10 @@ func TestFilterByPhaseSelector(t *testing.T) {
 	}
 
 	pods := []v1.Pod{
-		newPod("p1", v1.PodRunning, metav1.NamespaceDefault, nil, nil, ""),
-		newPod("p2", v1.PodRunning, metav1.NamespaceDefault, nil, nil, ""),
-		newPod("p3", v1.PodPending, metav1.NamespaceDefault, nil, nil, ""),
-		newPod("p4", v1.PodFailed, metav1.NamespaceDefault, nil, nil, ""),
+		newPod(PodArg{Name: "p1", Status: v1.PodRunning}),
+		newPod(PodArg{Name: "p2", Status: v1.PodRunning}),
+		newPod(PodArg{Name: "p3", Status: v1.PodPending}),
+		newPod(PodArg{Name: "p4", Status: v1.PodFailed}),
 	}
 
 	var tcs []TestCase
@@ -410,10 +409,10 @@ func TestFilterByAnnotations(t *testing.T) {
 	}
 
 	pods := []v1.Pod{
-		newPod("p1", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"p1": "p1"}, nil, ""),
-		newPod("p2", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"p2": "p2"}, nil, ""),
-		newPod("p3", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"t": "t"}, nil, ""),
-		newPod("p4", v1.PodRunning, metav1.NamespaceDefault, map[string]string{"t": "t"}, nil, ""),
+		newPod(PodArg{Name: "p1", Ans: map[string]string{"p1": "p1"}}),
+		newPod(PodArg{Name: "p2", Ans: map[string]string{"p2": "p2"}}),
+		newPod(PodArg{Name: "p3", Ans: map[string]string{"t": "t"}}),
+		newPod(PodArg{Name: "p4", Ans: map[string]string{"t": "t"}}),
 	}
 
 	var tcs []TestCase
@@ -459,10 +458,10 @@ func TestFilterNamespaceSelector(t *testing.T) {
 	}
 
 	pods := []v1.Pod{
-		newPod("p1", v1.PodRunning, "n1", nil, nil, ""),
-		newPod("p2", v1.PodRunning, "n2", nil, nil, ""),
-		newPod("p3", v1.PodRunning, "n2", nil, nil, ""),
-		newPod("p4", v1.PodRunning, "n4", nil, nil, ""),
+		newPod(PodArg{Name: "p1", Namespace: "n1"}),
+		newPod(PodArg{Name: "p2", Namespace: "n2"}),
+		newPod(PodArg{Name: "p3", Namespace: "n2"}),
+		newPod(PodArg{Name: "p4", Namespace: "n4"}),
 	}
 
 	var tcs []TestCase
@@ -530,10 +529,10 @@ func TestFilterPodByNode(t *testing.T) {
 	var tcs []TestCase
 
 	pods := []v1.Pod{
-		newPod("p1", v1.PodRunning, "n1", nil, nil, "node1"),
-		newPod("p2", v1.PodRunning, "n2", nil, nil, "node1"),
-		newPod("p3", v1.PodRunning, "n2", nil, nil, "node2"),
-		newPod("p4", v1.PodRunning, "n4", nil, nil, "node3"),
+		newPod(PodArg{Name: "p1", Namespace: "n1", Nodename: "node1"}),
+		newPod(PodArg{Name: "p2", Namespace: "n2", Nodename: "node1"}),
+		newPod(PodArg{Name: "p3", Namespace: "n2", Nodename: "node2"}),
+		newPod(PodArg{Name: "p4", Namespace: "n4", Nodename: "node3"}),
 	}
 
 	nodes := []v1.Node{
@@ -559,84 +558,4 @@ func TestFilterPodByNode(t *testing.T) {
 		g.Expect(filterPodByNode(tc.pods, tc.nodes)).To(Equal(tc.filteredPods), tc.name)
 	}
 
-}
-
-func newPod(
-	name string,
-	status v1.PodPhase,
-	namespace string,
-	ans map[string]string,
-	ls map[string]string,
-	nodename string,
-) v1.Pod {
-	return v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      ls,
-			Annotations: ans,
-		},
-		Spec: v1.PodSpec{
-			NodeName: nodename,
-		},
-		Status: v1.PodStatus{
-			Phase: status,
-		},
-	}
-}
-
-func generateNPods(
-	namePrefix string,
-	n int,
-	status v1.PodPhase,
-	ns string,
-	ans map[string]string,
-	ls map[string]string,
-	nodename string,
-) ([]runtime.Object, []v1.Pod) {
-	var podObjects []runtime.Object
-	var pods []v1.Pod
-	for i := 0; i < n; i++ {
-		pod := newPod(fmt.Sprintf("%s%d", namePrefix, i), status, ns, ans, ls, nodename)
-		podObjects = append(podObjects, &pod)
-		pods = append(pods, pod)
-	}
-
-	return podObjects, pods
-}
-
-func newNode(
-	name string,
-	label map[string]string,
-) v1.Node {
-	return v1.Node{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Node",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: label,
-		},
-	}
-}
-
-func generateNNodes(
-	namePrefix string,
-	n int,
-	label map[string]string,
-) ([]runtime.Object, []v1.Node) {
-	var nodeObjects []runtime.Object
-	var nodes []v1.Node
-
-	for i := 0; i < n; i++ {
-		node := newNode(fmt.Sprintf("%s%d", namePrefix, i), label)
-		nodeObjects = append(nodeObjects, &node)
-		nodes = append(nodes, node)
-	}
-	return nodeObjects, nodes
 }


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What problem does this PR solve?
There are two `GenerateNPods` exists with little difference, so merge them together
https://github.com/chaos-mesh/chaos-mesh/blob/26fe5523a8ff9fdc3d934c43e5a0cd8ec50aec48/pkg/utils/selector_test.go#L592
https://github.com/chaos-mesh/chaos-mesh/blob/6afb841b02df35a03bbca84419e70cb95eb8c8e1/controllers/test/types.go#L128

### What is changed and how does it work?

Add a struct so don't need to type in the arguments not used in certain test.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
