### PR TITLE
daemon: contain output in error when executing command 

### DIFF
--- a/pkg/chaosdaemon/dns_server.go
+++ b/pkg/chaosdaemon/dns_server.go
@@ -54,7 +54,7 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, err
+			return nil, encodeOutputToError(output, err)
 		}
 		if len(output) != 0 {
 			log.Info("command output", "output", string(output))
@@ -71,7 +71,7 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 		output, err = cmd.CombinedOutput()
 		if err != nil {
 			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, err
+			return nil, encodeOutputToError(output, err)
 		}
 		if len(output) != 0 {
 			log.Info("command output", "output", string(output))
@@ -87,7 +87,7 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, err
+			return nil, encodeOutputToError(output, err)
 		}
 		if len(output) != 0 {
 			log.Info("command output", "output", string(output))

--- a/pkg/chaosdaemon/ipset_server.go
+++ b/pkg/chaosdaemon/ipset_server.go
@@ -103,7 +103,7 @@ func createIPSet(ctx context.Context, enterNS bool, pid uint32, name string) err
 		output := string(out)
 		if !strings.Contains(output, ipsetExistErr) {
 			log.Error(err, "ipset create error", "command", cmd.String(), "output", output)
-			return err
+			return encodeOutputToError(out, err)
 		}
 
 		processBuilder = bpm.DefaultProcessBuilder("ipset", "flush", name).SetContext(ctx)
@@ -117,7 +117,7 @@ func createIPSet(ctx context.Context, enterNS bool, pid uint32, name string) err
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(err, "ipset flush error", "command", cmd.String(), "output", string(out))
-			return err
+			return encodeOutputToError(out, err)
 		}
 	}
 
@@ -138,7 +138,7 @@ func addCIDRsToIPSet(ctx context.Context, enterNS bool, pid uint32, name string,
 			output := string(out)
 			if !strings.Contains(output, ipExistErr) {
 				log.Error(err, "ipset add error", "command", cmd.String(), "output", output)
-				return err
+				return encodeOutputToError(out, err)
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func renameIPSet(ctx context.Context, enterNS bool, pid uint32, oldName string, 
 		output := string(out)
 		if !strings.Contains(output, ipsetNewNameExistErr) {
 			log.Error(err, "rename ipset failed", "command", cmd.String(), "output", output)
-			return err
+			return encodeOutputToError(out, err)
 		}
 
 		// swap the old ipset and the new ipset if the new ipset already exist.
@@ -174,7 +174,7 @@ func renameIPSet(ctx context.Context, enterNS bool, pid uint32, oldName string, 
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(err, "swap ipset failed", "command", cmd.String(), "output", string(out))
-			return err
+			return encodeOutputToError(out, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

create an attack by Chaosd and failed, the error message doesn't contain any useful information.
```bash
./bin/chaosd attack network loss -d eth0 -i 172.16.4.4 --percent 50
exit status 1
Error: exit status 1
```

### What is changed and how does it work?
 contain output in error when executing command 

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
