### PR TITLE
Add helm parameter to annotate dashboard service

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -70,6 +70,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `dashboard.persistentVolume.storageClassName` | Chaos Dashboard data Persistent Volume Storage Class | `standard` |
 | `dashboard.persistentVolume.mountPath` | Chaos Dashboard data Persistent Volume mount root path | `/data` |
 | `dashboard.persistentVolume.subPath` | Subdirectory of  Chaos Dashboard data Persistent Volume to mount | `` |
+| `dashboard.service.annotations` | Service annotations for the dashboard | `{}` |
 | `dashboard.service.type`              | Service type of the service created for exposing the dashboard                             | `NodePort`     |
 | `dashboard.service.clusterIP`         | Set the `clusterIP` of the dashboard service if the type is `ClusterIP` | `nil`           |
 | `dashboard.service.nodePort`          | Set the `nodePort` of the dashboard service if the type is `NodePort`  | `nil`           |

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -102,6 +102,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: chaos-dashboard
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+{{- with .Values.dashboard.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   selector:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -137,6 +137,7 @@ dashboard:
   podAnnotations: {}
 
   service:
+    annotations: {}
     type: NodePort
     # clusterIP:
     # nodePort:


### PR DESCRIPTION
Signed-off-by: toVersus <toversus2357@gmail.com>

### What problem does this PR solve?
We would love to add some cloud provider specific annotations to helm templated manifests
e.g. https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#create_service

### What is changed and how does it work?

Adding helm parameter to annotate dashboard service:

Define no service annotations:

```bash
$ helm template chaos-mesh -n chaos-mesh --set dashboard.create=true .
---
# Source: chaos-mesh/templates/chaos-dashboard-deployment.yaml
apiVersion: v1
kind: Service
metadata:
  namespace: chaos-mesh
  name: chaos-dashboard
  labels:
    app.kubernetes.io/name: chaos-mesh
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: chaos-mesh
    app.kubernetes.io/component: chaos-dashboard
    helm.sh/chart: chaos-mesh-v0.2.0
spec:
```

Define service annotations:

```bash
$ helm template chaos-mesh -n chaos-mesh --set dashboard.create=true,dashboard.service.annotations."cloud\.google\.com/backend-config"="\{\"ports\": \{\"http\":\"chaos-dashboard\"\}}" .
(...)
---
# Source: chaos-mesh/templates/chaos-dashboard-deployment.yaml
apiVersion: v1
kind: Service
metadata:
  namespace: chaos-mesh
  name: chaos-dashboard
  labels:
    app.kubernetes.io/name: chaos-mesh
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: chaos-mesh
    app.kubernetes.io/component: chaos-dashboard
    helm.sh/chart: chaos-mesh-v0.2.0
  annotations:
    cloud.google.com/backend-config: '{"ports": {"http":"chaos-dashboard"}}'
spec:
(...)
```

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?

```release-note
NONE
```
