### PR TITLE
chaos-daemon: support setting node selector

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -89,10 +89,6 @@ spec:
               hostPort: {{ .Values.chaosDaemon.grpcPort }}
             - name: http
               containerPort: {{ .Values.chaosDaemon.httpPort }}
-      {{- with .Values.chaosDaemon.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-      {{- end }}
 {{- if .Values.bpfki.create }}
         - name: bpfki
           image: {{ .Values.bpfki.image }}
@@ -140,3 +136,15 @@ spec:
           hostPath:
             path: /usr/src
 {{- end }}
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -136,15 +136,15 @@ spec:
           hostPath:
             path: /usr/src
 {{- end }}
-      {{- with .Values.controllerManager.nodeSelector }}
+      {{- with .Values.chaosDaemon.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- with .Values.controllerManager.affinity }}
+      {{- with .Values.chaosDaemon.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- with .Values.controllerManager.tolerations }}
+      {{- with .Values.chaosDaemon.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -86,7 +86,7 @@ chaosDaemon:
 
   # enable a podSecurityPolicy(psp)
   podSecurityPolicy: false
-  
+
   # runtime specifies which container runtime to use. Currently
   # we only supports docker and containerd.
   runtime: docker
@@ -111,7 +111,11 @@ chaosDaemon:
     #   cpu: 250m
     #   memory: 512Mi
 
+  nodeSelector: {}
+
   tolerations: []
+
+  affinity: {}
 
 dashboard:
   create: false


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

Need to set nodeSelector to define which nodes can install chaos-daemon

### What is changed and how does it work? 

Update helm charts 

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![image](https://user-images.githubusercontent.com/22956341/104153978-a80b5880-541e-11eb-8b6e-72e69eaf596c.png)

set nodeSelector and helm upgrade: 

![image](https://user-images.githubusercontent.com/22956341/104154020-c5d8bd80-541e-11eb-9394-780805423d3e.png)


