### PR TITLE
Fix meaningless retry operations caused by the updates of status field 

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -228,6 +228,7 @@ type InnerObject interface {
 	IsDeleted() bool
 	IsPaused() bool
 	GetChaos() *ChaosInstance
+	GetSpecAndMetaString() (string, error)
 	StatefulObject
 }
 

--- a/api/v1alpha1/zz_generated.chaosmesh.go
+++ b/api/v1alpha1/zz_generated.chaosmesh.go
@@ -14,6 +14,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"reflect"
 	"time"
 
@@ -118,6 +119,20 @@ func (in *DNSChaos) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *DNSChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *DNSChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true
@@ -238,6 +253,20 @@ func (in *HTTPChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
 
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *HTTPChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
+}
+
 // +kubebuilder:object:root=true
 
 // HTTPChaosList contains a list of HTTPChaos
@@ -354,6 +383,20 @@ func (in *IoChaos) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *IoChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *IoChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true
@@ -474,6 +517,20 @@ func (in *JVMChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
 
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *JVMChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
+}
+
 // +kubebuilder:object:root=true
 
 // JVMChaosList contains a list of JVMChaos
@@ -590,6 +647,20 @@ func (in *KernelChaos) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *KernelChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *KernelChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true
@@ -710,6 +781,20 @@ func (in *NetworkChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
 
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *NetworkChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
+}
+
 // +kubebuilder:object:root=true
 
 // NetworkChaosList contains a list of NetworkChaos
@@ -826,6 +911,20 @@ func (in *PodChaos) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *PodChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *PodChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true
@@ -946,6 +1045,20 @@ func (in *StressChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
 }
 
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *StressChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
+}
+
 // +kubebuilder:object:root=true
 
 // StressChaosList contains a list of StressChaos
@@ -1062,6 +1175,20 @@ func (in *TimeChaos) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *TimeChaos) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *TimeChaos) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.chaosmesh_test.go
+++ b/api/v1alpha1/zz_generated.chaosmesh_test.go
@@ -132,6 +132,14 @@ func TestDNSChaosGetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func TestDNSChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &DNSChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func TestDNSChaosListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -251,6 +259,14 @@ func TestHTTPChaosGetStatus(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	chaos.GetStatus()
+}
+
+func TestHTTPChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &HTTPChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
 }
 
 func TestHTTPChaosListChaos(t *testing.T) {
@@ -374,6 +390,14 @@ func TestIoChaosGetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func TestIoChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &IoChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func TestIoChaosListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -493,6 +517,14 @@ func TestJVMChaosGetStatus(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	chaos.GetStatus()
+}
+
+func TestJVMChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &JVMChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
 }
 
 func TestJVMChaosListChaos(t *testing.T) {
@@ -616,6 +648,14 @@ func TestKernelChaosGetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func TestKernelChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &KernelChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func TestKernelChaosListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -735,6 +775,14 @@ func TestNetworkChaosGetStatus(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	chaos.GetStatus()
+}
+
+func TestNetworkChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &NetworkChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
 }
 
 func TestNetworkChaosListChaos(t *testing.T) {
@@ -858,6 +906,14 @@ func TestPodChaosGetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func TestPodChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &PodChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func TestPodChaosListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -979,6 +1035,14 @@ func TestStressChaosGetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func TestStressChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &StressChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func TestStressChaosListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -1098,6 +1162,14 @@ func TestTimeChaosGetStatus(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	chaos.GetStatus()
+}
+
+func TestTimeChaosGetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &TimeChaos{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
 }
 
 func TestTimeChaosListChaos(t *testing.T) {

--- a/cmd/chaos-builder/impl.go
+++ b/cmd/chaos-builder/impl.go
@@ -20,6 +20,7 @@ import (
 
 const implImport = `
 import (
+	"encoding/json"
 	"reflect"
 	"time"
 
@@ -126,6 +127,20 @@ func (in *{{.Type}}) GetChaos() *ChaosInstance {
 // GetStatus returns the status
 func (in *{{.Type}}) GetStatus() *ChaosStatus {
 	return &in.Status.ChaosStatus
+}
+
+// GetSpecAndMetaString returns a string including the meta and spec field of this chaos object.
+func (in *{{.Type}}) GetSpecAndMetaString() (string, error) {
+	spec, err := json.Marshal(in.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	meta := in.ObjectMeta.DeepCopy()
+	meta.SetResourceVersion("")
+	meta.SetGeneration(0)
+
+	return string(spec) + meta.String(), nil
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/chaos-builder/test.go
+++ b/cmd/chaos-builder/test.go
@@ -148,6 +148,14 @@ func Test{{.Type}}GetStatus(t *testing.T) {
 	chaos.GetStatus()
 }
 
+func Test{{.Type}}GetSpecAndMetaString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	chaos := &{{.Type}}{}
+	err := faker.FakeData(chaos)
+	g.Expect(err).To(BeNil())
+	chaos.GetSpecAndMetaString()
+}
+
 func Test{{.Type}}ListChaos(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/controllers/reconciler/types.go
+++ b/controllers/reconciler/types.go
@@ -23,7 +23,6 @@ import (
 
 // InnerReconciler is interface for reconciler
 type InnerReconciler interface {
-
 	// Apply means the reconciler perform the chaos action
 	Apply(ctx context.Context, req ctrl.Request, chaos v1alpha1.InnerObject) error
 

--- a/controllers/twophase/state_machine.go
+++ b/controllers/twophase/state_machine.go
@@ -97,24 +97,41 @@ func apply(ctx context.Context, m *chaosStateMachine, targetPhase v1alpha1.Exper
 }
 
 func recover(ctx context.Context, m *chaosStateMachine, targetPhase v1alpha1.ExperimentPhase, now time.Time) (bool, error) {
+	duration, err := m.Chaos.GetDuration()
+	if err != nil {
+		m.Log.Error(err, "failed to get chaos duration")
+		return false, err
+	}
+	if duration == nil {
+		zero := time.Duration(0)
+		duration = &zero
+	}
+
 	currentPhase := m.Chaos.GetStatus().Experiment.Phase
 	status := m.Chaos.GetStatus()
 
 	m.Log.Info("recovering", "current phase", currentPhase, "target phase", targetPhase)
-	err := m.Recover(ctx, m.Req, m.Chaos)
-	if err != nil {
+	if err := m.Recover(ctx, m.Req, m.Chaos); err != nil {
 		status.FailedMessage = err.Error()
 
 		m.Log.Error(err, "fail to recover")
 		return true, err
 	}
+
 	status.Experiment.Phase = targetPhase
 	status.Experiment.EndTime = &metav1.Time{
 		Time: now,
 	}
+
 	if status.Experiment.StartTime != nil {
 		status.Experiment.Duration = now.Sub(status.Experiment.StartTime.Time).String()
 	}
+
+	// If this recover action is not called by pause action, reset recover time
+	if !now.Before(m.Chaos.GetNextRecover()) {
+		m.Chaos.SetNextRecover(m.Chaos.GetNextStart().Add(*duration))
+	}
+
 	return true, nil
 }
 
@@ -148,9 +165,8 @@ func resume(ctx context.Context, m *chaosStateMachine, _ v1alpha1.ExperimentPhas
 	}()
 
 	counter := 0
-	// nextStart is always after nextRecover
 	for {
-		if nextRecover.After(now) {
+		if nextRecover.After(now) && nextRecover.Before(nextStart) {
 			startTime = lastStart
 
 			return apply(ctx, m, v1alpha1.ExperimentPhaseRunning, startTime)

--- a/controllers/twophase/twophase_suite_test.go
+++ b/controllers/twophase/twophase_suite_test.go
@@ -117,6 +117,10 @@ func (in *fakeTwoPhaseChaos) IsPaused() bool {
 	return false
 }
 
+func (in *fakeTwoPhaseChaos) GetSpecAndMetaString() (string, error) {
+	return "", nil
+}
+
 func (r fakeEndpoint) Object() v1alpha1.InnerObject {
 	return &fakeTwoPhaseChaos{}
 }

--- a/pkg/router/reconciler.go
+++ b/pkg/router/reconciler.go
@@ -139,6 +139,14 @@ func NewReconciler(name string, object runtime.Object, mgr ctrl.Manager, endpoin
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(r.Object.DeepCopyObject()).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				old, _ := e.ObjectOld.(v1alpha1.InnerObject).GetSpecAndMetaString()
+				new, _ := e.ObjectNew.(v1alpha1.InnerObject).GetSpecAndMetaString()
+
+				return old != new
+			},
+		}).
 		Complete(r)
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

cherry-pick #1533 

### What is changed and how does it work?

Use `WithEventFilter` to filter update events and ignore updates to CRD object status.

To compare the spec and meta fields of the CRD object, we add a `GetSpecAndMetaString` function for each chaos CRD. If we update the CRD version to v1, we can delete `GetSpecAndMetaString` function, because we can use `unstructured.Unstructured` struct to parse CRD object directly.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
