### PR TITLE
validate the authority of selector in admission webhook

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -25,6 +25,7 @@ jobs:
           export CLUSTER="chart-testing"
           hack/local-up-chaos-mesh.sh
           kubectl set env deployment/chaos-dashboard SECURITY_MODE=true -n chaos-testing
+          kubectl set env deployment/chaos-controller-manager SECURITY_MODE=true -n chaos-testing
           sleep 5
           kubectl port-forward -n chaos-testing svc/chaos-dashboard 2333:2333 &
       

--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install Chaos Mesh
         run: |
           bash install.sh --local kind --crd ./manifests/crd.yaml
+          # TODO: the old version can't handle the webhook for validate authority, so delete it
+          # will remove this after the pr #1535 merged
+          kubectl delete ValidatingWebhookConfiguration validate-auth -n chaos-testing
 
       - name: Run integration test
         run: |

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -29,6 +29,15 @@ const (
 // LabelSelectorRequirements is list of LabelSelectorRequirement
 type LabelSelectorRequirements []metav1.LabelSelectorRequirement
 
+// +kubebuilder:object:generate=false
+
+// SelectSpec defines a common interface for selector
+type SelectSpec interface {
+	GetSelector() SelectorSpec
+	GetMode() PodMode
+	GetValue() string
+}
+
 // SelectorSpec defines the some selectors to select objects.
 // If the all selectors are empty, all objects will be used in chaos experiment.
 type SelectorSpec struct {
@@ -76,6 +85,38 @@ type SelectorSpec struct {
 	// supported value: Pending / Running / Succeeded / Failed / Unknown
 	// +optional
 	PodPhaseSelectors []string `json:"podPhaseSelectors,omitempty"`
+}
+
+// ClusterScoped returns true if the selector selects Pods in the cluster
+func (s SelectorSpec) ClusterScoped() bool {
+	// in fact, this will never happened, will add namespace if it is empty, so len(s.Namespaces) can not be 0,
+	// but still add judgentment here for safe
+	// https://github.com/chaos-mesh/chaos-mesh/blob/478d00d01bb0f9fb08a1085428a7da8c8f9df4e8/api/v1alpha1/common_webhook.go#L22
+	if len(s.Namespaces) == 0 && len(s.Pods) == 0 {
+		return true
+	}
+
+	return false
+}
+
+// AffectedNamespaces returns all the namespaces which the selector effect
+func (s SelectorSpec) AffectedNamespaces() []string {
+	affectedNamespacesMap := make(map[string]struct{})
+	affectedNamespacesArray := make([]string, 0, 2)
+
+	for namespace := range s.Pods {
+		affectedNamespacesMap[namespace] = struct{}{}
+	}
+
+	for _, namespace := range s.Namespaces {
+		affectedNamespacesMap[namespace] = struct{}{}
+	}
+
+	for namespace := range affectedNamespacesMap {
+		affectedNamespacesArray = append(affectedNamespacesArray, namespace)
+	}
+
+	return affectedNamespacesArray
 }
 
 // SchedulerSpec defines information about schedule of the chaos experiment.

--- a/api/v1alpha1/common_webhook.go
+++ b/api/v1alpha1/common_webhook.go
@@ -36,4 +36,8 @@ type ChaosValidator interface {
 	ValidateScheduler(spec *field.Path) field.ErrorList
 	// ValidatePodMode validates the value with podmode
 	ValidatePodMode(spec *field.Path) field.ErrorList
+
+	// GetSelectSpec returns the selector config for authority validate
+	// Note: network chaos also contains select spec in target, so return array
+	GetSelectSpec() []SelectSpec
 }

--- a/api/v1alpha1/dnschaos_webhook.go
+++ b/api/v1alpha1/dnschaos_webhook.go
@@ -73,6 +73,11 @@ func (in *DNSChaos) Validate() error {
 	return nil
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *DNSChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}
+
 // ValidateScheduler validates the scheduler and duration
 func (in *DNSChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
 	return ValidateScheduler(in, spec)

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -77,11 +77,10 @@ func (in *HTTPChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
 
 // ValidatePodMode validates the value with podmode
 func (in *HTTPChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
-	// Because aws chaos does not need a pod mode, so return nil here.
-	return nil
+	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
 
 // SelectSpec returns the selector config for authority validate
 func (in *HTTPChaos) GetSelectSpec() []SelectSpec {
-	return nil
+	return []SelectSpec{&in.Spec}
 }

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -25,7 +25,7 @@ import (
 // log is for logging in this package.
 var httpchaoslog = logf.Log.WithName("httpchaos-resource")
 
-// +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-awschaos,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=awschaos,verbs=create;update,versions=v1alpha1,name=mawschaos.kb.io
+// +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-httpchaos,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=httpchaos,verbs=create;update,versions=v1alpha1,name=mhttpchaos.kb.io
 
 var _ webhook.Defaulter = &HTTPChaos{}
 
@@ -34,7 +34,7 @@ func (in *HTTPChaos) Default() {
 	httpchaoslog.Info("default", "name", in.Name)
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-chaos-mesh-org-v1alpha1-awschaos,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=awschaos,versions=v1alpha1,name=vawschaos.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-chaos-mesh-org-v1alpha1-httpchaos,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=httpchaos,versions=v1alpha1,name=vhttpchaos.kb.io
 
 var _ ChaosValidator = &HTTPChaos{}
 

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Chaos Mesh Authors.
+// Copyright 2021 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,45 +23,43 @@ import (
 )
 
 // log is for logging in this package.
-var kernelchaoslog = logf.Log.WithName("kernelchaos-resource")
+var httpchaoslog = logf.Log.WithName("httpchaos-resource")
 
-// +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-kernelchaos,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=kernelchaos,verbs=create;update,versions=v1alpha1,name=mkernelchaos.kb.io
+// +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-awschaos,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=awschaos,verbs=create;update,versions=v1alpha1,name=mawschaos.kb.io
 
-var _ webhook.Defaulter = &KernelChaos{}
+var _ webhook.Defaulter = &HTTPChaos{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (in *KernelChaos) Default() {
-	kernelchaoslog.Info("default", "name", in.Name)
-
-	in.Spec.Selector.DefaultNamespace(in.GetNamespace())
+func (in *HTTPChaos) Default() {
+	httpchaoslog.Info("default", "name", in.Name)
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-chaos-mesh-org-v1alpha1-kernelchaos,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=kernelchaos,versions=v1alpha1,name=vkernelchaos.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-chaos-mesh-org-v1alpha1-awschaos,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=awschaos,versions=v1alpha1,name=vawschaos.kb.io
 
-var _ ChaosValidator = &KernelChaos{}
+var _ ChaosValidator = &HTTPChaos{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (in *KernelChaos) ValidateCreate() error {
-	kernelchaoslog.Info("validate create", "name", in.Name)
+func (in *HTTPChaos) ValidateCreate() error {
+	httpchaoslog.Info("validate create", "name", in.Name)
 	return in.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (in *KernelChaos) ValidateUpdate(old runtime.Object) error {
-	kernelchaoslog.Info("validate update", "name", in.Name)
+func (in *HTTPChaos) ValidateUpdate(old runtime.Object) error {
+	httpchaoslog.Info("validate update", "name", in.Name)
 	return in.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (in *KernelChaos) ValidateDelete() error {
-	kernelchaoslog.Info("validate delete", "name", in.Name)
+func (in *HTTPChaos) ValidateDelete() error {
+	httpchaoslog.Info("validate delete", "name", in.Name)
 
 	// Nothing to do?
 	return nil
 }
 
 // Validate validates chaos object
-func (in *KernelChaos) Validate() error {
+func (in *HTTPChaos) Validate() error {
 	specField := field.NewPath("spec")
 	allErrs := in.ValidateScheduler(specField)
 	allErrs = append(allErrs, in.ValidatePodMode(specField)...)
@@ -73,16 +71,17 @@ func (in *KernelChaos) Validate() error {
 }
 
 // ValidateScheduler validates the scheduler and duration
-func (in *KernelChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
+func (in *HTTPChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
 	return ValidateScheduler(in, spec)
 }
 
 // ValidatePodMode validates the value with podmode
-func (in *KernelChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
-	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
+func (in *HTTPChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
+	// Because aws chaos does not need a pod mode, so return nil here.
+	return nil
 }
 
 // SelectSpec returns the selector config for authority validate
-func (in *KernelChaos) GetSelectSpec() []SelectSpec {
-	return []SelectSpec{&in.Spec}
+func (in *HTTPChaos) GetSelectSpec() []SelectSpec {
+	return nil
 }

--- a/api/v1alpha1/iochaos_webhook.go
+++ b/api/v1alpha1/iochaos_webhook.go
@@ -94,6 +94,11 @@ func (in *IoChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
 	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *IoChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}
+
 func (in *IoChaosSpec) validateDelay(delay *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if in.Action == IoLatency {

--- a/api/v1alpha1/jvmchaos_types.go
+++ b/api/v1alpha1/jvmchaos_types.go
@@ -51,6 +51,21 @@ type JVMChaosSpec struct {
 	JVMParameter `json:",inline"`
 }
 
+// GetSelector is a getter for Selector (for implementing SelectSpec)
+func (in *JVMChaosSpec) GetSelector() SelectorSpec {
+	return in.Selector
+}
+
+// GetMode is a getter for Mode (for implementing SelectSpec)
+func (in *JVMChaosSpec) GetMode() PodMode {
+	return in.Mode
+}
+
+// GetValue is a getter for Value (for implementing SelectSpec)
+func (in *JVMChaosSpec) GetValue() string {
+	return in.Value
+}
+
 // JVMChaosAction represents the chaos action about jvm
 type JVMChaosAction string
 

--- a/api/v1alpha1/jvmchaos_webhook.go
+++ b/api/v1alpha1/jvmchaos_webhook.go
@@ -76,3 +76,8 @@ func (in *JVMChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
 func (in *JVMChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
 	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
+
+// SelectSpec returns the selector config for authority validate
+func (in *JVMChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}

--- a/api/v1alpha1/networkchaos_webhook.go
+++ b/api/v1alpha1/networkchaos_webhook.go
@@ -136,6 +136,16 @@ func (in *NetworkChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
 	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *NetworkChaos) GetSelectSpec() []SelectSpec {
+	selectSpecs := []SelectSpec{&in.Spec}
+	// when direction is both or from, will need to update target Pods
+	if in.Spec.Direction != To {
+		selectSpecs = append(selectSpecs, in.Spec.Target)
+	}
+	return selectSpecs
+}
+
 // ValidateTargets validates externalTargets and Targets
 func (in *NetworkChaos) ValidateTargets(target *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/api/v1alpha1/podchaos_webhook.go
+++ b/api/v1alpha1/podchaos_webhook.go
@@ -112,6 +112,11 @@ func (in *PodChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
 	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *PodChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}
+
 // validateContainerName validates the ContainerName
 func (in *PodChaosSpec) validateContainerName(containerField *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/api/v1alpha1/podiochaos_types.go
+++ b/api/v1alpha1/podiochaos_types.go
@@ -180,6 +180,9 @@ const (
 	Bmap        IoMethod = "bmap"
 )
 
+// KindPodIoChaos is the kind for pod io chaos
+const KindPodIoChaos = "PodIoChaos"
+
 // +kubebuilder:object:root=true
 
 // PodIoChaos is the Schema for the podiochaos API

--- a/api/v1alpha1/podnetworkchaos_webhook.go
+++ b/api/v1alpha1/podnetworkchaos_webhook.go
@@ -97,3 +97,8 @@ func (in *PodNetworkChaos) ValidateDelete() error {
 
 	return nil
 }
+
+// SelectSpec returns the selector config for authority validate
+func (in *PodNetworkChaos) GetSelectSpec() []SelectSpec {
+	return nil
+}

--- a/api/v1alpha1/stresschaos_webhook.go
+++ b/api/v1alpha1/stresschaos_webhook.go
@@ -90,6 +90,11 @@ func (in *StressChaos) ValidateScheduler(spec *field.Path) field.ErrorList {
 	return ValidateScheduler(in, spec)
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *StressChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}
+
 // Validate validates the scheduler and duration
 func (in *StressChaosSpec) Validate(parent *field.Path) field.ErrorList {
 	errs := field.ErrorList{}

--- a/api/v1alpha1/timechaos_webhook.go
+++ b/api/v1alpha1/timechaos_webhook.go
@@ -85,6 +85,11 @@ func (in *TimeChaos) ValidatePodMode(spec *field.Path) field.ErrorList {
 	return ValidatePodMode(in.Spec.Value, in.Spec.Mode, spec.Child("value"))
 }
 
+// SelectSpec returns the selector config for authority validate
+func (in *TimeChaos) GetSelectSpec() []SelectSpec {
+	return []SelectSpec{&in.Spec}
+}
+
 // validateTimeOffset validates the timeOffset
 func (in *TimeChaosSpec) validateTimeOffset(timeOffset *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/api/v1alpha1/zz_generated.chaosmesh.go
+++ b/api/v1alpha1/zz_generated.chaosmesh.go
@@ -1266,3 +1266,39 @@ func init() {
 	})
 
 }
+
+// GetChaosValidator returns chaos object by kind
+func GetChaosValidator(chaosKind string) ChaosValidator {
+	switch chaosKind {
+
+	case KindDNSChaos:
+		return &DNSChaos{}
+
+	case KindHTTPChaos:
+		return &HTTPChaos{}
+
+	case KindIoChaos:
+		return &IoChaos{}
+
+	case KindJVMChaos:
+		return &JVMChaos{}
+
+	case KindKernelChaos:
+		return &KernelChaos{}
+
+	case KindNetworkChaos:
+		return &NetworkChaos{}
+
+	case KindPodChaos:
+		return &PodChaos{}
+
+	case KindStressChaos:
+		return &StressChaos{}
+
+	case KindTimeChaos:
+		return &TimeChaos{}
+
+	default:
+		return nil
+	}
+}

--- a/api/webhook/validate_auth.go
+++ b/api/webhook/validate_auth.go
@@ -1,0 +1,161 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+)
+
+var authLog = ctrl.Log.WithName("validate-auth")
+
+// +kubebuilder:webhook:path=/validate-auth,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=*,verbs=create;update,versions=v1alpha1,name=vauth.kb.io
+
+// AuthValidator validates the authority
+type AuthValidator struct {
+	enabled bool
+	client  client.Client
+	reader  client.Reader
+	authCli *authorizationv1.AuthorizationV1Client
+
+	decoder *admission.Decoder
+
+	clusterScoped     bool
+	targetNamespace   string
+	allowedNamespaces string
+	ignoredNamespaces string
+}
+
+// NewAuthValidator returns a new AuthValidator
+func NewAuthValidator(enabled bool, client client.Client, reader client.Reader, authCli *authorizationv1.AuthorizationV1Client,
+	clusterScoped bool, targetNamespace, allowedNamespaces, ignoredNamespaces string) *AuthValidator {
+	return &AuthValidator{
+		enabled:           enabled,
+		client:            client,
+		reader:            reader,
+		authCli:           authCli,
+		clusterScoped:     clusterScoped,
+		targetNamespace:   targetNamespace,
+		allowedNamespaces: allowedNamespaces,
+		ignoredNamespaces: ignoredNamespaces,
+	}
+}
+
+// AuthValidator admits a pod iff a specific annotation exists.
+func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if !v.enabled {
+		return admission.Allowed("")
+	}
+
+	username := req.UserInfo.Username
+	groups := req.UserInfo.Groups
+	chaosKind := req.Kind.Kind
+
+	// these chaos doesn't contain selector field
+	if chaosKind == v1alpha1.KindPodNetworkChaos || chaosKind == v1alpha1.KindPodIoChaos {
+		return admission.Allowed("")
+	}
+
+	chaos := v1alpha1.GetChaosValidator(chaosKind)
+	if chaos == nil {
+		err := fmt.Errorf("kind %s is not support", chaosKind)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	err := v.decoder.Decode(req, chaos)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	specs := chaos.GetSelectSpec()
+
+	requireClusterPrivileges := false
+	affectedNamespaces := make(map[string]struct{})
+
+	for _, spec := range specs {
+		if spec.GetSelector().ClusterScoped() {
+			requireClusterPrivileges = true
+		}
+
+		for _, namespace := range spec.GetSelector().AffectedNamespaces() {
+			affectedNamespaces[namespace] = struct{}{}
+		}
+	}
+
+	if requireClusterPrivileges {
+		allow, err := v.auth(username, groups, "", chaosKind)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if !allow {
+			return admission.Denied(fmt.Sprintf("%s is forbidden on cluster", username))
+		}
+		authLog.Info("user have the privileges on cluster, auth validate passed", "user", username, "groups", groups, "namespace", affectedNamespaces)
+	} else {
+		for namespace := range affectedNamespaces {
+			allow, err := v.auth(username, groups, namespace, chaosKind)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+
+			if !allow {
+				return admission.Denied(fmt.Sprintf("%s is forbidden on namespace %s", username, namespace))
+			}
+		}
+
+		authLog.Info("user have the privileges on namespace, auth validate passed", "user", username, "groups", groups, "namespace", affectedNamespaces)
+	}
+
+	return admission.Allowed("")
+}
+
+// AuthValidator implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+
+// InjectDecoder injects the decoder.
+func (v *AuthValidator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+func (v *AuthValidator) auth(username string, groups []string, namespace string, resource string) (bool, error) {
+	sar := authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "create",
+				Group:     "chaos-mesh.org",
+				Resource:  resource,
+			},
+			User:   username,
+			Groups: groups,
+		},
+	}
+
+	response, err := v.authCli.SubjectAccessReviews().Create(&sar)
+	if err != nil {
+		return false, err
+	}
+
+	return response.Status.Allowed, nil
+}

--- a/cmd/chaos-builder/main.go
+++ b/cmd/chaos-builder/main.go
@@ -55,6 +55,7 @@ func main() {
 
 	testCode := codeHeader + testImport
 	initImpl := ""
+	allTypes := make([]string, 0, 10)
 
 	filepath.Walk("./api/v1alpha1", func(path string, info os.FileInfo, err error) error {
 		log := log.WithValues("file", path)
@@ -106,6 +107,7 @@ func main() {
 						implCode += generateImpl(baseType.Name.Name)
 						testCode += generateTest(baseType.Name.Name)
 						initImpl += generateInit(baseType.Name.Name)
+						allTypes = append(allTypes, baseType.Name.Name)
 						continue out
 					}
 				}
@@ -114,6 +116,8 @@ func main() {
 
 		return nil
 	})
+
+	validatorCode := generateGetChaosValidatorFunc(allTypes)
 
 	implCode += fmt.Sprintf(`
 func init() {
@@ -126,6 +130,7 @@ func init() {
 		os.Exit(1)
 	}
 	fmt.Fprint(file, implCode)
+	fmt.Fprint(file, validatorCode)
 
 	testCode += testInit
 	file, err = os.Create("./api/v1alpha1/zz_generated.chaosmesh_test.go")

--- a/cmd/chaos-builder/validator.go
+++ b/cmd/chaos-builder/validator.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"text/template"
+)
+
+const validatorTmpl = `
+// GetChaosValidator returns chaos object by kind
+func GetChaosValidator(chaosKind string) ChaosValidator {
+	switch chaosKind {
+{{range $val := .}}
+	case Kind{{$val}}:
+		return &{{$val}}{}
+{{end}}
+	default:
+		return nil
+	}
+}
+`
+
+func generateGetChaosValidatorFunc(allTypes []string) string {
+	tmpl, err := template.New("ini").Parse(validatorTmpl)
+	if err != nil {
+		log.Error(err, "fail to build template")
+		panic(err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, allTypes)
+	if err != nil {
+		log.Error(err, "fail to execute template")
+		panic(err)
+	}
+
+	return buf.String()
+
+}

--- a/cmd/chaos-controller-manager/main.go
+++ b/cmd/chaos-controller-manager/main.go
@@ -49,6 +49,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
@@ -120,6 +121,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	authCli, err := authorizationv1.NewForConfig(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to get authorization client")
+		os.Exit(1)
+	}
+
 	err = router.SetupWithManagerAndConfigs(mgr, ccfg.ControllerCfg)
 	if err != nil {
 		setupLog.Error(err, "fail to setup with manager")
@@ -186,6 +193,12 @@ func main() {
 			ControllerCfg: ccfg.ControllerCfg,
 			Metrics:       metricsCollector,
 		}},
+	)
+
+	hookServer.Register("/validate-auth", &webhook.Admission{
+		Handler: apiWebhook.NewAuthValidator(ccfg.ControllerCfg.SecurityMode, mgr.GetClient(), mgr.GetAPIReader(), authCli,
+			ccfg.ControllerCfg.ClusterScoped, ccfg.ControllerCfg.TargetNamespace, ccfg.ControllerCfg.AllowedNamespaces, ccfg.ControllerCfg.IgnoredNamespaces),
+	},
 	)
 
 	// +kubebuilder:scaffold:builder

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -29,9 +29,9 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-chaos-mesh-org-v1alpha1-awschaos
+      path: /mutate-chaos-mesh-org-v1alpha1-httpchaos
   failurePolicy: Fail
-  name: mawschaos.kb.io
+  name: mhttpchaos.kb.io
   rules:
   - apiGroups:
     - chaos-mesh.org
@@ -41,7 +41,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - awschaos
+    - httpchaos
 - clientConfig:
     caBundle: Cg==
     service:
@@ -235,9 +235,9 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-chaos-mesh-org-v1alpha1-awschaos
+      path: /validate-chaos-mesh-org-v1alpha1-httpchaos
   failurePolicy: Fail
-  name: vawschaos.kb.io
+  name: vhttpchaos.kb.io
   rules:
   - apiGroups:
     - chaos-mesh.org
@@ -247,7 +247,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - awschaos
+    - httpchaos
 - clientConfig:
     caBundle: Cg==
     service:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -29,6 +29,24 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-chaos-mesh-org-v1alpha1-awschaos
+  failurePolicy: Fail
+  name: mawschaos.kb.io
+  rules:
+  - apiGroups:
+    - chaos-mesh.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awschaos
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-chaos-mesh-org-v1alpha1-iochaos
   failurePolicy: Fail
   name: miochaos.kb.io
@@ -217,6 +235,24 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-chaos-mesh-org-v1alpha1-awschaos
+  failurePolicy: Fail
+  name: vawschaos.kb.io
+  rules:
+  - apiGroups:
+    - chaos-mesh.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awschaos
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-chaos-mesh-org-v1alpha1-iochaos
   failurePolicy: Fail
   name: viochaos.kb.io
@@ -374,3 +410,21 @@ webhooks:
     - UPDATE
     resources:
     - pods
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-auth
+  failurePolicy: Fail
+  name: vauth.kb.io
+  rules:
+  - apiGroups:
+    - chaos-mesh.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -84,6 +84,8 @@ spec:
             value: {{ .Values.dnsServer.name }}
           - name: CHAOS_DNS_SERVICE_PORT
             value: !!str {{ .Values.dnsServer.grpcPort }}
+          - name: SECURITY_MODE
+            value: "{{ .Values.dashboard.securityMode }}"
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -65,6 +65,11 @@ rules:
       - services
 {{- end }}
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
+      
 
 ---
 kind: Role
@@ -82,6 +87,10 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "configmaps", "services" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
 
 ---
 # bindings cluster level

--- a/helm/chaos-mesh/templates/webhook-configuration.yaml
+++ b/helm/chaos-mesh/templates/webhook-configuration.yaml
@@ -138,13 +138,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: admission-webhook
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
-  {{- if $certManagerEnabled }}
+  {{- if $certEnabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace "chaos-mesh-cert" | quote }}
   {{- end }}
 webhooks:
   - clientConfig:
-      {{- if $certManagerEnabled }}
+      {{- if $certEnabled }}
       caBundle: Cg==
       {{- else }}
       caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim $crtPEM)) (empty $crtPEM) }}

--- a/helm/chaos-mesh/templates/webhook-configuration.yaml
+++ b/helm/chaos-mesh/templates/webhook-configuration.yaml
@@ -126,6 +126,45 @@ webhooks:
   {{- end }}
   {{- end }}
 
+---
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validate-auth
+  labels:
+    app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admission-webhook
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+"  "_" }}
+  {{- if $certManagerEnabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace "chaos-mesh-cert" | quote }}
+  {{- end }}
+webhooks:
+  - clientConfig:
+      {{- if $certManagerEnabled }}
+      caBundle: Cg==
+      {{- else }}
+      caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim $crtPEM)) (empty $crtPEM) }}
+      {{- end }}
+      service:
+        name: {{ template "chaos-mesh.svc" $ }}
+        namespace: {{ $.Release.Namespace | quote }}
+        path: /validate-auth
+    failurePolicy: Fail
+    name: vauth.kb.io
+    rules:
+      - apiGroups:
+          - chaos-mesh.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources: [ "*" ]
+
 {{- if $certEnabled }}
 ---
 apiVersion: cert-manager.io/v1alpha2

--- a/install.sh
+++ b/install.sh
@@ -1754,7 +1754,7 @@ webhooks:
         resources:
           - jvmchaos
 ---
-# Source: chaos-mesh/templates/secrets-configuration.yaml
+# Source: chaos-mesh/templates/webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/install.sh
+++ b/install.sh
@@ -986,6 +986,10 @@ rules:
       - namespaces
       - services
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
 # bindings cluster level
@@ -1039,6 +1043,10 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "configmaps", "services" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
 # binding for control plane namespace
@@ -1348,6 +1356,8 @@ spec:
             value: chaos-mesh-dns-server
           - name: CHAOS_DNS_SERVICE_PORT
             value: !!str 9288
+          - name: SECURITY_MODE
+            value: "false"
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs
@@ -1743,6 +1753,34 @@ webhooks:
           - UPDATE
         resources:
           - jvmchaos
+---
+# Source: chaos-mesh/templates/secrets-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validate-auth
+  labels:
+    app.kubernetes.io/name: chaos-mesh
+    app.kubernetes.io/instance: chaos-mesh
+    app.kubernetes.io/component: admission-webhook
+webhooks:
+  - clientConfig:
+      caBundle: "${CA_BUNDLE}"
+      service:
+        name: chaos-mesh-controller-manager
+        namespace: "chaos-testing"
+        path: /validate-auth
+    failurePolicy: Fail
+    name: vauth.kb.io
+    rules:
+      - apiGroups:
+          - chaos-mesh.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources: [ "*" ]
 EOF
     # chaos-mesh.yaml end
 }

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -53,6 +53,9 @@ type ChaosControllerConfig struct {
 	DNSServiceName string `envconfig:"CHAOS_DNS_SERVICE_NAME" default:""`
 	DNSServicePort int    `envconfig:"CHAOS_DNS_SERVICE_PORT" default:""`
 
+	// SecurityMode is used for enable authority validation in admission webhook
+	SecurityMode bool `envconfig:"SECURITY_MODE" default:"true" json:"security_mode"`
+
 	// Namespace is the namespace which the controller manager run in
 	Namespace string `envconfig:"NAMESPACE" default:""`
 

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -41,14 +41,8 @@ import (
 
 var log = ctrl.Log.WithName("selector")
 
-type SelectSpec interface {
-	GetSelector() v1alpha1.SelectorSpec
-	GetMode() v1alpha1.PodMode
-	GetValue() string
-}
-
 // SelectAndFilterPods returns the list of pods that filtered by selector and PodMode
-func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, spec SelectSpec, clusterScoped bool, targetNamespace string, allowedNamespaces, ignoredNamespaces string) ([]v1.Pod, error) {
+func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, spec v1alpha1.SelectSpec, clusterScoped bool, targetNamespace string, allowedNamespaces, ignoredNamespaces string) ([]v1.Pod, error) {
 	if pods := mock.On("MockSelectAndFilterPods"); pods != nil {
 		return pods.(func() []v1.Pod)(), nil
 	}

--- a/test/integration_test/dashboard_authority/run.sh
+++ b/test/integration_test/dashboard_authority/run.sh
@@ -52,6 +52,7 @@ CLUSTER_MANAGER_TOKEN_LIST=($CLUSTER_MANAGER_TOKEN)
 
 CLUSTER_VIEW_TOKEN_LIST=($CLUSTER_MANAGER_TOKEN $CLUSTER_VIEWER_TOKEN)
 CLUSTER_VIEW_FORBIDDEN_TOKEN_LIST=($BUSYBOX_MANAGER_TOKEN $BUSYBOX_VIEWER_TOKEN)
+CLUSTER_MANAGER_FORBIDDEN_TOKEN_LIST=($CLUSTER_VIEWER_TOKEN $BUSYBOX_MANAGER_TOKEN $BUSYBOX_VIEWER_TOKEN)
 BUSYBOX_MANAGE_TOKEN_LIST=($CLUSTER_MANAGER_TOKEN $BUSYBOX_MANAGER_TOKEN)
 BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST=($CLUSTER_VIEWER_TOKEN $BUSYBOX_VIEWER_TOKEN)
 BUSYBOX_VIEW_TOKEN_LIST=($CLUSTER_MANAGER_TOKEN $CLUSTER_VIEWER_TOKEN $BUSYBOX_MANAGER_TOKEN $BUSYBOX_VIEWER_TOKEN)
@@ -145,7 +146,7 @@ echo "***** update chaos experiments *****"
 echo "viewer is forbidden to update experiments"
 REQUEST BUSYBOX_MANAGER_FORBIDDEN_TOKEN_LIST[@] "PUT" "/api/experiments/update" "update_exp.out" "is forbidden"
 
-echo "only manager can pause experiments"
+echo "only manager can update experiments"
 REQUEST BUSYBOX_MANAGE_TOKEN_LIST[@] "PUT" "/api/experiments/update" "update_exp.out" '"name":"ci-test"'
 
 
@@ -246,5 +247,23 @@ echo "only manager can delete archive experiments success"
 # here use one manager token to delete it
 REQUEST BUSYBOX_MANAGER_TOKEN_LIST[@] "DELETE" "/api/archives/${EXP_UID}?namespace=busybox" "delete_archives.out" "success"
 
+
+echo "***** test webhook authority ******"
+
+EXP_JSON='{"name": "ci-test2", "namespace": "busybox", "scope": {"mode": "one", "namespace_selectors": ["busybox"]}, "target": {"kind": "NetworkChaos", "network_chaos": {"direction": "both", "target_scope": {"namespace_selectors": ["chaos-testing"], "mode": "one"}, "action": "delay", "delay": {"latency": "1ms"}}}}'
+UPDATE_EXP_JSON='{"apiVersion": "chaos-mesh.org/v1alpha1", "kind": "NetworkChaos", "metadata": {"name": "ci-test2", "namespace": "busybox"}, "spec": {"direction": "both", "target": {"selector": {"namespaces": ["chaos-testing", "default" ]}, "mode": "one"}, "action": "delay", "latency": "2ms", "mode": "one"}}'
+
+# create experiment require the privileges of namespace busybox and chaos-testing, so only cluster manager can create exp success
+REQUEST CLUSTER_MANAGER_FORBIDDEN_TOKEN_LIST[@] "POST" "/api/experiments/new" "create_exp.out" 'is forbidden'
+
+REQUEST CLUSTER_MANAGER_TOKEN_LIST[@] "POST" "/api/experiments/new" "create_exp.out" '"name":"ci-test2"'
+
+# update the experiment require the privileges of namespace busybox, chaos-testing and default, so only cluster manager can update exp success
+REQUEST CLUSTER_MANAGER_FORBIDDEN_TOKEN_LIST[@] "PUT" "/api/experiments/update" "update_exp.out" "is forbidden"
+
+REQUEST CLUSTER_MANAGER_TOKEN_LIST[@] "PUT" "/api/experiments/update" "update_exp.out" '"name":"ci-test2"'
+
+# delete experiment
+kubectl delete networkchaos.chaos-mesh.org ci-test2 -n busybox
 
 echo "pass the dashboard authority test!"


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

cherry-pick from https://github.com/chaos-mesh/chaos-mesh/pull/1535

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Fix #1509.

### What is changed and how does it work?

add an admission webhook to validate the privileges, the user must have the privileges of all selected namespaces.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
