### PR TITLE
use go install instead of go get with code generation and linter tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ multithread_tracee: test/cmd/multithread_tracee/main.c
 	cc test/cmd/multithread_tracee/main.c -lpthread -O2 -o ./bin/test/multithread_tracee
 
 mockgen:
-	GO111MODULE=on go get github.com/golang/mock/mockgen@v1.5.0
+	GO111MODULE=on $(GO) install github.com/golang/mock/mockgen@v1.5.0
 
 generate-mock: mockgen
 	go generate ./pkg/workflow
@@ -325,15 +325,15 @@ docker-push-chaos-kernel:
 	docker push "${DOCKER_REGISTRY_PREFIX}pingcap/chaos-kernel:${IMAGE_TAG}"
 
 $(GOBIN)/controller-gen:
-	$(GO) get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
+	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
 $(GOBIN)/revive:
-	$(GO) get github.com/mgechev/revive@v1.0.2-0.20200225072153-6219ca02fffb
+	$(GO) install github.com/mgechev/revive@v1.0.2-0.20200225072153-6219ca02fffb
 $(GOBIN)/failpoint-ctl:
-	$(GO) get github.com/pingcap/failpoint/failpoint-ctl@v0.0.0-20200210140405-f8f9fb234798
+	$(GO) install github.com/pingcap/failpoint/failpoint-ctl@v0.0.0-20200210140405-f8f9fb234798
 $(GOBIN)/goimports:
-	$(GO) get golang.org/x/tools/cmd/goimports@v0.0.0-20200309202150-20ab64c0d93f
+	$(GO) install golang.org/x/tools/cmd/goimports@v0.0.0-20200309202150-20ab64c0d93f
 $(GOBIN)/gosec:
-	$(GO) get github.com/securego/gosec/cmd/gosec@v0.0.0-20200401082031-e946c8c39989
+	$(GO) install github.com/securego/gosec/cmd/gosec@v0.0.0-20200401082031-e946c8c39989
 
 lint: $(GOBIN)/revive
 	@echo "linting"


### PR DESCRIPTION

Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

It will fix #1650.

### What is changed and how does it work?
As `go help install` says:
```
If the arguments have version suffixes (like @latest or @v1.0.0), "go install"
builds packages in module-aware mode, ignoring the go.mod file in the current
directory or any parent directory, if there is one. This is useful for
installing executables without affecting the dependencies of the main module.
```

I think we should use `go install` to ignore the `go.mod` file in this repo.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
