### PR TITLE
modify stable repo for e2e helm

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -100,14 +100,14 @@ function e2e::setup_helm_server() {
     if hack::version_ge $(e2e::get_kube_version) "v1.16.0"; then
         # workaround for https://github.com/helm/helm/issues/6374
         # TODO remove this when we can upgrade to helm 2.15+, see https://github.com/helm/helm/pull/6462
-        $HELM_BIN init --service-account tiller --output yaml \
+        $HELM_BIN init --service-account tiller --stable-repo-url https://charts.helm.sh/stable --output yaml \
             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
             | sed 's@  replicas: 1@  replicas: 1\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
             | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
         echo "info: wait for tiller to be ready"
         e2e::__wait_for_deploy kube-system tiller-deploy
     else
-        $HELM_BIN init --service-account=tiller --wait
+        $HELM_BIN init --service-account=tiller --wait --stable-repo-url https://charts.helm.sh/stable
     fi
     $HELM_BIN version
 }


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

```
Error: error initializing local helm home: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

Modify stable repo to https://charts.helm.sh/stable