### PR TITLE
loading image nginx:latest while e2e tests

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -78,6 +78,13 @@ function e2e::image_load() {
         for image in ${images[@]}; do
             $KIND_BIN load docker-image --name $CLUSTER ${DOCKER_REGISTRY}/$image:$IMAGE_TAG --nodes $(hack::join ',' ${nodes[@]})
         done
+
+        # bypassing docker pull rate limit inner the kind container: kindest/node has no credentials
+        # nginx:latest is required for test
+        # we suppose that you could pull this image on your host docker
+        echo "info: load images nginx:latest"
+        docker pull nginx:latest
+        $KIND_BIN load docker-image --name $CLUSTER nginx:latest --nodes $(hack::join ',' ${nodes[@]})
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Bypass docker hub pull request rate limit.

### What is changed and how does it work?

Loading nginx:latest before installing chaos-mesh in e2e-tests, for avoiding docker pull rate limit. Similar to #1244

cherry pick from https://github.com/chaos-mesh/chaos-mesh/pull/1255

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
