### PR TITLE
change the default hostNetwork value of the Chaos daemon to true

### DIFF
--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -74,7 +74,7 @@ chaosDaemon:
   grpcPort: 31767
   httpPort: 31766
   env: {}
-  hostNetwork: false
+  hostNetwork: true
 
   podAnnotations: {}
 


### PR DESCRIPTION
### What problem does this PR solve?
Change the default hostNetwork value of the Chaos daemon to true for NetworkChaos/TimeChaos experiment
<!-- Add an issue link with a summary if exists. -->

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
