### PR TITLE
Cleanup parameters in helm values file

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -16,6 +16,8 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 
 |                 Parameter                  |                                                     Description                                                      |                         Default                         |
 |--------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride` |  | `` |
+| `fullnameOverride` |  | `` |
 | `clusterScoped`                            | whether chaos-mesh should manage kubernetes cluster wide chaos.Also see rbac.create and controllerManager.serviceAccount | `true` |
 | `rbac.create` |  | `true`                                                |
 | `timezone` | The timezone where controller-manager, chaos-daemon and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
@@ -27,8 +29,6 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `controllerManager.replicaCount` | Replicas for chaos-controller-manager | `1` |
 | `controllerManager.image` | docker image for chaos-controller-manager  | `pingcap/chaos-mesh:latest` |
 | `controllerManager.imagePullPolicy` | Image pull policy | `Always` |
-| `controllerManager.nameOverride` |  |  |
-| `controllerManager.fullnameOverride` |  |  |
 | `controllerManager.service.type` | Kubernetes Service type | `ClusterIP` |
 | `controllerManager.resources` | CPU/Memory resource requests/limits for chaos-controller-manager pod | `requests: { cpu: "250m", memory: "512Mi" }, limits:{ cpu: "500m", memory: "1024Mi" }`   |
 | `controllerManager.nodeSelector` |  Node labels for chaos-controller-manager pod assignment | `{}` |

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -1,6 +1,8 @@
 # Default values for chaos-mesh.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+nameOverride: ""
+fullnameOverride: ""
 
 # clusterScoped is whether chaos-mesh should manage kubernetes cluster wide chaos
 # Also see rbac.create and controllerManager.serviceAccount
@@ -21,8 +23,6 @@ timezone: "UTC"
 # enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon.
 enableProfiling: true
 
-kubectlImage: bitnami/kubectl:latest
-
 controllerManager:
   hostNetwork: false
   serviceAccount: chaos-controller-manager
@@ -33,9 +33,6 @@ controllerManager:
 
   image: pingcap/chaos-mesh:latest
   imagePullPolicy: IfNotPresent
-
-  nameOverride: ""
-  fullnameOverride: ""
 
   allowedNamespaces: ""
   ignoredNamespaces: ""


### PR DESCRIPTION
### What problem does this PR solve?
None

### What is changed and how does it work?
* Fix hierarchy of `nameOverride` and `fullnameOverride` parameters
  * e.g. The reference to `nameOverride` value is here
    https://github.com/chaos-mesh/chaos-mesh/blob/e8bc5db9b76cfdc4f5ee47c3f1fe20de7fa85557/helm/chaos-mesh/templates/_helpers.tpl#L5-L7
* Delete unused `kubectlImage` parameter

### Checklist

Tests
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?

```release-note
NONE
```
