### PR TITLE
Fix: client.Get gets empty GVK(Group/APIVersion/Kind)

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -21,9 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	"github.com/mitchellh/mapstructure"
@@ -39,9 +36,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 var log = ctrl.Log.WithName("experiment api")

--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -406,7 +406,7 @@ func (s *Service) getPodChaosDetail(namespace string, name string, kubeCli clien
 		return Detail{}, err
 	}
 
-	kind, err := apiutil.GVKForObject(chaos.DeepCopyObject(), s.scheme)
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
 	if err != nil {
 		return Detail{}, err
 	}
@@ -414,7 +414,7 @@ func (s *Service) getPodChaosDetail(namespace string, name string, kubeCli clien
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      kind.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -424,8 +424,8 @@ func (s *Service) getPodChaosDetail(namespace string, name string, kubeCli clien
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: kind.Version,
-			Kind:       kind.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -449,10 +449,15 @@ func (s *Service) getIoChaosDetail(namespace string, name string, kubeCli client
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -462,8 +467,8 @@ func (s *Service) getIoChaosDetail(namespace string, name string, kubeCli client
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -487,10 +492,15 @@ func (s *Service) getNetworkChaosDetail(namespace string, name string, kubeCli c
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -500,8 +510,8 @@ func (s *Service) getNetworkChaosDetail(namespace string, name string, kubeCli c
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -525,10 +535,15 @@ func (s *Service) getTimeChaosDetail(namespace string, name string, kubeCli clie
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -538,8 +553,8 @@ func (s *Service) getTimeChaosDetail(namespace string, name string, kubeCli clie
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -563,10 +578,15 @@ func (s *Service) getKernelChaosDetail(namespace string, name string, kubeCli cl
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -576,8 +596,8 @@ func (s *Service) getKernelChaosDetail(namespace string, name string, kubeCli cl
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -601,10 +621,15 @@ func (s *Service) getStressChaosDetail(namespace string, name string, kubeCli cl
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -614,8 +639,8 @@ func (s *Service) getStressChaosDetail(namespace string, name string, kubeCli cl
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,
@@ -639,10 +664,15 @@ func (s *Service) getDNSChaosDetail(namespace string, name string, kubeCli clien
 		return Detail{}, err
 	}
 
+	gvk, err := apiutil.GVKForObject(chaos, s.scheme)
+	if err != nil {
+		return Detail{}, err
+	}
+
 	return Detail{
 		Experiment: Experiment{
 			Base: Base{
-				Kind:      chaos.Kind,
+				Kind:      gvk.Kind,
 				Namespace: chaos.Namespace,
 				Name:      chaos.Name,
 			},
@@ -652,8 +682,8 @@ func (s *Service) getDNSChaosDetail(namespace string, name string, kubeCli clien
 			FailedMessage: chaos.GetStatus().FailedMessage,
 		},
 		YAML: core.ExperimentYAMLDescription{
-			APIVersion: chaos.APIVersion,
-			Kind:       chaos.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
 			Metadata: core.ExperimentYAMLMetadata{
 				Name:        chaos.Name,
 				Namespace:   chaos.Namespace,

--- a/pkg/collector/server.go
+++ b/pkg/collector/server.go
@@ -48,7 +48,7 @@ func NewServer(
 	conf *config.ChaosDashboardConfig,
 	archive core.ExperimentStore,
 	event core.EventStore,
-) (*Server, client.Client, client.Reader) {
+) (*Server, client.Client, client.Reader, *runtime.Scheme) {
 	s := &Server{}
 
 	// namespace scoped
@@ -101,7 +101,7 @@ func NewServer(
 		}
 	}
 
-	return s, s.Manager.GetClient(), s.Manager.GetAPIReader()
+	return s, s.Manager.GetClient(), s.Manager.GetAPIReader(), s.Manager.GetScheme()
 }
 
 // Register starts collectors manager.


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

![image](https://user-images.githubusercontent.com/22956341/103929307-15399800-5158-11eb-9c40-e3b83765b813.png)

`Client.Get` gets empty GVK(Group/APIVersion/Kind). 

### What is changed and how does it work?
 
Use `schema` and object to get GVK

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![image](https://user-images.githubusercontent.com/22956341/103929246-ff2bd780-5157-11eb-9a37-7ad524991891.png)
