### PR TITLE
fixes opt.semgrep.sprintf-host-port

### DIFF
--- a/controllers/dnschaos/types.go
+++ b/controllers/dnschaos/types.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	dnspb "github.com/chaos-mesh/k8s_dns_chaos/pb"
@@ -229,7 +231,7 @@ func (r *endpoint) setDNSServerRules(dnsServerIP string, port int, name string, 
 		}
 	}
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", dnsServerIP, port), grpc.WithInsecure())
+	conn, err := grpc.Dial(net.JoinHostPort(dnsServerIP, strconv.Itoa(port)), grpc.WithInsecure())
 	if err != nil {
 		return err
 	}
@@ -258,7 +260,7 @@ func (r *endpoint) setDNSServerRules(dnsServerIP string, port int, name string, 
 }
 
 func (r *endpoint) cancelDNSServerRules(dnsServerIP string, port int, name string) error {
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", dnsServerIP, port), grpc.WithInsecure())
+	conn, err := grpc.Dial(net.JoinHostPort(dnsServerIP, strconv.Itoa(port)), grpc.WithInsecure())
 	if err != nil {
 		return err
 	}

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -14,8 +14,9 @@
 package apiserver
 
 import (
-	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 
 	"go.uber.org/fx"
 
@@ -44,7 +45,7 @@ var (
 )
 
 func serverRegister(r *gin.Engine, conf *config.ChaosDashboardConfig) {
-	listenAddr := fmt.Sprintf("%s:%d", conf.ListenHost, conf.ListenPort)
+	listenAddr := net.JoinHostPort(conf.ListenHost, strconv.Itoa(conf.ListenPort))
 
 	go r.Run(listenAddr)
 }

--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -17,9 +17,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net"
+	"strconv"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -61,12 +61,12 @@ type tlsConfig struct {
 
 // Get the http address
 func (c *Config) HttpAddr() string {
-	return fmt.Sprintf("%s:%d", c.Host, c.HTTPPort)
+	return net.JoinHostPort(c.Host, strconv.Itoa(c.HTTPPort))
 }
 
 // Get the grpc address
 func (c *Config) GrpcAddr() string {
-	return fmt.Sprintf("%s:%d", c.Host, c.GRPCPort)
+	return net.JoinHostPort(c.Host, strconv.Itoa(c.GRPCPort))
 }
 
 // DaemonServer represents a grpc server for tc daemon

--- a/pkg/grpc/utils.go
+++ b/pkg/grpc/utils.go
@@ -17,8 +17,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
+	"net"
+	"strconv"
 	"time"
 
 	"google.golang.org/grpc/credentials"
@@ -56,7 +57,7 @@ func CreateGrpcConnection(address string, port int, caCertPath string, certPath 
 	}
 	options := []grpc.DialOption{grpc.WithUnaryInterceptor(TimeoutClientInterceptor)}
 	options = append(options, grpc.WithInsecure())
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", address, port), options...)
+	conn, err := grpc.Dial(net.JoinHostPort(address, strconv.Itoa(port)), options...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func CreateGrpcConnectionFromRaw(address string, port int, caCert []byte, cert [
 	})
 	options = append(options, grpc.WithTransportCredentials(creds))
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", address, port),
+	conn, err := grpc.Dial(net.JoinHostPort(address, strconv.Itoa(port)),
 		options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: someshkoli <kolisomesh27@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
fixes opt.semgrep.sprintf-host-port by replacing it with `net.JoinHostPort`. 
### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
