### PR TITLE
scheduler: fix error `nextRecover shouldn't be later than nextStart`

### DIFF
--- a/controllers/twophase/twophase_suite_test.go
+++ b/controllers/twophase/twophase_suite_test.go
@@ -16,6 +16,7 @@ package twophase_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -435,7 +436,8 @@ var _ = Describe("TwoPhase", func() {
 			Expect(chaos.NextStart.Time.Day()).To(Equal(exp.Day()))
 			Expect(chaos.NextStart.Time.Hour()).To(Equal(exp.Hour()))
 			Expect(chaos.NextStart.Time.Minute()).To(Equal(exp.Minute()))
-			Expect(chaos.NextStart.Time.Second()).To(Equal(exp.Second()))
+			// tolerate a small amount of deviation for second
+			Expect(math.Abs(float64(chaos.NextStart.Time.Second()-exp.Second())) <= 1).To(Equal(true))
 		})
 
 		It("TwoPhase ToApply Error", func() {

--- a/controllers/twophase/types.go
+++ b/controllers/twophase/types.go
@@ -169,7 +169,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			status.Experiment.StartTime = &metav1.Time{Time: now}
 		}
 
-		if chaos.GetNextStart().Before(now) {
+		// start the chaos before or equal now
+		if !chaos.GetNextStart().After(now) {
 			r.Log.Info("Starting")
 			if err = applyAction(ctx, r, req, *duration, chaos); err != nil {
 				updateFailedMessage(ctx, r, chaos, err.Error())

--- a/pkg/utils/scheduler.go
+++ b/pkg/utils/scheduler.go
@@ -15,6 +15,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -22,7 +23,11 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
-func NextTime(spec v1alpha1.SchedulerSpec, now time.Time) (*time.Time, error) {
+func NextTime(spec v1alpha1.SchedulerSpec, now time.Time, firstTime bool) (*time.Time, error) {
+	if firstTime && strings.Contains(spec.Cron, "every") {
+		return &now, nil
+	}
+
 	scheduler, err := cron.ParseStandard(spec.Cron)
 	if err != nil {
 		return nil, fmt.Errorf("fail to parse runner rule %s, %v", spec.Cron, err)

--- a/test/e2e/chaos/basic.go
+++ b/test/e2e/chaos/basic.go
@@ -1509,6 +1509,8 @@ selector:
 						return false
 					}
 
+					time.Sleep(time.Second)
+
 					data, err := recvUDPPacket(c, ports[target])
 					if err != nil || data != "ping\n" {
 						klog.Infof("Error: %v, Data: %s", err, data)


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

fix issue https://github.com/chaos-mesh/chaos-mesh/issues/1207

it is easy to meet this error when create a chaos test with "scheduler": {"cron":"*/1 * * * * "}, "duration": "50s"

https://github.com/chaos-mesh/chaos-mesh/pull/1221 is done a similar thing, but it is hard to cherry pick to release-1.0

### What is changed and how does it work?

when the chaos is the first time run, set the NextStart for it


### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
