### PR TITLE
e2e: disable unstable test

### DIFF
--- a/test/e2e/chaos/basic.go
+++ b/test/e2e/chaos/basic.go
@@ -399,9 +399,10 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			stresstestcases.TestcaseCPUStressInjectionOnceThenRecover(ns, cli, stressPeers, ports, c)
 		})
 
-		ginkgo.It("[Memory]", func() {
-			stresstestcases.TestcaseMemoryStressInjectionOnceThenRecover(ns, cli, stressPeers, ports, c)
-		})
+		// TODO: unstable test
+		// ginkgo.It("[Memory]", func() {
+		// 	stresstestcases.TestcaseMemoryStressInjectionOnceThenRecover(ns, cli, stressPeers, ports, c)
+		// })
 
 		ginkgo.JustAfterEach(func() {
 			for _, cancel := range pfCancels {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

This e2e test is unstable. In order to reduce time on rerunning the e2e test, this pr disable it temporarily. 

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
