### PR TITLE
docker client return error if the pid is zero

### DIFF
--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -84,6 +84,10 @@ func (c DockerClient) GetPidFromContainerID(ctx context.Context, containerID str
 		return 0, err
 	}
 
+	if container.State.Pid == 0 {
+		return 0, fmt.Errorf("container is not running, status: %s", container.State.Status)
+	}
+
 	return uint32(container.State.Pid), nil
 }
 


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

(I have forgotten to fix this bug for a long time :crying_cat_face:, sorry )

If the pid of a docker container is 0 (when the container is not running), an error will be returned.