### PR TITLE
Fix: Check the length of array before using it in ParseNamespacedName and ParseNamespacedNameContainer functions 

### DIFF
--- a/controllers/utils/controller/key.go
+++ b/controllers/utils/controller/key.go
@@ -21,16 +21,28 @@ import (
 
 func ParseNamespacedName(namespacedName string) types.NamespacedName {
 	parts := strings.Split(namespacedName, "/")
-	return types.NamespacedName{
-		Namespace: parts[0],
-		Name:      parts[1],
+	if len(parts) > 1 {
+		return types.NamespacedName{
+			Namespace: parts[0],
+			Name:      parts[1],
+		}
 	}
+	return types.NamespacedName{
+		Namespace: "",
+		Name:      "",
+	} 
 }
 
 func ParseNamespacedNameContainer(namespacedName string) (types.NamespacedName, string) {
 	parts := strings.Split(namespacedName, "/")
+	if len(parts) > 2 {
+		return types.NamespacedName{
+			Namespace: parts[0],
+			Name:      parts[1],
+		}, strings.Join(parts[2:], "")
+	}
 	return types.NamespacedName{
-		Namespace: parts[0],
-		Name:      parts[1],
-	}, strings.Join(parts[2:], "")
+		Namespace: "",
+		Name:      "",
+	}, ""
 }


### PR DESCRIPTION
Fixes #1933

Hi @cwen0 ! 

i wasn't sure what to return if the length of `parts` array was less than expected. Could you guide me a little here?
Thank you!