### PR TITLE
[update] resume chaos that has been paused for a long time

### DIFF
--- a/controllers/twophase/state_machine.go
+++ b/controllers/twophase/state_machine.go
@@ -27,7 +27,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
-const iterMax = 1e4
+const iterMax = 2
 
 type chaosStateMachine struct {
 	Chaos v1alpha1.InnerSchedulerObject
@@ -189,8 +189,18 @@ func resume(ctx context.Context, m *chaosStateMachine, _ v1alpha1.ExperimentPhas
 
 		counter++
 		if counter > iterMax {
-			err = errors.Errorf("the number of iterations exceeded while resuming from pause with nextRecover(%s) nextStart(%s)", nextRecover, nextStart)
-			return false, err
+			// If counter > iterMax, it means that chaos has been suspended for a long time,
+			// then directly restart chaos and set startTime to now.
+			startTime = now
+			start, recover, err = m.IterateNextTime(startTime, *duration)
+			if err != nil {
+				m.Log.Error(err, "failed to get the next start time and recover time")
+				return false, err
+			}
+			nextStart = *start
+			nextRecover = *recover
+
+			return apply(ctx, m, v1alpha1.ExperimentPhaseRunning, startTime)
 		}
 	}
 }

--- a/controllers/twophase/state_machine.go
+++ b/controllers/twophase/state_machine.go
@@ -27,7 +27,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
-const iterMax = 2
+const iterMax = 1e4
 
 type chaosStateMachine struct {
 	Chaos v1alpha1.InnerSchedulerObject

--- a/install.sh
+++ b/install.sh
@@ -461,7 +461,6 @@ metadata:
   name: "local-storage"
 provisioner: "kubernetes.io/no-provisioner"
 volumeBindingMode: "WaitForFirstConsumer"
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -475,7 +474,6 @@ data:
     local-storage:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
-
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -537,14 +535,12 @@ spec:
         - name: local-disks
           hostPath:
             path: /mnt/disks
-
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-storage-admin
   namespace: kube-system
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1312,8 +1308,8 @@ spec:
       priorityClassName: 
       containers:
       - name: chaos-mesh
-        image: localhost:5000/pingcap/chaos-mesh:${VERSION_TAG}
-        imagePullPolicy: Never
+        image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-mesh:${VERSION_TAG}
+        imagePullPolicy: IfNotPresent
         resources:
             limits: {}
             requests:

--- a/install.sh
+++ b/install.sh
@@ -461,6 +461,7 @@ metadata:
   name: "local-storage"
 provisioner: "kubernetes.io/no-provisioner"
 volumeBindingMode: "WaitForFirstConsumer"
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -474,6 +475,7 @@ data:
     local-storage:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -535,12 +537,14 @@ spec:
         - name: local-disks
           hostPath:
             path: /mnt/disks
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-storage-admin
   namespace: kube-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/install.sh
+++ b/install.sh
@@ -1312,8 +1312,8 @@ spec:
       priorityClassName: 
       containers:
       - name: chaos-mesh
-        image: ${DOCKER_REGISTRY_PREFIX}/pingcap/chaos-mesh:${VERSION_TAG}
-        imagePullPolicy: IfNotPresent
+        image: localhost:5000/pingcap/chaos-mesh:${VERSION_TAG}
+        imagePullPolicy: Never
         resources:
             limits: {}
             requests:


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

### What problem does this PR solve?
resume chaos that has been paused for a long time.
solve https://github.com/chaos-mesh/chaos-mesh/issues/1556

### What is changed and how does it work?
If chaos is suspended for a long time, which may result in "counter> iterMax", then the experiment cannot be restarted. When this happens, start the experiment directly.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
