### PR TITLE
fix swagger api

### DIFF
--- a/pkg/apiserver/common/common.go
+++ b/pkg/apiserver/common/common.go
@@ -301,7 +301,7 @@ func (s *Service) getAnnotations(c *gin.Context) {
 // @Description Get the config of Dashboard.
 // @Tags common
 // @Produce json
-// @Success 200 {object} json
+// @Success 200 {object} config.ChaosDashboardConfig
 // @Router /common/config [get]
 // @Failure 500 {object} utils.APIError
 func (s *Service) getConfig(c *gin.Context) {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

fix: 

```
18:35:23  #21 14.04 2020/12/10 10:35:23 Generate swagger docs....
18:35:23  #21 14.04 2020/12/10 10:35:23 Generate general API Info, search dir:./
18:35:23  #21 14.15 2020/12/10 10:35:23 ParseComment error in file pkg/apiserver/common/common.go :can not find schema type: "common.json"
18:35:23  #21 14.16 make[1]: *** [Makefile:122: swagger_spec] Error 1
18:35:23  #21 14.16 make[1]: Leaving directory '/src'
18:35:23  #21 14.16 make: *** [Makefile:113: chaos-dashboard] Error 2
18:35:23  #21    completed: 2020-12-10 10:35:23.505675782 +0000 UTC
18:35:23  #21     duration: 14.407029189s
18:35:23  #21        error: "executor failed running [/bin/sh -c IMG_LDFLAGS=$LDFLAGS make binary]: exit code: 2"
18:35:23  
18:35:23  rpc error: code = Unknown desc = executor failed running [/bin/sh -c IMG_LDFLAGS=$LDFLAGS make binary]: exit code: 2
```
### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
