### PR TITLE
Bugfix: Use `Last` to get current phase at start time of standard cron (#1286)

### DIFF
--- a/api/v1alpha1/common_validation.go
+++ b/api/v1alpha1/common_validation.go
@@ -63,21 +63,10 @@ func ValidateScheduler(schedulerObject InnerSchedulerObject, spec *field.Path) f
 func validateSchedulerParams(duration *time.Duration, durationField *field.Path, spec *SchedulerSpec, schedulerField *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if duration != nil && spec != nil {
-
 		cronField := schedulerField.Child("cron")
-		scheduler, err := ParseCron(spec.Cron, cronField)
+		_, err := ParseCron(spec.Cron, cronField)
 		if len(err) != 0 {
 			allErrs = append(allErrs, err...)
-		}
-
-		if scheduler != nil {
-			tmpTime := time.Time{}
-			nextTime := scheduler.Next(tmpTime)
-			interval := nextTime.Sub(tmpTime)
-			if *duration >= interval {
-				allErrs = append(allErrs, field.Invalid(cronField, spec.Cron,
-					fmt.Sprintf("the scheduling interval:\"%s\" must be greater than the duration:%s", spec.Cron, *duration)))
-			}
 		}
 	}
 	return allErrs

--- a/api/v1alpha1/iochaos_webhook_test.go
+++ b/api/v1alpha1/iochaos_webhook_test.go
@@ -251,59 +251,6 @@ var _ = Describe("iochaos_webhook", func() {
 					},
 					expect: "error",
 				},
-				{
-					name: "validate the duration and the scheduler.cron conflict",
-					chaos: IoChaos{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: metav1.NamespaceDefault,
-							Name:      "foo16",
-						},
-						Spec: IoChaosSpec{
-							Duration:  &duration,
-							Scheduler: &SchedulerSpec{Cron: "@every 1m"},
-						},
-					},
-					execute: func(chaos *IoChaos) error {
-						return chaos.ValidateCreate()
-					},
-					expect: "error",
-				},
-				{
-					name: "validate the duration and the scheduler.cron conflict",
-					chaos: IoChaos{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: metav1.NamespaceDefault,
-							Name:      "foo16",
-						},
-						Spec: IoChaosSpec{
-							Duration:  &duration,
-							Percent:   101,
-							Scheduler: &SchedulerSpec{Cron: "@every 1m"},
-						},
-					},
-					execute: func(chaos *IoChaos) error {
-						return chaos.ValidateCreate()
-					},
-					expect: "error",
-				},
-				{
-					name: "validate the duration and the scheduler.cron conflict",
-					chaos: IoChaos{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: metav1.NamespaceDefault,
-							Name:      "foo16",
-						},
-						Spec: IoChaosSpec{
-							Duration:  &duration,
-							Percent:   -100,
-							Scheduler: &SchedulerSpec{Cron: "@every 1m"},
-						},
-					},
-					execute: func(chaos *IoChaos) error {
-						return chaos.ValidateCreate()
-					},
-					expect: "error",
-				},
 			}
 
 			for _, tc := range tcs {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,149 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+)
+
+const (
+	// Set the top bit if a star was included in the expression.
+	starBit = 1 << 63
+)
+
+// LastTime returns the last time this schedule activated, less than or equal with the given time.
+func LastTime(spec v1alpha1.SchedulerSpec, now time.Time) (*time.Time, error) {
+	scheduler, err := cron.ParseStandard(spec.Cron)
+	if err != nil {
+		return nil, fmt.Errorf("fail to parse runner rule %s, %v", spec.Cron, err)
+	}
+	var last time.Time
+	if cronSpec, ok := scheduler.(*cron.SpecSchedule); ok {
+		scheduleLast := &cusSchedule{cronSpec}
+		last = scheduleLast.Last(now)
+	} else if cronSpec, ok := scheduler.(cron.ConstantDelaySchedule); ok {
+		scheduleLast := &cusConstantDelaySchedule{cronSpec}
+		last = scheduleLast.Last(now)
+	} else {
+		return nil, fmt.Errorf("assert cron spec failed")
+	}
+	return &last, nil
+}
+
+type cusConstantDelaySchedule struct {
+	cron.ConstantDelaySchedule
+}
+
+// Last returns the last time this schedule activated, less than or equal with the given time.
+// So it would always return now
+func (s cusConstantDelaySchedule) Last(t time.Time) time.Time {
+	return t
+}
+
+type cusSchedule struct {
+	*cron.SpecSchedule
+}
+
+// Last returns the last time this schedule activated, less than or equal with the given time.
+// If no time can be found to satisfy the schedule, return the zero time.
+// Modified from the original `Next` function in robfig/cron at Dec 15, 2020
+func (s *cusSchedule) Last(t time.Time) time.Time {
+	// General approach:
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then decrement the field until it matches.
+	// While decrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Convert the given time into the schedule's timezone, if one is specified.
+	// Save the original timezone so we can convert back after we find a time.
+	// Note that schedules without a time zone specified (time.Local) are treated
+	// as local to the time provided.
+	origLocation := t.Location()
+	loc := s.Location
+	if loc == time.Local {
+		loc = t.Location()
+	}
+	if s.Location != time.Local {
+		t = t.In(s.Location)
+	}
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() - 5
+
+WRAP:
+	if t.Year() < yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, loc).Add(-1 * time.Second)
+		if t.Month() == time.December {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		finalDay := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, loc).Add(-1 * time.Second).Day()
+		t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc).Add(-1 * time.Second)
+		if t.Day() == finalDay {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc).Add(-1 * time.Second)
+		if t.Hour() == 23 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		t = t.Truncate(time.Minute).Add(-1 * time.Second)
+		if t.Minute() == 59 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		t = t.Add(-1 * time.Second)
+		if t.Second() == 59 {
+			goto WRAP
+		}
+	}
+
+	return t.In(origLocation)
+}
+
+// dayMatches returns true if the schedule's day-of-week and day-of-month
+// restrictions are satisfied by the given time.
+func dayMatches(s *cusSchedule, t time.Time) bool {
+	var (
+		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+	)
+	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,146 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+)
+
+// Modified from the original `TestNext` function in robfig/cron at Dec 15, 2020
+func TestLast(t *testing.T) {
+	runs := []struct {
+		time, spec string
+		expected   string
+	}{
+		// `@every` cron
+		{"Jul 9 14:45:00 2012", "@every 1s", "Jul 9 14:45:00 2012"},
+		{"Jul 9 14:45:00 2012", "@every 1m", "Jul 9 14:45:00 2012"},
+		{"Jul 9 14:45:00 2012", "@every 1h", "Jul 9 14:45:00 2012"},
+		{"Jul 9 14:45:00 2012", "@every 1h1m1s", "Jul 9 14:45:00 2012"},
+
+		// Simple cases
+		{"Jul 9 14:45 2012", "0/15 * * * *", "Jul 9 14:45 2012"},
+		{"Jul 9 14:59 2012", "0/15 * * * *", "Jul 9 14:45 2012"},
+		{"Jul 9 14:59:59 2012", "0/15 * * * *", "Jul 9 14:45 2012"},
+
+		// Wrap around hours
+		{"Jul 9 16:15 2012", "20-35/15 * * * *", "Jul 9 15:35 2012"},
+
+		// Wrap around days
+		{"Jul 9 00:15 2012", "20-35/15 * * * *", "Jul 8 23:35 2012"},
+
+		// Wrap around months
+		{"Jul 9 23:35 2012", "0 0 10 Apr-Oct ?", "Jun 10 00:00 2012"},
+		{"Jul 9 23:35 2012", "0 0 */5 Apr,Aug,Oct Mon", "Apr 30 00:00 2012"},
+		{"Jul 9 23:35 2012", "0 0 */5 Oct Mon", "Oct 31 00:00 2011"},
+
+		// Wrap around years
+		{"Jan 9 23:35 2012", "0 0 * Feb Mon", "Feb 28 00:00 2011"},
+		{"Jan 9 23:35 2012", "0 0 * Feb Mon/2", "Feb 28 00:00 2011"},
+
+		// Leap year
+		{"Jan 9 23:35 2012", "0 0 29 Feb ?", "Feb 29 00:00 2008"},
+
+		// Daylight savings time 2am EST (-5) -> 3am EDT (-4)
+		{"2012-03-11T03:59:00-0400", "TZ=America/New_York 30 1 11 Mar ?", "2012-03-11T02:30:00-0400"},
+
+		// hourly job
+		{"2012-03-11T00:59:00-0500", "TZ=America/New_York 0 * * * ?", "2012-03-11T00:00:00-0500"},
+		{"2012-03-11T02:59:00-0400", "TZ=America/New_York 0 * * * ?", "2012-03-11T01:00:00-0500"},
+		{"2012-03-11T03:59:00-0400", "TZ=America/New_York 0 * * * ?", "2012-03-11T03:00:00-0400"},
+		{"2012-03-11T04:59:00-0400", "TZ=America/New_York 0 * * * ?", "2012-03-11T04:00:00-0400"},
+
+		// hourly job using CRON_TZ
+		{"2012-03-11T00:59:00-0500", "CRON_TZ=America/New_York 0 * * * ?", "2012-03-11T00:00:00-0500"},
+		{"2012-03-11T02:59:00-0400", "CRON_TZ=America/New_York 0 * * * ?", "2012-03-11T01:00:00-0500"},
+		{"2012-03-11T03:59:00-0400", "CRON_TZ=America/New_York 0 * * * ?", "2012-03-11T03:00:00-0400"},
+		{"2012-03-11T04:59:00-0400", "CRON_TZ=America/New_York 0 * * * ?", "2012-03-11T04:00:00-0400"},
+
+		// 1am nightly job
+		{"2012-03-11T01:59:00-0500", "TZ=America/New_York 0 1 * * ?", "2012-03-11T01:00:00-0500"},
+		{"2012-03-11T03:00:00-0400", "TZ=America/New_York 0 1 * * ?", "2012-03-11T01:00:00-0500"},
+
+		// 2am nightly job (skipped)
+		{"2012-03-12T01:00:00-0400", "TZ=America/New_York 0 2 * * ?", "2012-03-10T02:00:00-0500"},
+
+		// Daylight savings time 2am EDT (-4) => 1am EST (-5)
+		{"2012-11-04T02:30:00-0500", "TZ=America/New_York 0 0 04 Nov ?", "2012-11-04T00:00:00-0400"},
+		{"2012-11-04T01:30:00-0500", "TZ=America/New_York 45 1 04 Nov ?", "2012-11-04T01:45:00-0400"},
+
+		// hourly job
+		{"2012-11-04T00:59:00-0400", "TZ=America/New_York 0 * * * ?", "2012-11-04T00:00:00-0400"},
+		{"2012-11-04T01:00:00-0500", "TZ=America/New_York 30 * * * ?", "2012-11-04T01:30:00-0400"},
+		{"2012-11-04T01:00:00-0500", "TZ=America/New_York 0 * * * ?", "2012-11-04T01:00:00-0500"},
+
+		// 1am nightly job (runs twice)
+		{"2012-11-04T01:59:00-0400", "TZ=America/New_York 0 1 * * ?", "2012-11-04T01:00:00-0400"},
+		{"2012-11-04T02:00:00-0400", "TZ=America/New_York 0 1 * * ?", "2012-11-04T01:00:00-0500"},
+		{"2012-11-04T01:00:00-0500", "TZ=America/New_York 0 1 * * ?", "2012-11-04T01:00:00-0500"},
+
+		// 2am nightly job
+		{"2012-11-04T01:59:00-0500", "TZ=America/New_York 0 2 * * ?", "2012-11-03T02:00:00-0400"},
+
+		// Unsatisfiable
+		{"Jul 9 23:35 2012", "0 0 30 Feb ?", ""},
+		{"Jul 9 23:35 2012", "0 0 31 Apr ?", ""},
+	}
+
+	for _, c := range runs {
+		ss := v1alpha1.SchedulerSpec{Cron: c.spec}
+		actual, err := LastTime(ss, getTime(c.time))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		expected := getTime(c.expected)
+		if !actual.Equal(expected) {
+			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
+		}
+	}
+}
+
+func getTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+
+	var location = time.Local
+	if strings.HasPrefix(value, "TZ=") {
+		parts := strings.Fields(value)
+		loc, err := time.LoadLocation(parts[0][len("TZ="):])
+		if err != nil {
+			panic("could not parse location:" + err.Error())
+		}
+		location = loc
+		value = parts[1]
+	}
+
+	var layouts = []string{
+		"Jan 2 15:04 2006",
+		"Jan 2 15:04:05 2006",
+	}
+	for _, layout := range layouts {
+		if t, err := time.ParseInLocation(layout, value, location); err == nil {
+			return t
+		}
+	}
+	if t, err := time.ParseInLocation("2006-01-02T15:04:05-0700", value, location); err == nil {
+		return t
+	}
+	panic("could not parse time value " + value)
+}

--- a/test/e2e/chaos/basic.go
+++ b/test/e2e/chaos/basic.go
@@ -146,6 +146,10 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			ginkgo.It("[Pause]", func() {
 				timechaostestcases.TestcaseTimeSkewPauseThenUnpause(ns, cli, c, port)
 			})
+
+			ginkgo.It("[StartAtWaiting]", func() {
+				timechaostestcases.TestcaseTimeSkewStartAtWaitingThenIntoRunning(ns, cli, c, port)
+			})
 		})
 	})
 


### PR DESCRIPTION
cherry-pick #286 to release-1.1

---

### What problem does this PR solve?
fix #1270

### What is changed and how does it work?
Add function `Last` to get the last start time of standard cron, so we could know the current phase that chaos should go into when start.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [x] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
