### PR TITLE
fix invalid metadata name in helm chart files

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-daemon-target-namespace
+  name: {{ .Release.Name }}-chaos-daemon-target-namespace
   namespace: chaos-testing
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -33,13 +33,13 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-daemon-psp
+  name: {{ .Release.Name }}-chaos-daemon-psp
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}:chaos-daemon-psp
+  name: {{ .Release.Name }}-chaos-daemon-psp
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-target-namespace
+  name: {{ .Release.Name }}-chaos-controller-manager-target-namespace
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -49,7 +49,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-cluster-level
+  name: {{ .Release.Name }}-chaos-controller-manager-cluster-level
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -70,7 +70,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-control-plane
+  name: {{ .Release.Name }}-chaos-controller-manager-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -88,7 +88,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-cluster-level
+  name: {{ .Release.Name }}-chaos-controller-manager-cluster-level
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -98,7 +98,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-controller-manager-cluster-level
+  name: {{ .Release.Name }}-chaos-controller-manager-cluster-level
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}
@@ -109,7 +109,7 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-control-plane
+  name: {{ .Release.Name }}-chaos-controller-manager-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -120,7 +120,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}:chaos-controller-manager-control-plane
+  name: {{ .Release.Name }}-chaos-controller-manager-control-plane
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}
@@ -134,7 +134,7 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-controller-manager-target-namespace
+  name: {{ .Release.Name }}-chaos-controller-manager-target-namespace
   namespace: {{ .Values.controllerManager.targetNamespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -145,7 +145,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-controller-manager-target-namespace
+  name: {{ .Release.Name }}-chaos-controller-manager-target-namespace
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}

--- a/helm/chaos-mesh/templates/dns-rbac.yaml
+++ b/helm/chaos-mesh/templates/dns-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server
+  name: {{ .Release.Name }}-chaos-dns-server
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -39,7 +39,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server-cluster-level
+  name: {{ .Release.Name }}-chaos-dns-server-cluster-level
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -59,7 +59,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server-control-plane
+  name: {{ .Release.Name }}-chaos-dns-server-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -77,7 +77,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server-cluster-level
+  name: {{ .Release.Name }}-chaos-dns-server-cluster-level
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -87,7 +87,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-dns-server-cluster-level
+  name: {{ .Release.Name }}-chaos-dns-server-cluster-level
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}
@@ -98,7 +98,7 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server-control-plane
+  name: {{ .Release.Name }}-chaos-dns-server-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -109,7 +109,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}:chaos-dns-server-control-plane
+  name: {{ .Release.Name }}-chaos-dns-server-control-plane
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}
@@ -123,7 +123,7 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-dns-server-target-namespace
+  name: {{ .Release.Name }}-chaos-dns-server-target-namespace
   namespace: {{ .Values.dnsServer.targetNamespace }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -134,7 +134,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-dns-server-target-namespace
+  name: {{ .Release.Name }}-chaos-dns-server-target-namespace
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}

--- a/helm/chaos-mesh/templates/prometheus-rbac.yaml
+++ b/helm/chaos-mesh/templates/prometheus-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-prometheus
+  name: {{ .Release.Name }}-chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -31,7 +31,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}:chaos-prometheus
+  name: {{ .Release.Name }}-chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -44,7 +44,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}:chaos-prometheus
+  name: {{ .Release.Name }}-chaos-prometheus
   apiGroup: rbac.authorization.k8s.io
 
   {{- end }}

--- a/install.sh
+++ b/install.sh
@@ -943,7 +943,7 @@ data:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-target-namespace
+  name: chaos-mesh-chaos-controller-manager-target-namespace
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -974,7 +974,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-cluster-level
+  name: chaos-mesh-chaos-controller-manager-cluster-level
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -992,7 +992,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-cluster-level
+  name: chaos-mesh-chaos-controller-manager-cluster-level
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -1000,7 +1000,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chaos-mesh:chaos-controller-manager-cluster-level
+  name: chaos-mesh-chaos-controller-manager-cluster-level
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager
@@ -1010,7 +1010,7 @@ subjects:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-target-namespace
+  name: chaos-mesh-chaos-controller-manager-target-namespace
   namespace: chaos-testing
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1019,7 +1019,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chaos-mesh:chaos-controller-manager-target-namespace
+  name: chaos-mesh-chaos-controller-manager-target-namespace
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager
@@ -1029,7 +1029,7 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-control-plane
+  name: chaos-mesh-chaos-controller-manager-control-plane
   namespace: chaos-testing
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1045,7 +1045,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: chaos-mesh:chaos-controller-manager-control-plane
+  name: chaos-mesh-chaos-controller-manager-control-plane
   namespace: chaos-testing
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1054,7 +1054,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: chaos-mesh:chaos-controller-manager-control-plane
+  name: chaos-mesh-chaos-controller-manager-control-plane
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Upgrade helm to v3.4.2 and run `helm lint` 

```
helm lint helm/chaos-mesh
==> Linting helm/chaos-mesh
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-target-namespace": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-cluster-level": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-control-plane": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-cluster-level": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-control-plane": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253
[ERROR] templates/controller-manager-rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release:chaos-controller-manager-target-namespace": invalid metadata name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 253

Error: 1 chart(s) linted, 1 chart(s) failed
```

### What is changed and how does it work? 

use `-` instead of `:`

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
