### PR TITLE
fix: scope pods' isolation problem

### DIFF
--- a/ui/src/components/NewExperimentNext/data/target.ts
+++ b/ui/src/components/NewExperimentNext/data/target.ts
@@ -427,30 +427,48 @@ export const schema: Partial<Record<Kind, Record<string, Yup.ObjectSchema>>> = {
   NetworkChaos: {
     partition: Yup.object({
       direction: Yup.string().required('The direction is required'),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
+      }),
     }),
     loss: Yup.object({
       loss: Yup.object({
         loss: Yup.string().required('The loss is required'),
+      }),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
       }),
     }),
     delay: Yup.object({
       delay: Yup.object({
         latency: Yup.string().required('The latency is required'),
       }),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
+      }),
     }),
     duplicate: Yup.object({
       duplicate: Yup.object({
         duplicate: Yup.string().required('The duplicate is required'),
+      }),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
       }),
     }),
     corrupt: Yup.object({
       corrupt: Yup.object({
         corrupt: Yup.string().required('The corrupt is required'),
       }),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
+      }),
     }),
     bandwidth: Yup.object({
       bandwidth: Yup.object({
         rate: Yup.string().required('The rate of bandwidth is required'),
+      }),
+      target_scope: Yup.object({
+        namespace_selectors: Yup.array().min(1, 'The namespace selectors is required'),
       }),
     }),
   },

--- a/ui/src/components/NewExperimentNext/form/Scope.tsx
+++ b/ui/src/components/NewExperimentNext/form/Scope.tsx
@@ -3,7 +3,12 @@ import { Box, InputAdornment, MenuItem, Typography } from '@material-ui/core'
 import React, { useEffect, useMemo, useRef } from 'react'
 import { RootState, useStoreDispatch } from 'store'
 import { arrToObjBySep, joinObjKVs, toTitleCase } from 'lib/utils'
-import { getAnnotations, getLabels, getPodsByNamespaces as getPods } from 'slices/experiments'
+import {
+  getAnnotations,
+  getCommonPodsByNamespaces as getCommonPods,
+  getLabels,
+  getNetworkTargetPodsByNamespaces as getNetworkTargetPods,
+} from 'slices/experiments'
 import { getIn, useFormikContext } from 'formik'
 
 import AdvancedOptions from 'components/AdvancedOptions'
@@ -35,7 +40,10 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope', pods
     annotation_selectors: currentAnnotations,
   } = getIn(values, scope)
 
-  const { labels, annotations, pods } = useSelector((state: RootState) => state.experiments)
+  const experiments = useSelector((state: RootState) => state.experiments)
+  const { labels, annotations } = experiments
+  const pods = scope === 'scope' ? experiments.pods : experiments.networkTargetPods
+  const getPods = scope === 'scope' ? getCommonPods : getNetworkTargetPods
   const dispatch = useStoreDispatch()
 
   const kvSeparator = ': '
@@ -81,7 +89,7 @@ const ScopeStep: React.FC<ScopeStepProps> = ({ namespaces, scope = 'scope', pods
       dispatch(getLabels(currentNamespaces))
       dispatch(getAnnotations(currentNamespaces))
     }
-  }, [currentNamespaces, dispatch])
+  }, [currentNamespaces, getPods, dispatch])
 
   useEffect(() => {
     if (firstRender.current) {

--- a/ui/src/components/NewExperimentNext/form/TargetGenerated.tsx
+++ b/ui/src/components/NewExperimentNext/form/TargetGenerated.tsx
@@ -3,16 +3,16 @@ import { Box, Button, MenuItem } from '@material-ui/core'
 import { Form, Formik, FormikErrors, FormikTouched, getIn } from 'formik'
 import { Kind, Spec } from '../data/target'
 import React, { useEffect, useState } from 'react'
+import { useStoreDispatch, useStoreSelector } from 'store'
 
 import AdvancedOptions from 'components/AdvancedOptions'
 import { ObjectSchema } from 'yup'
 import PublishIcon from '@material-ui/icons/Publish'
-import { RootState } from 'store'
 import Scope from './Scope'
 import T from 'components/T'
 import _snakecase from 'lodash.snakecase'
 import basicData from '../data/basic'
-import { useSelector } from 'react-redux'
+import { clearNetworkTargetPods } from 'slices/experiments'
 
 interface TargetGeneratedProps {
   kind?: Kind | ''
@@ -22,7 +22,8 @@ interface TargetGeneratedProps {
 }
 
 const TargetGenerated: React.FC<TargetGeneratedProps> = ({ kind, data, validationSchema, onSubmit }) => {
-  const { namespaces, target } = useSelector((state: RootState) => state.experiments)
+  const { namespaces, target } = useStoreSelector((state) => state.experiments)
+  const dispatch = useStoreDispatch()
 
   let initialValues = Object.entries(data).reduce((acc, [k, v]) => {
     if (v instanceof Object && v.field) {
@@ -157,11 +158,22 @@ const TargetGenerated: React.FC<TargetGeneratedProps> = ({ kind, data, validatio
           }
         }
 
+        const afterTargetClose = () => {
+          if (getIn(values, 'target_scope')) {
+            setFieldValue('target_scope', undefined)
+            dispatch(clearNetworkTargetPods())
+          }
+        }
+
         return (
           <Form>
             {parseDataToFormFields(errors, touched)}
             {kind === 'NetworkChaos' && (
-              <AdvancedOptions title={T('newE.target.network.target.title')} beforeOpen={beforeTargetOpen}>
+              <AdvancedOptions
+                title={T('newE.target.network.target.title')}
+                beforeOpen={beforeTargetOpen}
+                afterClose={afterTargetClose}
+              >
                 {values.target_scope && (
                   <Scope
                     namespaces={namespaces}

--- a/ui/src/slices/experiments.ts
+++ b/ui/src/slices/experiments.ts
@@ -16,8 +16,12 @@ export const getAnnotations = createAsyncThunk(
   'common/annotations',
   async (podNamespaceList: string[]) => (await api.common.annotations(podNamespaceList)).data
 )
-export const getPodsByNamespaces = createAsyncThunk(
+export const getCommonPodsByNamespaces = createAsyncThunk(
   'common/pods',
+  async (data: Partial<ExperimentScope>) => (await api.common.pods(data)).data
+)
+export const getNetworkTargetPodsByNamespaces = createAsyncThunk(
+  'network/target/pods',
   async (data: Partial<ExperimentScope>) => (await api.common.pods(data)).data
 )
 
@@ -26,6 +30,7 @@ const initialState: {
   labels: Record<string, string[]>
   annotations: Record<string, string[]>
   pods: any[]
+  networkTargetPods: any[]
   step1: boolean
   step2: boolean
   kindAction: [Kind | '', string]
@@ -36,6 +41,7 @@ const initialState: {
   labels: {},
   annotations: {},
   pods: [],
+  networkTargetPods: [],
   // New Experiment needed
   step1: false,
   step2: false,
@@ -50,6 +56,9 @@ const experimentsSlice = createSlice({
   name: 'experiments',
   initialState,
   reducers: {
+    clearNetworkTargetPods(state) {
+      state.networkTargetPods = []
+    },
     setStep1(state, action: PayloadAction<boolean>) {
       state.step1 = action.payload
     },
@@ -83,12 +92,23 @@ const experimentsSlice = createSlice({
     builder.addCase(getAnnotations.fulfilled, (state, action) => {
       state.annotations = action.payload
     })
-    builder.addCase(getPodsByNamespaces.fulfilled, (state, action) => {
+    builder.addCase(getCommonPodsByNamespaces.fulfilled, (state, action) => {
       state.pods = action.payload as any[]
+    })
+    builder.addCase(getNetworkTargetPodsByNamespaces.fulfilled, (state, action) => {
+      state.networkTargetPods = action.payload as any[]
     })
   },
 })
 
-export const { setStep1, setStep2, setKindAction, setTarget, setBasic, resetNewExperiment } = experimentsSlice.actions
+export const {
+  clearNetworkTargetPods,
+  setStep1,
+  setStep2,
+  setKindAction,
+  setTarget,
+  setBasic,
+  resetNewExperiment,
+} = experimentsSlice.actions
 
 export default experimentsSlice.reducer


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

This PR solves the pods' isolation problem between `normal scope pods` and `network target scope pods`.

Before these changes, when you get any scope pods, the others will sync at the same time. This is unexpected behavior.

### What is changed and how does it work?

Pods will not sync between scopes.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
