### PR TITLE
fix: missing stressors checking

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -334,6 +334,21 @@ func (s *Service) createKernelChaos(exp *core.ExperimentInfo, kubeCli client.Cli
 }
 
 func (s *Service) createStressChaos(exp *core.ExperimentInfo, kubeCli client.Client) error {
+	var stressors *v1alpha1.Stressors
+
+	// Error checking
+	if exp.Target.StressChaos.Stressors.CPUStressor.Workers <= 0 && exp.Target.StressChaos.Stressors.MemoryStressor.Workers > 0 {
+		stressors = &v1alpha1.Stressors{
+			MemoryStressor: exp.Target.StressChaos.Stressors.MemoryStressor,
+		}
+	} else if exp.Target.StressChaos.Stressors.MemoryStressor.Workers <= 0 && exp.Target.StressChaos.Stressors.CPUStressor.Workers > 0 {
+		stressors = &v1alpha1.Stressors{
+			CPUStressor: exp.Target.StressChaos.Stressors.CPUStressor,
+		}
+	} else {
+		stressors = exp.Target.StressChaos.Stressors
+	}
+
 	chaos := &v1alpha1.StressChaos{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        exp.Name,
@@ -345,7 +360,7 @@ func (s *Service) createStressChaos(exp *core.ExperimentInfo, kubeCli client.Cli
 			Selector:          exp.Scope.ParseSelector(),
 			Mode:              v1alpha1.PodMode(exp.Scope.Mode),
 			Value:             exp.Scope.Value,
-			Stressors:         exp.Target.StressChaos.Stressors,
+			Stressors:         stressors,
 			StressngStressors: exp.Target.StressChaos.StressngStressors,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Resolve #1380.

This PR prevents unexpected behaviors when creating `StressChaos`.

### What is changed and how does it work?

After changes, the `CPU` or `Memory` workers must be at least one bigger than zero.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
