### PR TITLE
improve gitVersion format

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -17,16 +17,13 @@ set -euo pipefail
 
 function chaos_mesh::version::get_version_vars() {
   if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
-
     # Use git describe to find the version based on tags.
     if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
       DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
-      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
-        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
-        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
-      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
-        # We have distance to base tag (v1.1.0-1-gCommitHash)
-        GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      if [[ "${DASHES_IN_VERSION}" != "" ]] ; then
+        # GIT_VERSION=gitBranch-gitCommitHash
+        IFS='-' read -ra GIT_ARRAY <<< "$GIT_VERSION"
+        GIT_VERSION=$(git rev-parse --abbrev-ref HEAD)-${GIT_ARRAY[${#GIT_ARRAY[@]}-1]}
       fi
     fi
   fi


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

At present, we don't create git tags on the master branch, which makes gitVersion based on tags confuse users. 
```
-X 'github.com/chaos-mesh/chaos-mesh/pkg/version.gitVersion=v0.9.0-201+8d8dce88ff5371'
```

### What is changed and how does it work? 

If the current git commit don't have any git tags, we use `branch+gitcommit` to generate `gitVersion`

```
-X 'github.com/chaos-mesh/chaos-mesh/pkg/version.gitVersion=master-ga7abd818a7b2d6
```

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
