### PR TITLE
chore(helm): allow install to namespace with numbers only

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: chaos-daemon
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -3,7 +3,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ .Values.chaosDaemon.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -30,7 +30,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.chaosDaemon.serviceAccount }}
     # apiGroup: rbac.authorization.k8s.io
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-chaos-daemon-psp

--- a/helm/chaos-mesh/templates/chaos-daemon-service.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "chaos-daemon.svc" . }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -96,7 +96,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "chaos-dashboard.svc" . }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: CLUSTER_SCOPED
               value: "{{ .Values.clusterScoped }}"
             - name: TARGET_NAMESPACE
-              value: {{ .Values.controllerManager.targetNamespace }}
+              value: {{ .Values.controllerManager.targetNamespace | quote }}
             {{- if .Values.controllerManager.allowedNamespaces }}
             - name: ALLOWED_NAMESPACES
               value: {{ .Values.controllerManager.allowedNamespaces }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-pvc.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-pvc.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "chaos-mesh.name" . }}-chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: chaos-controller-manager
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           - name: ALLOW_HOST_NETWORK_TESTING
             value: "{{ .Values.controllerManager.allowHostNetworkTesting }}"
           - name: TARGET_NAMESPACE
-            value: {{ .Values.controllerManager.targetNamespace }}
+            value: {{ .Values.controllerManager.targetNamespace | quote }}
           - name: CLUSTER_SCOPED
             value: "{{ .Values.clusterScoped }}"
           - name: TZ

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -135,7 +135,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-controller-manager-target-namespace
-  namespace: {{ .Values.controllerManager.targetNamespace }}
+  namespace: {{ .Values.controllerManager.targetNamespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -2,7 +2,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ .Values.controllerManager.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -71,7 +71,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-controller-manager-control-plane
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -102,7 +102,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 
 ---
 # binding for control plane namespace
@@ -110,7 +110,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-controller-manager-control-plane
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -124,7 +124,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 
 ---
 {{- if .Values.clusterScoped }}
@@ -149,5 +149,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerManager.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "chaos-mesh.svc" . }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/dns-configmap.yaml
+++ b/helm/chaos-mesh/templates/dns-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dns-server-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: chaos-dns-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/chaos-mesh/templates/dns-rbac.yaml
+++ b/helm/chaos-mesh/templates/dns-rbac.yaml
@@ -124,7 +124,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-dns-server-target-namespace
-  namespace: {{ .Values.dnsServer.targetNamespace }}
+  namespace: {{ .Values.dnsServer.targetNamespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/chaos-mesh/templates/dns-rbac.yaml
+++ b/helm/chaos-mesh/templates/dns-rbac.yaml
@@ -2,7 +2,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ .Values.dnsServer.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -60,7 +60,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-dns-server-control-plane
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -91,7 +91,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 
 ---
 # binding for control plane namespace
@@ -99,7 +99,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-dns-server-control-plane
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -113,7 +113,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 
 ---
 {{- if .Values.clusterScoped }}
@@ -138,5 +138,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.dnsServer.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helm/chaos-mesh/templates/dns-service.yaml
+++ b/helm/chaos-mesh/templates/dns-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.dnsServer.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     prometheus.io/port: "9153"
     prometheus.io/scrape: "true"
@@ -31,4 +31,4 @@ spec:
   - name: grpc
     port: {{ .Values.dnsServer.grpcPort }}
     protocol: TCP
-{{- end }} 
+{{- end }}

--- a/helm/chaos-mesh/templates/ingress.yaml
+++ b/helm/chaos-mesh/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "chaos-dashboard.svc" . }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/prometheus-configmap.yaml
+++ b/helm/chaos-mesh/templates/prometheus-configmap.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: prometheus-config
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/prometheus-deployment.yaml
+++ b/helm/chaos-mesh/templates/prometheus-deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -93,7 +93,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: prometheus-pvc
 spec:
   {{- if .Values.prometheus.volume.storageClassName }}

--- a/helm/chaos-mesh/templates/prometheus-rbac.yaml
+++ b/helm/chaos-mesh/templates/prometheus-rbac.yaml
@@ -4,7 +4,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ .Values.prometheus.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -41,7 +41,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.prometheus.serviceAccount }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-chaos-prometheus

--- a/helm/chaos-mesh/templates/prometheus-service.yaml
+++ b/helm/chaos-mesh/templates/prometheus-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   name: chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/webhook-configuration.yaml
+++ b/helm/chaos-mesh/templates/webhook-configuration.yaml
@@ -9,7 +9,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "chaos-mesh.certs" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -47,7 +47,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "chaos-mesh.svc" . }}
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ .Release.Namespace | quote }}
         path: "/inject-v1-pod"
     rules:
       - operations: [ "CREATE" ]
@@ -67,7 +67,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "chaos-mesh.svc" $ }}
-        namespace: {{ $.Release.Namespace }}
+        namespace: {{ $.Release.Namespace | quote }}
         path: /mutate-chaos-mesh-org-v1alpha1-{{ $crd }}
     failurePolicy: Fail
     name: m{{ $crd }}.kb.io
@@ -109,7 +109,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "chaos-mesh.svc" $ }}
-        namespace: {{ $.Release.Namespace }}
+        namespace: {{ $.Release.Namespace | quote }}
         path: /validate-chaos-mesh-org-v1alpha1-{{ $crd }}
     failurePolicy: Fail
     name: v{{ $crd }}.kb.io
@@ -132,7 +132,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: chaos-mesh-selfsigned
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   selfSigned: {}
 
@@ -141,7 +141,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: chaos-mesh-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   duration: 43800h #5year
   dnsNames:

--- a/install.sh
+++ b/install.sh
@@ -1011,7 +1011,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: chaos-mesh-chaos-controller-manager-target-namespace
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh

--- a/install.sh
+++ b/install.sh
@@ -1255,7 +1255,7 @@ spec:
             - name: CLUSTER_SCOPED
               value: "true"
             - name: TARGET_NAMESPACE
-              value: chaos-testing
+              value: "chaos-testing"
             - name: SECURITY_MODE
               value: "false"
             - name: DNS_SERVER_CREATE
@@ -1323,7 +1323,7 @@ spec:
           - name: ALLOW_HOST_NETWORK_TESTING
             value: "false"
           - name: TARGET_NAMESPACE
-            value: chaos-testing
+            value: "chaos-testing"
           - name: CLUSTER_SCOPED
             value: "true"
           - name: TZ

--- a/install.sh
+++ b/install.sh
@@ -905,7 +905,7 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-daemon
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -916,7 +916,7 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-controller-manager
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -928,7 +928,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: chaos-mesh-webhook-certs
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -1004,7 +1004,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager
-    namespace: chaos-testing
+    namespace: "chaos-testing"
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
 kind: ClusterRoleBinding
@@ -1023,14 +1023,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager
-    namespace: chaos-testing
+    namespace: "chaos-testing"
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: chaos-mesh-chaos-controller-manager-control-plane
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -1046,7 +1046,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: chaos-mesh-chaos-controller-manager-control-plane
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   labels:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -1058,13 +1058,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: chaos-controller-manager
-    namespace: chaos-testing
+    namespace: "chaos-testing"
 ---
 # Source: chaos-mesh/templates/chaos-daemon-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-daemon
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1089,7 +1089,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-dashboard
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1111,7 +1111,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-mesh-controller-manager
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1140,7 +1140,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-daemon
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1208,7 +1208,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-dashboard
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1275,7 +1275,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: chaos-testing
+  namespace: "chaos-testing"
   name: chaos-controller-manager
   labels:
     app.kubernetes.io/name: chaos-mesh
@@ -1373,7 +1373,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: "/inject-v1-pod"
     rules:
       - operations: [ "CREATE" ]
@@ -1388,7 +1388,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-podchaos
     failurePolicy: Fail
     name: mpodchaos.kb.io
@@ -1406,7 +1406,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-iochaos
     failurePolicy: Fail
     name: miochaos.kb.io
@@ -1424,7 +1424,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-timechaos
     failurePolicy: Fail
     name: mtimechaos.kb.io
@@ -1442,7 +1442,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-networkchaos
     failurePolicy: Fail
     name: mnetworkchaos.kb.io
@@ -1460,7 +1460,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-kernelchaos
     failurePolicy: Fail
     name: mkernelchaos.kb.io
@@ -1478,7 +1478,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-stresschaos
     failurePolicy: Fail
     name: mstresschaos.kb.io
@@ -1496,7 +1496,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-awschaos
     failurePolicy: Fail
     name: mawschaos.kb.io
@@ -1514,7 +1514,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-podiochaos
     failurePolicy: Fail
     name: mpodiochaos.kb.io
@@ -1532,7 +1532,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-podnetworkchaos
     failurePolicy: Fail
     name: mpodnetworkchaos.kb.io
@@ -1550,7 +1550,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-dnschaos
     failurePolicy: Fail
     name: mdnschaos.kb.io
@@ -1568,7 +1568,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /mutate-chaos-mesh-org-v1alpha1-jvmchaos
     failurePolicy: Fail
     name: mjvmchaos.kb.io
@@ -1597,7 +1597,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-podchaos
     failurePolicy: Fail
     name: vpodchaos.kb.io
@@ -1615,7 +1615,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-iochaos
     failurePolicy: Fail
     name: viochaos.kb.io
@@ -1633,7 +1633,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-timechaos
     failurePolicy: Fail
     name: vtimechaos.kb.io
@@ -1651,7 +1651,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-networkchaos
     failurePolicy: Fail
     name: vnetworkchaos.kb.io
@@ -1669,7 +1669,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-kernelchaos
     failurePolicy: Fail
     name: vkernelchaos.kb.io
@@ -1687,7 +1687,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-stresschaos
     failurePolicy: Fail
     name: vstresschaos.kb.io
@@ -1705,7 +1705,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-awschaos
     failurePolicy: Fail
     name: vawschaos.kb.io
@@ -1723,7 +1723,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-podnetworkchaos
     failurePolicy: Fail
     name: vpodnetworkchaos.kb.io
@@ -1741,7 +1741,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-dnschaos
     failurePolicy: Fail
     name: vdnschaos.kb.io
@@ -1759,7 +1759,7 @@ webhooks:
       caBundle: "${CA_BUNDLE}"
       service:
         name: chaos-mesh-controller-manager
-        namespace: chaos-testing
+        namespace: "chaos-testing"
         path: /validate-chaos-mesh-org-v1alpha1-jvmchaos
     failurePolicy: Fail
     name: vjvmchaos.kb.io


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
fixes #1493

### What is changed and how does it work?
All used namespace vars are quoted to allow use number in namespace only

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
