### PR TITLE
upgrade toda to v0.1.11 (#1367)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache curl tar
 
 WORKDIR /bin
 
-RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.10/toda-linux-amd64.tar.gz | tar -xz
+RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.1.11/toda-linux-amd64.tar.gz | tar -xz
 RUN curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.5/nsexec-linux-amd64.tar.gz | tar -xz
 
 COPY ./scripts /scripts


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

cherry pick pr #1367 

Fix the bug on [old version of kernel](https://github.com/chaos-mesh/chaos-mesh/issues/1357#issuecomment-755888909) . Now it gets stabler on CentOS, and the retry count is limited.
