### PR TITLE
chore: init workflow api types

### DIFF
--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -58,7 +58,7 @@ type Topology struct {
 // TopologyNode defines the basic structure of a node.
 type TopologyNode struct {
 	Type  nodeType  `json:"type"`
-	State nodeState `json:"state"`
+	State nodeState `json:"state,omitempty"`
 }
 
 // Node defines the single step of a workflow.
@@ -151,8 +151,8 @@ const (
 // Detail defines the detail of a workflow.
 type Detail struct {
 	gorm.Model
-	WorkflowID uint       `json:"workflow_id"`
-	Templates  []Template `json:"templates"`
+	WorkflowUID string     `json:"workflow_uid"`
+	Templates   []Template `json:"templates"`
 }
 
 // Template defines a complete structure of a template.

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -1,0 +1,164 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package workflow includes all type definitaions about Workflow.
+package workflow
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Workflow defines the root structure of a workflow.
+type Workflow struct {
+	gorm.Model
+	UID         string         `gorm:"index:uid" json:"uid"`
+	Name        string         `json:"name"`
+	Entry       string         `json:"entry"` // the entry node name
+	Status      workflowStatus `json:"status"`
+	CurrentNode TopologyNode   `json:"current_node"`
+	Topology    Topology       `json:"topology"`
+}
+
+// workflowState defines the current state of a workflow.
+//
+// Includes: Initializing, Running, Errored, Finished.
+//
+// Const definitions can be found below this type.
+type workflowStatus string
+
+const (
+	// WorkflowInitializing represents a workflow is being initialized.
+	WorkflowInitializing workflowStatus = "Initializing"
+
+	// WorkflowRunning represents that a workflow is running.
+	WorkflowRunning workflowStatus = "Running"
+
+	// WorkflowErrored represents an error in a workflow.
+	WorkflowErrored workflowStatus = "Errored"
+
+	// WorkflowFinished represents that a workflow has ended.
+	WorkflowFinished workflowStatus = "Finished"
+)
+
+// Topology describes the process of a workflow.
+type Topology struct {
+	Nodes []TopologyNode `json:"nodes"`
+}
+
+// TopologyNode defines the basic structure of a node.
+type TopologyNode struct {
+	Type  nodeType  `json:"type"`
+	State nodeState `json:"state"`
+}
+
+// Node defines the single step of a workflow.
+type Node struct {
+	TopologyNode
+	Serial   NodeSerial   `json:"serial,omitempty"`
+	Parallel NodeParallel `json:"parallel,omitempty"`
+	Template Template     `json:"template"`
+}
+
+// NodeSerial defines SerialNode's specific fields.
+type NodeSerial struct {
+	Tasks    []Node `json:"tasks"`
+	Circular bool   `json:"circular"`
+}
+
+// NodeParallel defines ParallelNode's specific fields.
+type NodeParallel struct {
+	Tasks []Node `json:"tasks"`
+}
+
+// nodeType defines the type of a workflow node.
+//
+// There will be five types can be refered as nodeType: Chaos, Serial, Parallel, Suspend, Task.
+//
+// Const definitions can be found below this type.
+type nodeType string
+
+const (
+	// ChaosNode represents a node will perform a single Chaos Experiment.
+	ChaosNode nodeType = "ChaosNode"
+
+	// SerialNode represents a node that will perform continuous templates.
+	SerialNode nodeType = "SerialNode"
+
+	// ParallelNode represents a node that will perform parallel templates.
+	ParallelNode nodeType = "ParallelNode"
+
+	// SuspendNode represents a node that will perform wait operation.
+	SuspendNode nodeType = "SuspendNode"
+
+	// TaskNode represents a node that will perform user-defined task.
+	TaskNode nodeType = "TaskNode"
+)
+
+// nodeState represents a node in different stage.
+//
+// It should be note that not all states are applicable to any node types.
+// A Node will contains only partial defined states.
+//
+// Const definitions can be found below this type.
+type nodeState string
+
+const (
+	// NodeInitializing represents a node is being initialized.
+	NodeInitializing nodeState = "Initializing"
+
+	// NodeWaitingForSchedule represents a node is idle and safe for next scheduling.
+	//
+	// Only available in: SerialNode, ParallelNode and TaskNode.
+	NodeWaitingForSchedule nodeState = "WaitingForSchedule"
+
+	// NodeWaitingForChild represents at least 1 child node is in Running or Holding state.
+	//
+	// Only available in: SerialNode, ParallelNode and TaskNode.
+	NodeWaitingForChild nodeState = "WaitingForChild"
+
+	// NodeRunning represents a node is doing dirty works.
+	//
+	// Available in: ChaosNode, SuspendNode and TaskNode.
+	NodeRunning nodeState = "Running"
+
+	// NodeEvaluating represents a node is collecting the result of a user's pod, then picks a template to execute.
+	//
+	// Only available: TaskNode.
+	NodeEvaluating nodeState = "Evaluating"
+
+	// NodeHolding represents that the current node is waiting for the next action.
+	//
+	// Only available: ChaosNode and SuspendNode.
+	NodeHolding nodeState = "Holding"
+
+	// NodeSucceed represents a node is completed.
+	NodeSucceed nodeState = "Succeed"
+
+	// NodeFailed represents a node is failed.
+	NodeFailed nodeState = "Failed"
+)
+
+// Detail defines the detail of a workflow.
+type Detail struct {
+	gorm.Model
+	WorkflowID uint       `json:"workflow_id"`
+	Templates  []Template `json:"templates"`
+}
+
+// Template defines a complete structure of a template.
+type Template struct {
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Duration string      `json:"duration,omitempty"`
+	Spec     interface{} `json:"spec"`
+}

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -21,7 +21,7 @@ type Workflow struct {
 	Entry       string         `json:"entry"` // the entry node name
 	Status      workflowStatus `json:"status"`
 	Topology    Topology       `json:"topology"`
-	CurrentNode Node           `json:"current_node"`
+	CurrentNode []Node         `json:"current_node"`
 }
 
 // workflowState defines the current state of a workflow.

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -16,12 +16,12 @@ package workflow
 
 // Workflow defines the root structure of a workflow.
 type Workflow struct {
-	UID         string         `json:"uid"`
-	Name        string         `json:"name"`
-	Entry       string         `json:"entry"` // the entry node name
-	Status      workflowStatus `json:"status"`
-	Topology    Topology       `json:"topology"`
-	CurrentNode []Node         `json:"current_node"`
+	UID          string         `json:"uid"`
+	Name         string         `json:"name"`
+	Entry        string         `json:"entry"` // the entry node name
+	Status       workflowStatus `json:"status"`
+	Topology     Topology       `json:"topology"`
+	CurrentNodes []Node         `json:"current_nodes"`
 }
 
 // workflowState defines the current state of a workflow.

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -52,6 +52,7 @@ type Topology struct {
 
 // TopologyNode defines the basic structure of a node.
 type TopologyNode struct {
+	Name  string    `json:"name"`
 	Type  nodeType  `json:"type"`
 	State nodeState `json:"state,omitempty"`
 }
@@ -66,12 +67,12 @@ type Node struct {
 
 // NodeSerial defines SerialNode's specific fields.
 type NodeSerial struct {
-	Tasks []Node `json:"tasks"`
+	Tasks []string `json:"tasks"`
 }
 
 // NodeParallel defines ParallelNode's specific fields.
 type NodeParallel struct {
-	Tasks []Node `json:"tasks"`
+	Tasks []string `json:"tasks"`
 }
 
 // nodeType defines the type of a workflow node.

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -14,13 +14,8 @@
 // Package workflow includes all type definitaions about Workflow.
 package workflow
 
-import (
-	"github.com/jinzhu/gorm"
-)
-
 // Workflow defines the root structure of a workflow.
 type Workflow struct {
-	gorm.Model
 	UID         string         `gorm:"index:uid" json:"uid"`
 	Name        string         `json:"name"`
 	Entry       string         `json:"entry"` // the entry node name
@@ -150,7 +145,6 @@ const (
 
 // Detail defines the detail of a workflow.
 type Detail struct {
-	gorm.Model
 	WorkflowUID string     `json:"workflow_uid"`
 	Templates   []Template `json:"templates"`
 }

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -16,12 +16,12 @@ package workflow
 
 // Workflow defines the root structure of a workflow.
 type Workflow struct {
-	UID         string         `gorm:"index:uid" json:"uid"`
+	UID         string         `json:"uid"`
 	Name        string         `json:"name"`
 	Entry       string         `json:"entry"` // the entry node name
 	Status      workflowStatus `json:"status"`
-	CurrentNode TopologyNode   `json:"current_node"`
 	Topology    Topology       `json:"topology"`
+	CurrentNode Node           `json:"current_node"`
 }
 
 // workflowState defines the current state of a workflow.
@@ -47,22 +47,17 @@ const (
 
 // Topology describes the process of a workflow.
 type Topology struct {
-	Nodes []TopologyNode `json:"nodes"`
-}
-
-// TopologyNode defines the basic structure of a node.
-type TopologyNode struct {
-	Name  string    `json:"name"`
-	Type  nodeType  `json:"type"`
-	State nodeState `json:"state,omitempty"`
+	Nodes []Node `json:"nodes"`
 }
 
 // Node defines the single step of a workflow.
 type Node struct {
-	TopologyNode
+	Name     string       `json:"name"`
+	Type     nodeType     `json:"type"`
+	State    nodeState    `json:"state,omitempty"`
 	Serial   NodeSerial   `json:"serial,omitempty"`
 	Parallel NodeParallel `json:"parallel,omitempty"`
-	Template Template     `json:"template"`
+	Template string       `json:"template"`
 }
 
 // NodeSerial defines SerialNode's specific fields.

--- a/pkg/core/workflow/types.go
+++ b/pkg/core/workflow/types.go
@@ -66,8 +66,7 @@ type Node struct {
 
 // NodeSerial defines SerialNode's specific fields.
 type NodeSerial struct {
-	Tasks    []Node `json:"tasks"`
-	Circular bool   `json:"circular"`
+	Tasks []Node `json:"tasks"`
 }
 
 // NodeParallel defines ParallelNode's specific fields.


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What is changed and how does it work?

This is a draft PR that describes the type definitions of workflow API base on [the workflow design](https://github.com/chaos-mesh/chaos-mesh/blob/master/workflow/docs/design.md).

> This PR may not necessarily be merged.

The whole package starts from `Workflow`. Suppose we take restful API as the standard, this type usually used in the below routes:

- `GET` `/workflows`
- `GET` `/workflows/{id}`
- `PUT` `/workflows/{id}`
- `DELETE` `/workflows/{id}`

For creating a workflow, we should use the `Node` type. Each workflow can be described as a `[]Node`. So we can also define the route as:

- `POST` `/workflows`

If we want to get the detail of a workflow, we should use the `Detail` type. The route definition:

- `GET` `/workflows/{id}/detail`

---

And others that need to note are:

- All `Status` and `State` types maybe duplicate in the code of the workflow engine. These definitions are just placeholders.
- `Topology` represents the topology structure of a workflow. It will be used to display the entire workflow process on the front-end.
- `Node` has specialized fields like `Serial`. This represents this `Node` has some extra definitions.
- The `spec` field under a `Template` is just a YAML definition. So I use `interface{}` to define it.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
