### PR TITLE
fix: the bad camelCase conversion method

### DIFF
--- a/api/v1alpha1/zz_generated.schedule.chaosmesh.go
+++ b/api/v1alpha1/zz_generated.schedule.chaosmesh.go
@@ -57,15 +57,15 @@ type ScheduleItem struct {
 	// +optional
 	AwsChaos *AwsChaosSpec `json:"awsChaos,omitempty"`
 	// +optional
-	DNSChaos *DNSChaosSpec `json:"dNSChaos,omitempty"`
+	DNSChaos *DNSChaosSpec `json:"dnsChaos,omitempty"`
 	// +optional
 	GcpChaos *GcpChaosSpec `json:"gcpChaos,omitempty"`
 	// +optional
-	HTTPChaos *HTTPChaosSpec `json:"hTTPChaos,omitempty"`
+	HTTPChaos *HTTPChaosSpec `json:"httpChaos,omitempty"`
 	// +optional
-	IOChaos *IOChaosSpec `json:"iOChaos,omitempty"`
+	IOChaos *IOChaosSpec `json:"ioChaos,omitempty"`
 	// +optional
-	JVMChaos *JVMChaosSpec `json:"jVMChaos,omitempty"`
+	JVMChaos *JVMChaosSpec `json:"jvmChaos,omitempty"`
 	// +optional
 	KernelChaos *KernelChaosSpec `json:"kernelChaos,omitempty"`
 	// +optional

--- a/api/v1alpha1/zz_generated.workflow.chaosmesh.go
+++ b/api/v1alpha1/zz_generated.workflow.chaosmesh.go
@@ -55,15 +55,15 @@ type EmbedChaos struct {
 	// +optional
 	AwsChaos *AwsChaosSpec `json:"awsChaos,omitempty"`
 	// +optional
-	DNSChaos *DNSChaosSpec `json:"dNSChaos,omitempty"`
+	DNSChaos *DNSChaosSpec `json:"dnsChaos,omitempty"`
 	// +optional
 	GcpChaos *GcpChaosSpec `json:"gcpChaos,omitempty"`
 	// +optional
-	HTTPChaos *HTTPChaosSpec `json:"hTTPChaos,omitempty"`
+	HTTPChaos *HTTPChaosSpec `json:"httpChaos,omitempty"`
 	// +optional
-	IOChaos *IOChaosSpec `json:"iOChaos,omitempty"`
+	IOChaos *IOChaosSpec `json:"ioChaos,omitempty"`
 	// +optional
-	JVMChaos *JVMChaosSpec `json:"jVMChaos,omitempty"`
+	JVMChaos *JVMChaosSpec `json:"jvmChaos,omitempty"`
 	// +optional
 	KernelChaos *KernelChaosSpec `json:"kernelChaos,omitempty"`
 	// +optional

--- a/cmd/chaos-builder/workflow.go
+++ b/cmd/chaos-builder/workflow.go
@@ -16,9 +16,10 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/iancoleman/strcase"
 	"strings"
 	"text/template"
+
+	"github.com/iancoleman/strcase"
 )
 
 // struct workflowCodeGenerator will render content of one file contains code blocks that required by workflow

--- a/cmd/chaos-builder/workflow.go
+++ b/cmd/chaos-builder/workflow.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/iancoleman/strcase"
 	"strings"
 	"text/template"
 )
@@ -176,7 +177,13 @@ func generateEmbedChaos(typeName string) string {
 }
 
 func lowercaseCamelCase(str string) string {
-	return strings.ToLower(str[0:1]) + str[1:]
+	// here are some name thing issue about the acronyms, we used ALLCAP name in chaos kind, like DNSChaos or JVMChaos,
+	// library could not resolve that well, so we just manually do it.
+	if strings.Contains(str, "Chaos") {
+		position := strings.Index(str, "Chaos")
+		return strings.ToLower(str[:position]) + str[position:]
+	}
+	return strcase.ToLowerCamel(str)
 }
 
 const spawnObjectEntryTemplate = `	case Type{{.Type}}:

--- a/cmd/chaos-builder/workflow_test.go
+++ b/cmd/chaos-builder/workflow_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func Test_lowercaseCamelCase(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "common",
+			args: args{
+				str: "PodChaos",
+			},
+			want: "podChaos",
+		}, {
+			name: "ALLCAP",
+			args: args{
+				str: "DNSChaos",
+			},
+			want: "dnsChaos",
+		}, {
+			name: "ALLCAP",
+			args: args{
+				str: "JVMChaos",
+			},
+			want: "jvmChaos",
+		}, {
+			name: "workflow",
+			args: args{
+				str: "Workflow",
+			},
+			want: "workflow",
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lowercaseCamelCase(tt.args.str); got != tt.want {
+				t.Errorf("lowercaseCamelCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -72,7 +72,7 @@ spec:
               - Forbid
               - Allow
               type: string
-            dNSChaos:
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -214,7 +214,10 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            historyLimit:
+              minimum: 1
+              type: integer
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -398,10 +401,7 @@ spec:
               - selector
               - target
               type: object
-            historyLimit:
-              minimum: 1
-              type: integer
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -615,7 +615,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:
@@ -1574,7 +1574,7 @@ spec:
                         - awsRegion
                         - ec2Instance
                         type: object
-                      dNSChaos:
+                      dnsChaos:
                         description: DNSChaosSpec defines the desired state of DNSChaos
                         properties:
                           action:
@@ -1718,7 +1718,7 @@ spec:
                         - project
                         - zone
                         type: object
-                      hTTPChaos:
+                      httpChaos:
                         properties:
                           abort:
                             description: Abort is a rule to abort a http session.
@@ -1902,7 +1902,7 @@ spec:
                         - selector
                         - target
                         type: object
-                      iOChaos:
+                      ioChaos:
                         description: IOChaosSpec defines the desired state of IOChaos
                         properties:
                           action:
@@ -2116,7 +2116,7 @@ spec:
                         - selector
                         - volumePath
                         type: object
-                      jVMChaos:
+                      jvmChaos:
                         description: JVMChaosSpec defines the desired state of JVMChaos
                         properties:
                           action:

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -70,7 +70,10 @@ spec:
               - awsRegion
               - ec2Instance
               type: object
-            dNSChaos:
+            deadline:
+              format: date-time
+              type: string
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -176,9 +179,6 @@ spec:
               - mode
               - selector
               type: object
-            deadline:
-              format: date-time
-              type: string
             gcpChaos:
               description: GcpChaosSpec is the content of the specification for a GcpChaos
               properties:
@@ -215,7 +215,7 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -399,7 +399,7 @@ spec:
               - selector
               - target
               type: object
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -613,7 +613,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -75,7 +75,7 @@ spec:
                     - awsRegion
                     - ec2Instance
                     type: object
-                  dNSChaos:
+                  dnsChaos:
                     description: DNSChaosSpec defines the desired state of DNSChaos
                     properties:
                       action:
@@ -219,7 +219,7 @@ spec:
                     - project
                     - zone
                     type: object
-                  hTTPChaos:
+                  httpChaos:
                     properties:
                       abort:
                         description: Abort is a rule to abort a http session.
@@ -403,7 +403,7 @@ spec:
                     - selector
                     - target
                     type: object
-                  iOChaos:
+                  ioChaos:
                     description: IOChaosSpec defines the desired state of IOChaos
                     properties:
                       action:
@@ -617,7 +617,7 @@ spec:
                     - selector
                     - volumePath
                     type: object
-                  jVMChaos:
+                  jvmChaos:
                     description: JVMChaosSpec defines the desired state of JVMChaos
                     properties:
                       action:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -72,7 +72,7 @@ spec:
               - Forbid
               - Allow
               type: string
-            dNSChaos:
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -214,7 +214,10 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            historyLimit:
+              minimum: 1
+              type: integer
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -398,10 +401,7 @@ spec:
               - selector
               - target
               type: object
-            historyLimit:
-              minimum: 1
-              type: integer
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -615,7 +615,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:
@@ -1574,7 +1574,7 @@ spec:
                         - awsRegion
                         - ec2Instance
                         type: object
-                      dNSChaos:
+                      dnsChaos:
                         description: DNSChaosSpec defines the desired state of DNSChaos
                         properties:
                           action:
@@ -1718,7 +1718,7 @@ spec:
                         - project
                         - zone
                         type: object
-                      hTTPChaos:
+                      httpChaos:
                         properties:
                           abort:
                             description: Abort is a rule to abort a http session.
@@ -1902,7 +1902,7 @@ spec:
                         - selector
                         - target
                         type: object
-                      iOChaos:
+                      ioChaos:
                         description: IOChaosSpec defines the desired state of IOChaos
                         properties:
                           action:
@@ -2116,7 +2116,7 @@ spec:
                         - selector
                         - volumePath
                         type: object
-                      jVMChaos:
+                      jvmChaos:
                         description: JVMChaosSpec defines the desired state of JVMChaos
                         properties:
                           action:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -70,7 +70,10 @@ spec:
               - awsRegion
               - ec2Instance
               type: object
-            dNSChaos:
+            deadline:
+              format: date-time
+              type: string
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -176,9 +179,6 @@ spec:
               - mode
               - selector
               type: object
-            deadline:
-              format: date-time
-              type: string
             gcpChaos:
               description: GcpChaosSpec is the content of the specification for a GcpChaos
               properties:
@@ -215,7 +215,7 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -399,7 +399,7 @@ spec:
               - selector
               - target
               type: object
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -613,7 +613,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -75,7 +75,7 @@ spec:
                     - awsRegion
                     - ec2Instance
                     type: object
-                  dNSChaos:
+                  dnsChaos:
                     description: DNSChaosSpec defines the desired state of DNSChaos
                     properties:
                       action:
@@ -219,7 +219,7 @@ spec:
                     - project
                     - zone
                     type: object
-                  hTTPChaos:
+                  httpChaos:
                     properties:
                       abort:
                         description: Abort is a rule to abort a http session.
@@ -403,7 +403,7 @@ spec:
                     - selector
                     - target
                     type: object
-                  iOChaos:
+                  ioChaos:
                     description: IOChaosSpec defines the desired state of IOChaos
                     properties:
                       action:
@@ -617,7 +617,7 @@ spec:
                     - selector
                     - volumePath
                     type: object
-                  jVMChaos:
+                  jvmChaos:
                     description: JVMChaosSpec defines the desired state of JVMChaos
                     properties:
                       action:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -3165,7 +3165,7 @@ spec:
               - Forbid
               - Allow
               type: string
-            dNSChaos:
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -3348,7 +3348,10 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            historyLimit:
+              minimum: 1
+              type: integer
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -3583,10 +3586,7 @@ spec:
               - selector
               - target
               type: object
-            historyLimit:
-              minimum: 1
-              type: integer
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -3847,7 +3847,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:
@@ -5104,7 +5104,7 @@ spec:
                         - awsRegion
                         - ec2Instance
                         type: object
-                      dNSChaos:
+                      dnsChaos:
                         description: DNSChaosSpec defines the desired state of DNSChaos
                         properties:
                           action:
@@ -5300,7 +5300,7 @@ spec:
                         - project
                         - zone
                         type: object
-                      hTTPChaos:
+                      httpChaos:
                         properties:
                           abort:
                             description: Abort is a rule to abort a http session.
@@ -5550,7 +5550,7 @@ spec:
                         - selector
                         - target
                         type: object
-                      iOChaos:
+                      ioChaos:
                         description: IOChaosSpec defines the desired state of IOChaos
                         properties:
                           action:
@@ -5819,7 +5819,7 @@ spec:
                         - selector
                         - volumePath
                         type: object
-                      jVMChaos:
+                      jvmChaos:
                         description: JVMChaosSpec defines the desired state of JVMChaos
                         properties:
                           action:
@@ -7758,7 +7758,10 @@ spec:
               - awsRegion
               - ec2Instance
               type: object
-            dNSChaos:
+            deadline:
+              format: date-time
+              type: string
+            dnsChaos:
               description: DNSChaosSpec defines the desired state of DNSChaos
               properties:
                 action:
@@ -7902,9 +7905,6 @@ spec:
               - mode
               - selector
               type: object
-            deadline:
-              format: date-time
-              type: string
             gcpChaos:
               description: GcpChaosSpec is the content of the specification for a
                 GcpChaos
@@ -7944,7 +7944,7 @@ spec:
               - project
               - zone
               type: object
-            hTTPChaos:
+            httpChaos:
               properties:
                 abort:
                   description: Abort is a rule to abort a http session.
@@ -8179,7 +8179,7 @@ spec:
               - selector
               - target
               type: object
-            iOChaos:
+            ioChaos:
               description: IOChaosSpec defines the desired state of IOChaos
               properties:
                 action:
@@ -8440,7 +8440,7 @@ spec:
               - selector
               - volumePath
               type: object
-            jVMChaos:
+            jvmChaos:
               description: JVMChaosSpec defines the desired state of JVMChaos
               properties:
                 action:
@@ -9819,7 +9819,7 @@ spec:
                     - awsRegion
                     - ec2Instance
                     type: object
-                  dNSChaos:
+                  dnsChaos:
                     description: DNSChaosSpec defines the desired state of DNSChaos
                     properties:
                       action:
@@ -10011,7 +10011,7 @@ spec:
                     - project
                     - zone
                     type: object
-                  hTTPChaos:
+                  httpChaos:
                     properties:
                       abort:
                         description: Abort is a rule to abort a http session.
@@ -10254,7 +10254,7 @@ spec:
                     - selector
                     - target
                     type: object
-                  iOChaos:
+                  ioChaos:
                     description: IOChaosSpec defines the desired state of IOChaos
                     properties:
                       action:
@@ -10520,7 +10520,7 @@ spec:
                     - selector
                     - volumePath
                     type: object
-                  jVMChaos:
+                  jvmChaos:
                     description: JVMChaosSpec defines the desired state of JVMChaos
                     properties:
                       action:


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

Thanks @AsterNighT, there are some weird fields names in our generated definition,like:

https://github.com/chaos-mesh/chaos-mesh/blob/46ce60e620f2f4758ed9b25c8b93a460afa7d8b1/api/v1alpha1/zz_generated.schedule.chaosmesh.go#L56-82

take a look on hTTP, jVM, dNS.

### What is changed and how does it work?

more logic on `lowercaseCamelCase()`, resolve these ALLCAP name with prefix `Chaos`.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
