### PR TITLE
cherry-pick-to-release-1.0: modify stable repo (#1315)

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -98,14 +98,14 @@ function e2e::setup_helm_server() {
     if hack::version_ge $(e2e::get_kube_version) "v1.16.0"; then
         # workaround for https://github.com/helm/helm/issues/6374
         # TODO remove this when we can upgrade to helm 2.15+, see https://github.com/helm/helm/pull/6462
-        $HELM_BIN init --service-account tiller --output yaml \
+        $HELM_BIN init --service-account tiller --stable-repo-url https://charts.helm.sh/stable --output yaml \
             | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' \
             | sed 's@  replicas: 1@  replicas: 1\n  selector: {"matchLabels": {"app": "helm", "name": "tiller"}}@' \
             | $KUBECTL_BIN --context $KUBECONTEXT apply -f -
         echo "info: wait for tiller to be ready"
         e2e::__wait_for_deploy kube-system tiller-deploy
     else
-        $HELM_BIN init --service-account=tiller --wait
+        $HELM_BIN init --service-account=tiller --wait --stable-repo-url https://charts.helm.sh/stable
     fi
     $HELM_BIN version
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
Try to fix e2e test failed, which belongs to "type/1.0-cherry-pick", like #1346.
### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
