### PR TITLE
fix failed recover

### DIFF
--- a/controllers/twophase/state_machine.go
+++ b/controllers/twophase/state_machine.go
@@ -353,7 +353,7 @@ var phaseTransitionMap = map[v1alpha1.ExperimentPhase]map[v1alpha1.ExperimentPha
 		v1alpha1.ExperimentPhaseWaiting:       noop,
 		v1alpha1.ExperimentPhasePaused:        noop,
 		v1alpha1.ExperimentPhaseFailed:        noop,
-		v1alpha1.ExperimentPhaseFinished:      noop,
+		v1alpha1.ExperimentPhaseFinished:      recover,
 	},
 	v1alpha1.ExperimentPhaseFinished: {
 		v1alpha1.ExperimentPhaseUninitialized: unexpected,

--- a/controllers/twophase/state_machine_test.go
+++ b/controllers/twophase/state_machine_test.go
@@ -190,6 +190,27 @@ var _ = Describe("TwoPhase StateMachine", func() {
 			Expect(updated).To(Equal(true))
 			Expect(sm.Chaos.GetStatus().Experiment.Phase).To(Equal(v1alpha1.ExperimentPhaseRunning))
 		})
+
+		It("StateMachine Unexpected State", func() {
+			var unexpectedState v1alpha1.ExperimentPhase = "wrong-state"
+			now := time.Now()
+
+			for _, status := range statuses {
+				sm := setupStateMachineWithStatus(status)
+				updated, err := sm.run(context.TODO(), unexpectedState, now)
+				Expect(updated).To(Equal(false))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unexpected target phase"))
+			}
+
+			sm := setupStateMachineWithStatus(unexpectedState)
+			for _, status := range statuses {
+				updated, err := sm.run(context.TODO(), status, now)
+				Expect(updated).To(Equal(false))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unexpected current phase"))
+			}
+		})
 	})
 
 })


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

### What problem does this PR solve?
https://github.com/chaos-mesh/chaos-mesh/issues/1506

### What is changed and how does it work?
If the injection experiment fails, it will not enter the "recover" func, so the experiment cannot be deleted.
This pr wants to merge these changes into master and release 1.2.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
