### PR TITLE
fix: also set NextRecover with cron expression

### DIFF
--- a/controllers/twophase/twophase_suite_test.go
+++ b/controllers/twophase/twophase_suite_test.go
@@ -287,10 +287,12 @@ var _ = Describe("TwoPhase", func() {
 		})
 
 		It("TwoPhase Delete", func() {
+			duration := "5m"
 			chaos := fakeTwoPhaseChaos{
 				TypeMeta:   typeMeta,
 				ObjectMeta: objectMeta,
 				Scheduler:  &v1alpha1.SchedulerSpec{Cron: "@hourly"},
+				Duration:   &duration,
 				Deleted:    true,
 			}
 

--- a/controllers/twophase/types.go
+++ b/controllers/twophase/types.go
@@ -86,6 +86,11 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if phase == v1alpha1.ExperimentPhaseWaiting {
 			targetPhase = phase
 			chaos.SetNextStart(*nextStart)
+			duration, err := chaos.GetDuration()
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			chaos.SetNextRecover(nextStart.Add(*duration))
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

I think this PR could fix the unstable e2e test cases `TimeSkew/StartAtWaiting`


Previous code: 

https://github.com/chaos-mesh/chaos-mesh/blob/2ce9bbcffb40aea384bf0ec592cb5a5a54370db0/controllers/twophase/types.go#L81-L90

It does not set `NextRecover`, that affects `calcRequeueAfterTime` always return 0 as `requeueAfter`.

https://github.com/chaos-mesh/chaos-mesh/blob/2ce9bbcffb40aea384bf0ec592cb5a5a54370db0/controllers/twophase/types.go#L145-L173



### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [x] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
