### PR TITLE
chore: add the label after blur

### DIFF
--- a/ui/src/components/FormField/LabelField.tsx
+++ b/ui/src/components/FormField/LabelField.tsx
@@ -43,27 +43,35 @@ const LabelField: React.FC<LabelFieldProps & TextFieldProps> = ({ isKV = false, 
     setText(e.target.value)
   }
 
+  const processText = () => {
+    const t = text.trim()
+
+    if (t === '') {
+      return
+    }
+
+    if (isKV && !/^.+:.+$/.test(t)) {
+      setError('Invalid key:value format')
+
+      return
+    }
+
+    const duplicate = labels.some((d) => d === t)
+
+    if (!duplicate) {
+      setLabels(labels.concat([t]))
+    }
+
+    setText('')
+  }
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (error) {
       setError('')
     }
 
     if (e.key === ' ') {
-      const t = text.trim()
-
-      if (isKV && !/^.+:.+$/.test(t)) {
-        setError('Invalid key:value format')
-
-        return
-      }
-
-      const duplicate = labels.some((d) => d === t)
-
-      if (!duplicate) {
-        setLabels(labels.concat([t]))
-      }
-
-      setText('')
+      processText()
     }
 
     if (e.key === 'Backspace' && text === '') {
@@ -104,6 +112,7 @@ const LabelField: React.FC<LabelFieldProps & TextFieldProps> = ({ isKV = false, 
             helperText={error !== '' ? error : isKV ? T('common.isKVHelperText') : props.helperText}
             onChange={onInputChange}
             onKeyDown={onKeyDown}
+            onBlur={processText}
             error={error !== ''}
           />
         )}


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What is changed and how does it work?

As the title.

Now the `LabelField` will submit a label automatically when losing the focus on the text field. This prevents users from forgetting to submit labels by pressing space.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
