### PR TITLE
upgrade toda to v0.1.11

### DIFF
--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -12,7 +12,7 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 ENV RUST_BACKTRACE 1
 
-RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.10/toda-linux-amd64.tar.gz -o /usr/local/bin/toda.tar.gz
+RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.11/toda-linux-amd64.tar.gz -o /usr/local/bin/toda.tar.gz
 RUN curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.5/nsexec-linux-amd64.tar.gz -o /usr/local/bin/nsexec.tar.gz
 
 RUN tar xvf /usr/local/bin/toda.tar.gz -C /usr/local/bin


### PR DESCRIPTION
### What problem does this PR solve?

Fix the bug on [old version of kernel](https://github.com/chaos-mesh/chaos-mesh/issues/1357#issuecomment-755888909) . Now it gets stabler on CentOS, and the retry count is limited.
