### PR TITLE
chaosctl: cleanup init functions, avoid load kubernetes client before operate anything

### DIFF
--- a/pkg/chaosctl/cmd/completion.go
+++ b/pkg/chaosctl/cmd/completion.go
@@ -82,7 +82,3 @@ PS> ./bin/chaosctl completion powershell > chaosctl.ps1
 		}
 	},
 }
-
-func init() {
-	rootCmd.AddCommand(completionCmd)
-}

--- a/pkg/chaosctl/cmd/debug.go
+++ b/pkg/chaosctl/cmd/debug.go
@@ -16,7 +16,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,13 +41,8 @@ const (
 	ioChaos      = "iochaos"
 )
 
-func init() {
+func NewDebugCommand() (*cobra.Command, error) {
 	o := &debugOptions{}
-
-	c, err := cm.InitClientSet()
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	debugCmd := &cobra.Command{
 		Use:   `debug (CHAOSTYPE) [-c CHAOSNAME] [-n NAMESPACE]`,
@@ -70,16 +64,22 @@ Examples:
 		Use:   `networkchaos (CHAOSNAME) [-n NAMESPACE]`,
 		Short: `Print the debug information for certain network chaos`,
 		Long:  `Print the debug information for certain network chaos`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := o.Run("networkchaos", args, c); err != nil {
-				log.Fatal(err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return err
 			}
+			return o.Run("networkchaos", args, clientset)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			return listChaos("networkchaos", o.namespace, toComplete, c.CtrlCli)
+			return listChaos("networkchaos", o.namespace, toComplete, clientset.CtrlCli)
 		},
 	}
 
@@ -87,16 +87,22 @@ Examples:
 		Use:   `stresschaos (CHAOSNAME) [-n NAMESPACE]`,
 		Short: `Print the debug information for certain stress chaos`,
 		Long:  `Print the debug information for certain stress chaos`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := o.Run("stresschaos", args, c); err != nil {
-				log.Fatal(err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return err
 			}
+			return o.Run("stresschaos", args, clientset)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			return listChaos("stresschaos", o.namespace, toComplete, c.CtrlCli)
+			return listChaos("stresschaos", o.namespace, toComplete, clientset.CtrlCli)
 		},
 	}
 
@@ -104,16 +110,23 @@ Examples:
 		Use:   `iochaos (CHAOSNAME) [-n NAMESPACE]`,
 		Short: `Print the debug information for certain io chaos`,
 		Long:  `Print the debug information for certain io chaos`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := o.Run("iochaos", args, c); err != nil {
-				log.Fatal(err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return err
 			}
+			return o.Run("iochaos", args, clientset)
+
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			clientset, err := cm.InitClientSet()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			return listChaos("iochaos", o.namespace, toComplete, c.CtrlCli)
+			return listChaos("iochaos", o.namespace, toComplete, clientset.CtrlCli)
 		},
 	}
 
@@ -122,14 +135,14 @@ Examples:
 	debugCmd.AddCommand(ioCmd)
 
 	debugCmd.PersistentFlags().StringVarP(&o.namespace, "namespace", "n", "default", "namespace to find chaos")
-	err = debugCmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return listNamespace(toComplete, c.KubeCli)
+	err := debugCmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		clientset, err := cm.InitClientSet()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+		return listNamespace(toComplete, clientset.KubeCli)
 	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	rootCmd.AddCommand(debugCmd)
+	return debugCmd, err
 }
 
 // Run debug

--- a/pkg/chaosctl/cmd/logs.go
+++ b/pkg/chaosctl/cmd/logs.go
@@ -34,13 +34,8 @@ type logsOptions struct {
 	node string
 }
 
-func init() {
+func NewLogsCmd() (*cobra.Command, error) {
 	o := &logsOptions{}
-
-	c, err := cm.InitClientSet()
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	logsCmd := &cobra.Command{
 		Use:   `logs [-t LINE]`,
@@ -54,7 +49,7 @@ Examples:
   # Print 100 log lines for chaosmesh components in node NODENAME
   chaosctl logs -t 100 -n NODENAME`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := o.Run(args, c); err != nil {
+			if err := o.Run(args); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -63,20 +58,27 @@ Examples:
 
 	logsCmd.Flags().Int64VarP(&o.tail, "tail", "t", -1, "Number of lines of recent log")
 	logsCmd.Flags().StringVarP(&o.node, "node", "n", "", "Number of lines of recent log")
-	err = logsCmd.RegisterFlagCompletionFunc("node", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return listNodes(toComplete, c.KubeCli)
+	err := logsCmd.RegisterFlagCompletionFunc("node", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		clientset, err := cm.InitClientSet()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+		return listNodes(toComplete, clientset.KubeCli)
 	})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-
-	rootCmd.AddCommand(logsCmd)
+	return logsCmd, nil
 }
 
 // Run logs
-func (o *logsOptions) Run(args []string, c *cm.ClientSet) error {
+func (o *logsOptions) Run(args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	c, err := cm.InitClientSet()
+	if err != nil {
+		return err
+	}
 
 	componentsNeeded := []string{"controller-manager", "chaos-daemon", "chaos-dashboard"}
 	for _, name := range componentsNeeded {

--- a/pkg/chaosctl/cmd/root.go
+++ b/pkg/chaosctl/cmd/root.go
@@ -14,8 +14,7 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +28,7 @@ Interacting with chaos mesh
 
   # show debug info
   chaosctl debug networkchaos
-  
+
   # show logs of all chaos-mesh componentes
   chaosctl logs`,
 }
@@ -37,10 +36,25 @@ Interacting with chaos mesh
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	logsCmd, err := NewLogsCmd()
+	if err != nil {
+		printErrorThenQuit(err)
 	}
+	rootCmd.AddCommand(logsCmd)
+
+	debugCommand, err := NewDebugCommand()
+	if err != nil {
+		printErrorThenQuit(err)
+	}
+
+	rootCmd.AddCommand(debugCommand)
+	rootCmd.AddCommand(completionCmd)
+	if err := rootCmd.Execute(); err != nil {
+		printErrorThenQuit(err)
+	}
+}
+func printErrorThenQuit(err error) {
+	log.Fatal(err)
 }
 
 func noCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
It's a part of #1397.
### What is changed and how does it work?

- cleanup unnecessary `func init(){}` from codes;
- initial kubernetes client only when context need it 
 
### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
