### PR TITLE
fix: missing append pods in foreach

### DIFF
--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -157,13 +157,16 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 			if err := listFunc(ctx, &podList, &listOptions); err != nil {
 				return nil, err
 			}
+
+			pods = append(pods, podList.Items...)
 		}
 	} else {
 		if err := listFunc(ctx, &podList, &listOptions); err != nil {
 			return nil, err
 		}
+
+		pods = append(pods, podList.Items...)
 	}
-	pods = append(pods, podList.Items...)
 
 	var (
 		nodes           []v1.Node


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

As the title.

Missing the `append` operation in the foreach, add it to avoid only pods under last namespace was added.

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
