### PR TITLE
Add webhook to reject updating chaos spec

### DIFF
--- a/api/v1alpha1/awschaos_webhook.go
+++ b/api/v1alpha1/awschaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -47,6 +48,9 @@ func (in *AwsChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *AwsChaos) ValidateUpdate(old runtime.Object) error {
 	awschaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*AwsChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/awschaos_webhook.go
+++ b/api/v1alpha1/awschaos_webhook.go
@@ -26,6 +26,9 @@ import (
 // log is for logging in this package.
 var awschaoslog = logf.Log.WithName("awschaos-resource")
 
+// updating spec of a chaos will have no effect, we'd better reject it
+var ErrCanNotUpdateChaos = fmt.Errorf("Cannot update chaos spec")
+
 // +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-awschaos,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=awschaos,verbs=create;update,versions=v1alpha1,name=mawschaos.kb.io
 
 var _ webhook.Defaulter = &AwsChaos{}
@@ -49,7 +52,7 @@ func (in *AwsChaos) ValidateCreate() error {
 func (in *AwsChaos) ValidateUpdate(old runtime.Object) error {
 	awschaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*AwsChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/dnschaos_webhook.go
+++ b/api/v1alpha1/dnschaos_webhook.go
@@ -51,7 +51,7 @@ func (in *DNSChaos) ValidateCreate() error {
 func (in *DNSChaos) ValidateUpdate(old runtime.Object) error {
 	dnschaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*DNSChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/dnschaos_webhook.go
+++ b/api/v1alpha1/dnschaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -49,6 +50,9 @@ func (in *DNSChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *DNSChaos) ValidateUpdate(old runtime.Object) error {
 	dnschaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*DNSChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/gcpchaos_webhook.go
+++ b/api/v1alpha1/gcpchaos_webhook.go
@@ -49,7 +49,7 @@ func (in *GcpChaos) ValidateCreate() error {
 func (in *GcpChaos) ValidateUpdate(old runtime.Object) error {
 	gcpchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*GcpChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/gcpchaos_webhook.go
+++ b/api/v1alpha1/gcpchaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -47,6 +48,9 @@ func (in *GcpChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *GcpChaos) ValidateUpdate(old runtime.Object) error {
 	gcpchaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*GcpChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -47,6 +48,9 @@ func (in *HTTPChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *HTTPChaos) ValidateUpdate(old runtime.Object) error {
 	httpchaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*HTTPChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -49,7 +49,7 @@ func (in *HTTPChaos) ValidateCreate() error {
 func (in *HTTPChaos) ValidateUpdate(old runtime.Object) error {
 	httpchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*HTTPChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/iochaos_webhook.go
+++ b/api/v1alpha1/iochaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,6 +59,9 @@ func (in *IOChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *IOChaos) ValidateUpdate(old runtime.Object) error {
 	iochaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*IoChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/iochaos_webhook.go
+++ b/api/v1alpha1/iochaos_webhook.go
@@ -59,7 +59,7 @@ func (in *IOChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *IOChaos) ValidateUpdate(old runtime.Object) error {
 	iochaoslog.Info("validate update", "name", in.Name)
-	if !reflect.DeepEqual(in.Spec, old.(*IoChaos).Spec) {
+	if !reflect.DeepEqual(in.Spec, old.(*IOChaos).Spec) {
 		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()

--- a/api/v1alpha1/iochaos_webhook.go
+++ b/api/v1alpha1/iochaos_webhook.go
@@ -60,7 +60,7 @@ func (in *IOChaos) ValidateCreate() error {
 func (in *IOChaos) ValidateUpdate(old runtime.Object) error {
 	iochaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*IoChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/jvmchaos_webhook.go
+++ b/api/v1alpha1/jvmchaos_webhook.go
@@ -53,7 +53,7 @@ func (in *JVMChaos) ValidateCreate() error {
 func (in *JVMChaos) ValidateUpdate(old runtime.Object) error {
 	jvmchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*JVMChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/jvmchaos_webhook.go
+++ b/api/v1alpha1/jvmchaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +52,9 @@ func (in *JVMChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *JVMChaos) ValidateUpdate(old runtime.Object) error {
 	jvmchaoslog.Info("validate update", "name", in.Name)
-
+	if !reflect.DeepEqual(in.Spec, old.(*JVMChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/kernelchaos_webhook.go
+++ b/api/v1alpha1/kernelchaos_webhook.go
@@ -51,7 +51,7 @@ func (in *KernelChaos) ValidateCreate() error {
 func (in *KernelChaos) ValidateUpdate(old runtime.Object) error {
 	kernelchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*KernelChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/kernelchaos_webhook.go
+++ b/api/v1alpha1/kernelchaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -49,6 +50,9 @@ func (in *KernelChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *KernelChaos) ValidateUpdate(old runtime.Object) error {
 	kernelchaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*KernelChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/networkchaos_webhook.go
+++ b/api/v1alpha1/networkchaos_webhook.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,9 @@ func (in *NetworkChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *NetworkChaos) ValidateUpdate(old runtime.Object) error {
 	networkchaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*NetworkChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/networkchaos_webhook.go
+++ b/api/v1alpha1/networkchaos_webhook.go
@@ -86,7 +86,7 @@ func (in *NetworkChaos) ValidateCreate() error {
 func (in *NetworkChaos) ValidateUpdate(old runtime.Object) error {
 	networkchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*NetworkChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/podchaos_webhook.go
+++ b/api/v1alpha1/podchaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -49,6 +50,9 @@ func (in *PodChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *PodChaos) ValidateUpdate(old runtime.Object) error {
 	podchaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*PodChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/podchaos_webhook.go
+++ b/api/v1alpha1/podchaos_webhook.go
@@ -51,7 +51,7 @@ func (in *PodChaos) ValidateCreate() error {
 func (in *PodChaos) ValidateUpdate(old runtime.Object) error {
 	podchaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*PodChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/stresschaos_webhook.go
+++ b/api/v1alpha1/stresschaos_webhook.go
@@ -62,7 +62,7 @@ func (in *StressChaos) ValidateCreate() error {
 func (in *StressChaos) ValidateUpdate(old runtime.Object) error {
 	stressChaosLog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*StressChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/api/v1alpha1/stresschaos_webhook.go
+++ b/api/v1alpha1/stresschaos_webhook.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/docker/go-units"
@@ -60,6 +61,9 @@ func (in *StressChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *StressChaos) ValidateUpdate(old runtime.Object) error {
 	stressChaosLog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*StressChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/timechaos_webhook.go
+++ b/api/v1alpha1/timechaos_webhook.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,6 +52,9 @@ func (in *TimeChaos) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (in *TimeChaos) ValidateUpdate(old runtime.Object) error {
 	timechaoslog.Info("validate update", "name", in.Name)
+	if !reflect.DeepEqual(in.Spec, old.(*TimeChaos).Spec) {
+		return fmt.Errorf("Cannot update chaos spec")
+	}
 	return in.Validate()
 }
 

--- a/api/v1alpha1/timechaos_webhook.go
+++ b/api/v1alpha1/timechaos_webhook.go
@@ -53,7 +53,7 @@ func (in *TimeChaos) ValidateCreate() error {
 func (in *TimeChaos) ValidateUpdate(old runtime.Object) error {
 	timechaoslog.Info("validate update", "name", in.Name)
 	if !reflect.DeepEqual(in.Spec, old.(*TimeChaos).Spec) {
-		return fmt.Errorf("Cannot update chaos spec")
+		return ErrCanNotUpdateChaos
 	}
 	return in.Validate()
 }

--- a/pkg/apiserver/event/event.go
+++ b/pkg/apiserver/event/event.go
@@ -63,7 +63,7 @@ func Register(r *gin.RouterGroup, s *Service) {
 // @Param name query string false "The name of the object"
 // @Param namespace query string false "The namespace of the object"
 // @Param object_id query string false "The UID of the object"
-// @Param kind query string false "kind" Enums(PodChaos, IoChaos, NetworkChaos, TimeChaos, KernelChaos, StressChaos, AwsChaos, GcpChaos, DNSChaos, Schedule)
+// @Param kind query string false "kind" Enums(PodChaos, IOChaos, NetworkChaos, TimeChaos, KernelChaos, StressChaos, AwsChaos, GcpChaos, DNSChaos, Schedule)
 // @Param limit query string false "The max length of events list"
 // @Success 200 {array} core.Event
 // @Router /events [get]


### PR DESCRIPTION
Signed-off-by: AsterNighT <klxjt99@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
fix #1905
### What is changed and how does it work?
Add webhook for updating chaos
I wonder what to do with chaos and workflow
### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
