### PR TITLE
more better logs in e2e tests

### DIFF
--- a/test/e2e/chaos/stresschaos/cpu.go
+++ b/test/e2e/chaos/stresschaos/cpu.go
@@ -15,6 +15,7 @@ package stresschaos
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -51,7 +52,7 @@ func TestcaseCPUStressInjectionOnceThenRecover(
 		diff[1] = conditions[1].CpuTime - lastCPUTime[1]
 		lastCPUTime[0] = conditions[0].CpuTime
 		lastCPUTime[1] = conditions[1].CpuTime
-		framework.Logf("get CPU: [%d, %d]", diff[0], diff[1])
+		By(fmt.Sprintf("get CPU: [%d, %d]", diff[0], diff[1]))
 		// diff means the increasing CPU time (in nanosecond)
 		// just pick two threshold, 5e8 is a little shorter than one second
 		if diff[0] > 5e8 && diff[1] < 5e6 {
@@ -77,7 +78,7 @@ func TestcaseCPUStressInjectionOnceThenRecover(
 		diff[1] = conditions[1].CpuTime - lastCPUTime[1]
 		lastCPUTime[0] = conditions[0].CpuTime
 		lastCPUTime[1] = conditions[1].CpuTime
-		framework.Logf("get CPU: [%d, %d]", diff[0], diff[1])
+		By(fmt.Sprintf("get CPU: [%d, %d]", diff[0], diff[1]))
 		// diff means the increasing CPU time (in nanosecond)
 		// just pick two threshold, they are both much shorter than 1 second
 		if diff[0] < 1e7 && diff[1] < 5e6 {

--- a/test/e2e/chaos/stresschaos/memory.go
+++ b/test/e2e/chaos/stresschaos/memory.go
@@ -15,6 +15,7 @@ package stresschaos
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -47,7 +48,7 @@ func TestcaseMemoryStressInjectionOnceThenRecover(
 		if conditions[0].MemoryUsage-conditions[1].MemoryUsage > 50*1024*1024 {
 			return true, nil
 		}
-		framework.Logf("get Memory: [%d, %d]", conditions[0].MemoryUsage, conditions[1].MemoryUsage)
+		By(fmt.Sprintf("get Memory: [%d, %d]", conditions[0].MemoryUsage, conditions[1].MemoryUsage))
 		return false, nil
 	})
 	framework.ExpectNoError(err, "memory stress failed")
@@ -64,7 +65,7 @@ func TestcaseMemoryStressInjectionOnceThenRecover(
 		if conditions[0].MemoryUsage-conditions[1].MemoryUsage < 1*1024*1024 {
 			return true, nil
 		}
-		framework.Logf("get Memory: [%d, %d]", conditions[0].MemoryUsage, conditions[1].MemoryUsage)
+		By(fmt.Sprintf("get Memory: [%d, %d]", conditions[0].MemoryUsage, conditions[1].MemoryUsage))
 		return false, nil
 	})
 	framework.ExpectNoError(err, "fail to recover from memory stress")


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
use `ginkgo.By` instead of `framework.log`, the former could make better view in e2e tests with parallel nodes

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
