### PR TITLE
pack chaosctl in controller-manager image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,6 @@ endif
 watchmaker:
 	$(CGO) build -ldflags '$(LDFLAGS)' -o bin/watchmaker ./cmd/watchmaker/...
 
-# Build chaosctl
-chaosctl:
-	$(GO) build -ldflags '$(LDFLAGS)' -o bin/chaosctl ./cmd/chaosctl/*.go
-
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
 	$(GO) run ./cmd/controller-manager/main.go
@@ -180,6 +176,10 @@ GO_TARGET_PHONY :=
 
 BINARIES :=
 
+# $(1): the binary output target
+# $(2): the source code of the binary
+# $(3): whether built with cgo
+# $(4): extra dependencies
 define COMPILE_GO_TEMPLATE
 ifeq ($(IN_DOCKER),1)
 
@@ -247,6 +247,9 @@ $(eval $(call COMPILE_GO_TEMPLATE,images/chaos-dashboard/bin/chaos-dashboard,./c
 
 $(eval $(call BUILD_IN_DOCKER_TEMPLATE,chaos-mesh,images/chaos-mesh/bin/chaos-controller-manager))
 $(eval $(call COMPILE_GO_TEMPLATE,images/chaos-mesh/bin/chaos-controller-manager,./cmd/chaos-controller-manager/main.go,0))
+
+$(eval $(call BUILD_IN_DOCKER_TEMPLATE,chaos-mesh,images/chaos-mesh/bin/chaosctl))
+$(eval $(call COMPILE_GO_TEMPLATE,images/chaos-mesh/bin/chaosctl,./cmd/chaosctl/main.go,0))
 
 $(eval $(call BUILD_IN_DOCKER_TEMPLATE,chaos-mesh-e2e,test/image/e2e/bin/ginkgo))
 $(eval $(call COMPILE_GO_TEMPLATE,test/image/e2e/bin/ginkgo,github.com/onsi/ginkgo/ginkgo,0))

--- a/images/chaos-mesh/Dockerfile
+++ b/images/chaos-mesh/Dockerfile
@@ -6,3 +6,4 @@ ARG HTTP_PROXY
 RUN apk add tzdata --no-cache
 
 COPY bin/chaos-controller-manager /usr/local/bin/chaos-controller-manager
+COPY bin/chaosctl /usr/local/bin/chaosctl


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Pack chaosctl in controller-manager's image, so that the users can use them without downloading extra binary.

And we have met a situation where the users failed to run `chaosctl` on his machine, but we haven't found the problem :( . Preparing a stable environment to run our software is always better than running it in a unpredictable and unreproducible environment.
