### PR TITLE
[update] delete events if there are too many experiments

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -1125,6 +1125,12 @@ func (s *Service) batchDeleteExperiment(c *gin.Context) {
 	uidSlice = strings.Split(uids, ",")
 	errFlag = false
 
+	if len(uidSlice) > 100 {
+		c.Status(http.StatusBadRequest)
+		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(fmt.Errorf("too many uids, please reduce the number of uids")))
+		return
+	}
+
 	for _, uid := range uidSlice {
 		if exp, err = s.archive.FindByUID(context.Background(), uid); err != nil {
 			if gorm.IsRecordNotFoundError(err) {

--- a/pkg/store/event/event.go
+++ b/pkg/store/event/event.go
@@ -477,8 +477,13 @@ func (e *eventStore) DeleteByUIDs(_ context.Context, uids []string) error {
 	for _, et := range eventList {
 		eventIDList = append(eventIDList, et.ID)
 	}
-	if err = e.db.Model(core.PodRecord{}).Where("event_id IN (?)", eventIDList).Unscoped().Delete(core.PodRecord{}).Error; err != nil {
-		return err
+	splitNum :=len(eventIDList) / 100 + 1
+	splitEventIDList := splitArray(eventIDList,splitNum)
+
+	for _, etList := range splitEventIDList {
+		if err = e.db.Model(core.PodRecord{}).Where("event_id IN (?)", etList).Unscoped().Delete(core.PodRecord{}).Error; err != nil {
+			return err
+		}
 	}
 	return e.db.Where("experiment_id IN (?)", uids).Unscoped().Delete(core.Event{}).Error
 }
@@ -567,4 +572,24 @@ func constructQueryArgs(experimentName, experimentNamespace, uid, kind, startTim
 	}
 
 	return query, args
+}
+
+func splitArray (arr []uint, num int) ([][]uint) {
+	max := int(len(arr))
+	if max < num {
+		return nil
+	}
+	var segments =make([][]uint,0)
+	quantity:=max/num
+	end:=int(0)
+	for i := int(1); i <= num; i++ {
+		point :=i*quantity
+		if i != num {
+			segments= append(segments,arr[i-1+end:point])
+		}else {
+			segments= append(segments,arr[i-1+end:])
+		}
+		end=point-i
+	}
+	return segments
 }


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
The maxium sql variables in sqlite is 999, If there are too many events,  it maybe an error like this:
 
![image](https://user-images.githubusercontent.com/16437100/118856074-1dc18c80-b909-11eb-8f65-b4f8b58fa154.png)


### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
