### PR TITLE
feat: also append workflow name for controlled chaos object

### DIFF
--- a/pkg/workflow/controllers/chaos_node_reconciler.go
+++ b/pkg/workflow/controllers/chaos_node_reconciler.go
@@ -196,6 +196,7 @@ func (it *ChaosNodeReconciler) createChaos(ctx context.Context, node v1alpha1.Wo
 	}))
 	meta.SetLabels(map[string]string{
 		v1alpha1.LabelControlledBy: node.Name,
+		v1alpha1.LabelWorkflow:     node.Spec.WorkflowName,
 	})
 
 	err = it.kubeClient.Create(ctx, chaosObject)


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Thanks to @fewdan , he notices me that I forget this thing.


### What is changed and how does it work?

Appending another label `chaos-mesh.org/workflow: <workflow-name>` for chaos objects which controlled by workflow.

 
### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
