### PR TITLE
add `check-install-script` task into dependencies of `check` task in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ go_build_cache_directory:
 	mkdir -p $(GO_BUILD_CACHE)/chaos-mesh-gobuild
 	mkdir -p $(GO_BUILD_CACHE)/chaos-mesh-gopath
 
-check: fmt vet boilerplate lint generate manifests/crd.yaml tidy
+check: fmt vet boilerplate lint generate manifests/crd.yaml tidy check-install-script
 
 # Run tests
 test: failpoint-enable generate generate-mock manifests test-utils


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
Sometimes we forget run `make check-install-script` before creating new PR, and CI doesn't check it.

### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
