### PR TITLE
fix storage class var name in helm

### DIFF
--- a/helm/chaos-mesh/templates/chaos-dashboard-pvc.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-pvc.yaml
@@ -10,11 +10,11 @@ metadata:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-dashboard
 spec:
-{{- if .Values.dashboard.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.dashboard.persistentVolume.storageClass) }}
+{{- if .Values.dashboard.persistentVolume.storageClassName }}
+{{- if (eq "-" .Values.dashboard.persistentVolume.storageClassName) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.dashboard.persistentVolume.storageClass }}"
+  storageClassName: "{{ .Values.dashboard.persistentVolume.storageClassName }}"
 {{- end }}
 {{- end }}
   accessModes:


### PR DESCRIPTION
### What problem does this PR solve?
In helm, persistent volume claim for chaos mesh dashboard is not creating due to the issue in PVC storage class variable name.

### What is changed and how does it work?
Used the correct storage class variable name in PVC template.
