### PR TITLE
chore: bump kind to 0.11.0 for cgroupv2

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -30,7 +30,7 @@ HELM_BIN=$OUTPUT_BIN/helm
 # (https://github.com/helm/helm/issues/6361) has been fixed.
 #
 HELM_VERSION=3.5.3
-KIND_VERSION=${KIND_VERSION:-0.10.0}
+KIND_VERSION=${KIND_VERSION:-0.11.0}
 KIND_BIN=$OUTPUT_BIN/kind
 KUBEBUILDER_PATH=$OUTPUT_BIN/kubebuilder
 KUBEBUILDER_BIN=$KUBEBUILDER_PATH/bin/kubebuilder


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

This PR bump the kind version to 0.11.0, for compatibility with cgroupv2.

I have tried kind 0.11.0 for several days, it works well with fedora 34 and cgourpv2. I do not have to raise another VM for e2e test anymore. :tada:

But the e2e test of stresschaos still not work fine with cgroupv2, I will try to fix it in next PR


### What is changed and how does it work?

just changing `KIND_VERSION`

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
