### PR TITLE
fix localstack installation in integration tests

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install localstack && aws client
         run: |
           helm repo add localstack-repo http://helm.localstack.cloud
-          helm upgrade --install localstack localstack-repo/localstack
+          helm upgrade --install localstack localstack-repo/localstack --version 0.1.2
           pip install awscli
 
       - name: Run integration test


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
The latest helm chart of localstack with version 0.1.3 has some issue, it breaks the integration test.😰

### What is changed and how does it work?

Install localstack with helm chart 0.1.2.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
