### PR TITLE
HELM : Support priorityClassName

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: chaos-testing

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaos-testing

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -23,6 +23,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `controllerManager.hostNetwork` | running chaos-controller-manager on host network | `false` |
 | `controllerManager.allowHostNetworkTesting`   | Allow testing on `hostNetwork` pods | `false` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |
+| `controllerManager.priorityClassName` | Custom priorityClassName for using pod priorities | `` |
 | `controllerManager.replicaCount` | Replicas for chaos-controller-manager | `1` |
 | `controllerManager.image` | docker image for chaos-controller-manager  | `pingcap/chaos-mesh:latest` |
 | `controllerManager.imagePullPolicy` | Image pull policy | `Always` |
@@ -42,6 +43,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `chaosDaemon.httpPort` | The port which http server listens on | `31766` |
 | `chaosDaemon.env` | chaosDaemon envs | `{}` |
 | `chaosDaemon.hostNetwork` | running chaosDaemon on host network | `false` |
+| `chaosDaemon.priorityClassName` | Custom priorityClassName for using pod priorities | `` |
 | `chaosDaemon.podAnnotations` | Pod annotations of chaos-daemon | `{}` |
 | `chaosDaemon.runtime` | Runtime specifies which container runtime to use. Currently we only supports docker and containerd. | `docker` |
 | `chaosDaemon.socketPath` | Specifies the container runtime socket | `/var/run/docker.sock` |
@@ -54,6 +56,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `bpfki.resources` | CPU/Memory resource requests/limits for chaos-kernel container | `requests: { cpu: "250m", memory: "512Mi" }, limits:{ cpu: "500m", memory: "1024Mi" }`  |
 | `dashboard.create` | Enable chaos-dashboard | `false` |
 | `dashboard.serviceAccount` | The serviceAccount for chaos-dashboard  | `chaos-dashboard` |
+| `dashboard.priorityClassName` | Custom priorityClassName for using pod priorities | `` |
 | `dashboard.image` | Docker image for chaos-dashboard | `pingcap/chaos-dashboard:latest` |
 | `dashboard.imagePullPolicy` | Image pull policy | `Always` |
 | `dashboard.nodeSelector` | Node labels for chaos-dashboard  pod assignment | `{}` |
@@ -85,6 +88,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `dashboard.ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                                             | `dashboard.local-tls` |
 | `prometheus.create` | Enable prometheus | `false` |
 | `prometheus.serviceAccount` | The serviceAccount for prometheus | `prometheus` |
+| `prometheus.priorityClassName` | Custom priorityClassName for using pod priorities | `` |
 | `prometheus.image` | Docker image for prometheus | `prom/prometheus:v2.15.2` |
 | `prometheus.imagePullPolicy` | Image pull policy | `IfNotPresent` |
 | `prometheus.nodeSelector` | Node labels for prometheus pod assignment | `{}` |

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -34,6 +34,7 @@ spec:
   {{- end }}
       hostIPC: true
       hostPID: true
+      priorityClassName: {{ .Values.chaosDaemon.priorityClassName}}
       containers:
         - name: chaos-daemon
           image: {{ .Values.chaosDaemon.image }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- if .Values.dashboard.serviceAccount }}
       serviceAccount: {{ .Values.dashboard.serviceAccount }}
       {{- end }}
+      priorityClassName: {{ .Values.dashboard.priorityClassName}}
       containers:
         - name: chaos-dashboard
           image: {{ .Values.dashboard.image }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -34,6 +34,7 @@ spec:
     {{- if .Values.controllerManager.serviceAccount }}
       serviceAccount: {{ .Values.controllerManager.serviceAccount }}
     {{- end }}
+      priorityClassName: {{ .Values.controllerManager.priorityClassName}}
       containers:
       - name: chaos-mesh
         image: {{ .Values.controllerManager.image }}

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -51,6 +51,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      priorityClassName: {{ .Values.dnsServer.priorityClassName}}
       containers:
       - name: chaos-dns-server
         image: {{ .Values.dnsServer.image }}

--- a/helm/chaos-mesh/templates/prometheus-deployment.yaml
+++ b/helm/chaos-mesh/templates/prometheus-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       {{- if .Values.prometheus.serviceAccount }}
       serviceAccount: {{ .Values.prometheus.serviceAccount }}
       {{- end }}
+      priorityClassName: {{ .Values.prometheus.priorityClassName}}
       initContainers:
         - name: data-permission-fix
           image: busybox

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -29,6 +29,8 @@ controllerManager:
 
   replicaCount: 1
 
+  priorityClassName: ""
+
   image: pingcap/chaos-mesh:latest
   imagePullPolicy: IfNotPresent
 
@@ -76,6 +78,8 @@ chaosDaemon:
   env: {}
   hostNetwork: false
 
+  priorityClassName: ""
+
   podAnnotations: {}
 
   serviceAccount: chaos-daemon
@@ -113,6 +117,8 @@ dashboard:
   create: false
 
   replicaCount: 1
+
+  priorityClassName: ""
 
   serviceAccount: chaos-controller-manager
 
@@ -232,6 +238,8 @@ dnsServer:
 
   imagePullPolicy: IfNotPresent
 
+  priorityClassName: ""
+
   nodeSelector: {}
 
   runtime: docker
@@ -265,6 +273,8 @@ prometheus:
 
   image: prom/prometheus:v2.18.1
   imagePullPolicy: IfNotPresent
+
+  priorityClassName: ""
 
   nodeSelector: {}
 

--- a/install.sh
+++ b/install.sh
@@ -1163,6 +1163,7 @@ spec:
       serviceAccount: chaos-daemon
       hostIPC: true
       hostPID: true
+      priorityClassName: 
       containers:
         - name: chaos-daemon
           image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-daemon:${VERSION_TAG}
@@ -1234,6 +1235,7 @@ spec:
         app.kubernetes.io/component: chaos-dashboard
     spec:
       serviceAccount: chaos-controller-manager
+      priorityClassName: 
       containers:
         - name: chaos-dashboard
           image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-dashboard:${VERSION_TAG}
@@ -1301,6 +1303,7 @@ spec:
     spec:
       hostNetwork: ${host_network}
       serviceAccount: chaos-controller-manager
+      priorityClassName: 
       containers:
       - name: chaos-mesh
         image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-mesh:${VERSION_TAG}


### PR DESCRIPTION
### What problem does this PR solve?
Currently you cannot pass priorityClassName to set a pod priority on deployed pods/daemonsets. This allows you to specify a custom priorityClassName if desired.

### What is changed and how does it work?
added the field priorityClassName to the template spec for deployments/daemonset to allow custom values.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
