### PR TITLE
dashboard: add HTTP API for getting rbac config

### DIFF
--- a/pkg/apiserver/common/common.go
+++ b/pkg/apiserver/common/common.go
@@ -16,11 +16,11 @@ package common
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"sort"
 	"strings"
-
-	"github.com/gin-gonic/gin"
+	"time"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/apiserver/utils"
@@ -29,8 +29,75 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/pkg/core"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector"
 
+	"github.com/gin-gonic/gin"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	roleManager = "manager"
+	roleViewer  = "viewer"
+
+	serviceAccountTemplate = `kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: %s
+  name: %s
+`
+	roleTemplate = `kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: %s
+  name: %s
+rules:
+- apiGroups: [""]
+  resources: ["pods", "namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - chaos-mesh.org
+  resources: [ "*" ]
+  verbs: [%s]
+`
+	clusterRoleTemplate = `kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: %s
+rules:
+- apiGroups: [""]
+  resources: ["pods", "namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - chaos-mesh.org
+  resources: [ "*" ]
+  verbs: [%s]
+`
+	roleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: %s
+  namespace: %s
+subjects:
+- kind: ServiceAccount
+  name: %s
+  namespace: %s
+roleRef:
+  kind: Role
+  name: %s
+  apiGroup: rbac.authorization.k8s.io
+`
+	clusterRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: %s
+subjects:
+- kind: ServiceAccount
+  name: %s
+  namespace: %s
+roleRef:
+  kind: ClusterRole
+  name: %s
+  apiGroup: rbac.authorization.k8s.io
+`
 )
 
 // Pod defines the basic information of a pod
@@ -70,6 +137,7 @@ func Register(r *gin.RouterGroup, s *Service) {
 	endpoint.GET("/labels", s.getLabels)
 	endpoint.GET("/annotations", s.getAnnotations)
 	endpoint.GET("/config", s.getConfig)
+	endpoint.GET("/rbac-config", s.getRbacConfig)
 }
 
 // @Summary Get pods from Kubernetes cluster.
@@ -308,6 +376,50 @@ func (s *Service) getConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, s.conf)
 }
 
+// @Summary Get the rbac config according to the user's choice.
+// @Description Get the rbac config according to the user's choice.
+// @Tags common
+// @Produce json
+// @Success 200 {object} MapSlice
+// @Router /common/rbac-config [get]
+// @Failure 500 {object} utils.APIError
+func (s *Service) getRbacConfig(c *gin.Context) {
+	namespace := c.Query("namespace")
+	roleType := c.Query("role")
+
+	var serviceAccount, role, roleBinding, verbs string
+	randomStr := randomStringWithCharset(5, charset)
+
+	scope := namespace
+	if len(namespace) == 0 {
+		namespace = "default"
+		scope = "cluster"
+	}
+	if roleType == roleManager {
+		verbs = `"get", "list", "watch", "create", "delete", "patch", "update"`
+	} else {
+		verbs = `"get", "list", "watch"`
+	}
+
+	serviceAccountName := fmt.Sprintf("account-%s-%s-%s", scope, roleType, randomStr)
+	roleName := fmt.Sprintf("role-%s-%s-%s", scope, roleType, randomStr)
+	roleBindingName := fmt.Sprintf("bind-%s-%s-%s", scope, roleType, randomStr)
+
+	serviceAccount = fmt.Sprintf(serviceAccountTemplate, namespace, serviceAccountName)
+	if scope == "cluster" {
+		role = fmt.Sprintf(clusterRoleTemplate, roleName, verbs)
+		roleBinding = fmt.Sprintf(clusterRoleBindingTemplate, roleBindingName, serviceAccountName, namespace, roleName)
+	} else {
+		role = fmt.Sprintf(roleTemplate, namespace, roleName, verbs)
+		roleBinding = fmt.Sprintf(roleBindingTemplate, roleBindingName, namespace, serviceAccountName, namespace, roleName)
+	}
+
+	rbacMap := make(map[string]string)
+	rbacMap[serviceAccountName] = serviceAccount + "\n---\n" + role + "\n---\n" + roleBinding
+
+	c.JSON(http.StatusOK, rbacMap)
+}
+
 // inSlice checks given string in string slice or not.
 func inSlice(v string, sl []string) bool {
 	for _, vv := range sl {
@@ -316,4 +428,15 @@ func inSlice(v string, sl []string) bool {
 		}
 	}
 	return false
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyz"
+
+func randomStringWithCharset(length int, charset string) string {
+	var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

users can choose the namespace/cluster and role(manager/viewer) in the dashboard, and then dashboard generates the rbac config.

### What is changed and how does it work?

```bash
curl -X GET "127.0.0.1:2333/api/common/rbac-config?role=viewer&namespace=busybox"  
```
`
{"account-busybox-viewer-ekjzo":"kind: ServiceAccount\napiVersion: v1\nmetadata:\n  namespace: busybox\n  name: account-busybox-viewer-ekjzo\n\n---\nkind: Role\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  namespace: busybox\n  name: role-busybox-viewer-ekjzo\nrules:\n- apiGroups: [\"\"]\n  resources: [\"pods\", \"namespaces\"]\n  verbs: [\"get\", \"watch\", \"list\"]\n- apiGroups:\n  - chaos-mesh.org\n  resources: [ \"*\" ]\n  verbs: [\"get\", \"list\", \"watch\"]\n\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: bind-busybox-viewer-ekjzo\n  namespace: busybox\nsubjects:\n- kind: ServiceAccount\n  name: account-busybox-viewer-ekjzo\n  namespace: busybox\nroleRef:\n  kind: Role\n  name: role-busybox-viewer-ekjzo\n  apiGroup: rbac.authorization.k8s.io\n"}
`

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
