### PR TITLE
fix(route): batch delete schedule archives

### DIFF
--- a/pkg/apiserver/archive/archive.go
+++ b/pkg/apiserver/archive/archive.go
@@ -74,7 +74,7 @@ func Register(r *gin.RouterGroup, s *Service) {
 	endpoint.GET("/schedules", s.listSchedule)
 	endpoint.GET("/schedules/:uid", s.detailSchedule)
 	endpoint.DELETE("/schedules/:uid", s.deleteSchedule)
-	endpoint.DELETE("/schedules/", s.batchDeleteSchedule)
+	endpoint.DELETE("/schedules", s.batchDeleteSchedule)
 }
 
 // Archive defines the basic information of an archive.


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What is changed and how does it work?

Change `/schedules/` to `/schedules` to correct the route matching. Before change, route `DELETE /archives/schedules` will jump into `DELETE /archives/:uid`. This is unexpected behavior.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
