### PR TITLE
chore: update image tag and chart file version for release-1.2.0

### DIFF
--- a/helm/chaos-mesh/Chart.yaml
+++ b/helm/chaos-mesh/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: "v0.9.0"
+appVersion: "v1.2.0"
 description: Chaos Mesh® is a cloud-native Chaos Engineering platform that orchestrates chaos on Kubernetes environments.
 home: https://chaos-mesh.org
 icon: https://raw.githubusercontent.com/pingcap/chaos-mesh/master/static/logo.svg
 sources:
   - https://github.com/pingcap/chaos-mesh
 name: chaos-mesh
-version: v0.2.0
+version: v0.5.0
 keywords:
   - chaos-engineering
   - resiliency

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -33,7 +33,7 @@ controllerManager:
 
   priorityClassName: ""
 
-  image: pingcap/chaos-mesh:latest
+  image: pingcap/chaos-mesh:v1.2.0
   imagePullPolicy: IfNotPresent
 
   allowedNamespaces: ""
@@ -70,7 +70,7 @@ controllerManager:
   allowHostNetworkTesting: false
 
 chaosDaemon:
-  image: pingcap/chaos-daemon:latest
+  image: pingcap/chaos-daemon:v1.2.0
   imagePullPolicy: IfNotPresent
   grpcPort: 31767
   httpPort: 31766
@@ -141,7 +141,7 @@ dashboard:
 
   serviceAccount: chaos-controller-manager
 
-  image: pingcap/chaos-dashboard:latest
+  image: pingcap/chaos-dashboard:v1.2.0
   imagePullPolicy: IfNotPresent
 
   securityMode: true
@@ -356,7 +356,7 @@ webhook:
 
 bpfki:
   create: false
-  image: pingcap/chaos-kernel:latest
+  image: pingcap/chaos-kernel:v1.2.0
   imagePullPolicy: IfNotPresent
   grpcPort: 50051
   resources: {}

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ FLAGS:
         --microk8s           Install chaos-mesh in microk8s environment
         --host-network       Install chaos-mesh using hostNetwork
 OPTIONS:
-    -v, --version            Version of chaos-mesh, default value: latest
+    -v, --version            Version of chaos-mesh, default value: v1.2.0
     -l, --local [kind]       Choose a way to run a local kubernetes cluster, supported value: kind,
                              If this value is not set and the Kubernetes is not installed, this script will exit with 1.
     -n, --name               Name of Kubernetes cluster, default value: kind
@@ -60,7 +60,7 @@ EOF
 
 main() {
     local local_kube=""
-    local cm_version="latest"
+    local cm_version="v1.2.0"
     local kind_name="kind"
     local kind_version="v0.7.0"
     local node_num=3


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Prepare for release-1.2

### What is changed and how does it work?
- Set the version/tag of images from `latest` to `v1.2.0`.
- Set the version of helm chart to `0.5.0`, appVersion to `v1.2.0`

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
