### PR TITLE
fix vauth.kb.io webhook, use the lowercase resource name

### DIFF
--- a/api/webhook/validate_auth.go
+++ b/api/webhook/validate_auth.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	authv1 "k8s.io/api/authorization/v1"
 	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -136,14 +137,18 @@ func (v *AuthValidator) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
-func (v *AuthValidator) auth(username string, groups []string, namespace string, resource string) (bool, error) {
+func (v *AuthValidator) auth(username string, groups []string, namespace string, chaosKind string) (bool, error) {
+	resourceName, err := v.resourceFor(chaosKind)
+	if err != nil {
+		return false, err
+	}
 	sar := authv1.SubjectAccessReview{
 		Spec: authv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &authv1.ResourceAttributes{
 				Namespace: namespace,
 				Verb:      "create",
 				Group:     "chaos-mesh.org",
-				Resource:  resource,
+				Resource:  resourceName,
 			},
 			User:   username,
 			Groups: groups,
@@ -156,4 +161,9 @@ func (v *AuthValidator) auth(username string, groups []string, namespace string,
 	}
 
 	return response.Status.Allowed, nil
+}
+
+func (v *AuthValidator) resourceFor(name string) (string, error) {
+	// TODO: we should use RESTMapper, but it relates to many dependencies
+	return strings.ToLower(name), nil
 }

--- a/test/integration_test/auth-rbac-webhook/podchaos-example.yaml
+++ b/test/integration_test/auth-rbac-webhook/podchaos-example.yaml
@@ -1,0 +1,12 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-kill-example
+spec:
+  action: pod-kill
+  mode: one
+  selector:
+    labelSelectors:
+      "app.kubernetes.io/component": "no-applications-were-harmed"
+  scheduler:
+    cron: "@every 1m"

--- a/test/integration_test/auth-rbac-webhook/rbac.yaml
+++ b/test/integration_test/auth-rbac-webhook/rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fake-sa
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-chaos-creation-only
+rules:
+  - apiGroups:
+      - chaos-mesh.org
+    resources:
+      - podchaos
+    verbs:
+      - 'create'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fake-sa-could-only-create-podchaos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-chaos-creation-only
+subjects:
+  - kind: ServiceAccount
+    name: fake-sa
+    namespace: default

--- a/test/integration_test/auth-rbac-webhook/run.sh
+++ b/test/integration_test/auth-rbac-webhook/run.sh
@@ -32,6 +32,6 @@ CURRENT_CLUSTER=$(kubectl config get-contexts "${CURRENT_CONTEXT}" |awk 'NR==2'|
 kubectl config set-context fake-sa-test --cluster "${CURRENT_CLUSTER}" --user fake-sa
 
 kubectl --context fake-sa-test auth can-i create podchaos || exit 1
-kubectl --context fake-sa-test auth can-i get podchaos && exit 1 || exit 0
+kubectl --context fake-sa-test auth can-i get podchaos && exit 1
 
-k --context fake-sa-test create -f podchaos-example.yaml || exit 1
+kubectl --context fake-sa-test create -f podchaos-example.yaml || exit 1

--- a/test/integration_test/auth-rbac-webhook/run.sh
+++ b/test/integration_test/auth-rbac-webhook/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+cur=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd $cur
+
+kubectl apply -f ./rbac.yaml
+
+SA_SECRET_NAME=$(kubectl get serviceaccounts fake-sa -ojsonpath='{.secrets[0].name}')
+SA_SECRET=$(kubectl get secrets "${SA_SECRET_NAME}" -o=jsonpath='{.data.token}' | base64 -d)
+
+kubectl config set-credentials fake-sa --token "${SA_SECRET}"
+
+CURRENT_CONTEXT=$(kubectl config current-context)
+# line 2, column 3
+CURRENT_CLUSTER=$(kubectl config get-contexts "${CURRENT_CONTEXT}" |awk 'NR==2'| awk '{print $3}')
+
+kubectl config set-context fake-sa-test --cluster "${CURRENT_CLUSTER}" --user fake-sa
+
+kubectl --context fake-sa-test auth can-i create podchaos || exit 1
+kubectl --context fake-sa-test auth can-i get podchaos && exit 1 || exit 0
+
+k --context fake-sa-test create -f podchaos-example.yaml || exit 1


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
fix #1684 
fix #1613

### What is changed and how does it work?

Using Resource instead of Kind. The elegant way is using `schema` and `RestMapper` converting the kind to resource, but it needs more things in the AuthValidator.

And here is a convention that the CamelCase Kind and lowercase resource, so we just use `strings.toLowerCase()`.

I put a TODO here, we will finish with `RestMapper` in another PR.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
