### PR TITLE
[update] delete events by experiment UID (cherry-pick #1372)

### DIFF
--- a/pkg/apiserver/archive/archive.go
+++ b/pkg/apiserver/archive/archive.go
@@ -305,6 +305,11 @@ func (s *Service) delete(c *gin.Context) {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
 	} else {
-		c.JSON(http.StatusOK, StatusResponse{Status: "success"})
+		if err = s.event.DeleteByUID(context.Background(), uid); err != nil {
+			c.Status(http.StatusInternalServerError)
+			_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
+		} else {
+			c.JSON(http.StatusOK, StatusResponse{Status: "success"})
+		}
 	}
 }

--- a/pkg/apiserver/event/event_test.go
+++ b/pkg/apiserver/event/event_test.go
@@ -158,6 +158,10 @@ func (m *MockEventService) DeleteByFinishTime(context.Context, time.Duration) er
 	panic("implement me")
 }
 
+func (m *MockEventService) DeleteByUID(context.Context, string) error {
+	panic("implement me")
+}
+
 func (m *MockEventService) UpdateIncompleteEvents(context.Context, string, string) error {
 	panic("implement me")
 }

--- a/pkg/core/event.go
+++ b/pkg/core/event.go
@@ -62,6 +62,9 @@ type EventStore interface {
 	// DeleteByFinishTime deletes events and podrecords whose time difference is greater than the given time from FinishTime.
 	DeleteByFinishTime(context.Context, time.Duration) error
 
+	// DeleteByUID deletes events list by the UID.
+	DeleteByUID(context.Context, string) error
+
 	// UpdateIncompleteEvents updates the incomplete event by the namespace and name
 	// If chaos is deleted before an event is over, then the incomplete event would be stored in datastore,
 	// which means the event would never save the finish_time.

--- a/test/integration_test/dashboard_authority/run.sh
+++ b/test/integration_test/dashboard_authority/run.sh
@@ -82,7 +82,7 @@ function REQUEST() {
 echo "***** create chaos experiments *****"
 
 echo "viewer is forbidden to create experiments"
-REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "POST" "/api/experiments/new" "create_exp.out" "is forbidden" 
+REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "POST" "/api/experiments/new" "create_exp.out" "is forbidden"
 
 echo "only manager can create experiments success"
 # here just use busybox manager because experiment can be created only one time
@@ -137,7 +137,7 @@ echo "viewer is forbidden to restart experiments"
 REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "PUT" "/api/experiments/start/${EXP_UID}?namespace=busybox" "restart_exp.out" "is forbidden"
 
 echo "only manager can pause experiments"
-REQUEST BUSYBOX_MANAGE_TOKEN_LIST[@] "PUT" "/api/experiments/start/${EXP_UID}?namespace=busybox" "restart_exp.out" "success"                    
+REQUEST BUSYBOX_MANAGE_TOKEN_LIST[@] "PUT" "/api/experiments/start/${EXP_UID}?namespace=busybox" "restart_exp.out" "success"
 
 
 echo "***** update chaos experiments *****"
@@ -157,6 +157,45 @@ REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "DELETE" "/api/experiments/${EXP
 echo "only manager can delete experiments success"
 # here just use cluster manager because experiment can be delete only one time
 REQUEST CLUSTER_MANAGER_TOKEN_LIST[@] "DELETE" "/api/experiments/${EXP_UID}" "delete_exp.out" "success"
+
+
+echo "***** list events *****"
+
+echo "all token can list events under namespace busybox"
+REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events?namespace=busybox" "list_event.out" "ci-test"
+
+echo "cluster manager and viewer can list events in the cluster"
+REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events" "list_event.out" "ci-test"
+
+echo "busybox manager and viewer is forbidden to list events in the cluster or other namespace"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events" "list_event.out" "can't list"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events?namespace=default" "list_event.out" "can't list"
+
+
+echo "***** list dry events *****"
+
+echo "all token can list dry events under namespace busybox"
+REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events?namespace=busybox" "list_dry_event.out" "ci-test"
+
+echo "cluster manager and viewer can list dry events in the cluster"
+REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events/dry" "list_dry_event.out" "ci-test"
+
+echo "busybox manager and viewer is forbidden to list dry events in the cluster or other namespace"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/dry" "list_dry_event.out" "can't list"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/dry?namespace=default" "list_dry_event.out" "can't list"
+
+
+echo "***** get event by id *****"
+
+echo "all token can get event under namespace busybox"
+REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events/get?id=1&namespace=busybox" "get_event.out" "experiment_id"
+
+echo "cluster manager and viewer can get event in the cluster"
+REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events/get?id=1" "get_event.out" "experiment_id"
+
+echo "busybox manager and viewer is forbidden to get event in the cluster or other namespace"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/get?id=1" "get_event.out" "can't list"
+REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/get?id=1&namespace=default" "get_event.out" "can't list"
 
 
 echo "***** list archive chaos experiments *****"
@@ -206,45 +245,6 @@ REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "DELETE" "/api/archives/${EXP_UI
 echo "only manager can delete archive experiments success"
 # here use one manager token to delete it
 REQUEST BUSYBOX_MANAGER_TOKEN_LIST[@] "DELETE" "/api/archives/${EXP_UID}?namespace=busybox" "delete_archives.out" "success"
-
-
-echo "***** list events *****"
-
-echo "all token can list events under namespace busybox"
-REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events?namespace=busybox" "list_event.out" "ci-test"
-
-echo "cluster manager and viewer can list events in the cluster"
-REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events" "list_event.out" "ci-test"
-
-echo "busybox manager and viewer is forbidden to list events in the cluster or other namespace"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events" "list_event.out" "can't list"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events?namespace=default" "list_event.out" "can't list"
-
-
-echo "***** list dry events *****"
-
-echo "all token can list dry events under namespace busybox"
-REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events?namespace=busybox" "list_dry_event.out" "ci-test"
-
-echo "cluster manager and viewer can list dry events in the cluster"
-REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events/dry" "list_dry_event.out" "ci-test"
-
-echo "busybox manager and viewer is forbidden to list dry events in the cluster or other namespace"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/dry" "list_dry_event.out" "can't list"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/dry?namespace=default" "list_dry_event.out" "can't list"
-
-
-echo "***** get event by id *****"
-
-echo "all token can get event under namespace busybox"
-REQUEST BUSYBOX_VIEW_TOKEN_LIST[@] "GET" "/api/events/get?id=1&namespace=busybox" "get_event.out" "experiment_id"
-
-echo "cluster manager and viewer can get event in the cluster"
-REQUEST CLUSTER_VIEW_TOKEN_LIST[@] "GET" "/api/events/get?id=1" "get_event.out" "experiment_id"
-
-echo "busybox manager and viewer is forbidden to get event in the cluster or other namespace"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/get?id=1" "get_event.out" "can't list"
-REQUEST CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST[@] "GET" "/api/events/get?id=1&namespace=default" "get_event.out" "can't list"
 
 
 echo "pass the dashboard authority test!"


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

cherry-pick #1372 to release-1.1

### What problem does this PR solve?
When deleting archived experiments, delete the corresponding events and pod records.

### What is changed and how does it work?
Delete the corresponding events and pod records by experiment UID.



### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
