### PR TITLE
chore: specify the different test name on github action

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run:
-    name: Test
+    name: Integration Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run:
-    name: Test
+    name: Script Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -19,7 +19,7 @@ jobs:
           # Must use at least depth 2!
           fetch-depth: 2
 
-      - name: Creating kind cluster 
+      - name: Creating kind cluster
         uses: helm/kind-action@v1.0.0-rc.1
 
       - name: Install Chaos Mesh


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

The same job name of different tests blocks the integration with ti-chi bot.

### What is changed and how does it work?

Change the job name to be different.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
Signed-off-by: STRRL <str_ruiling@outlook.com>