### PR TITLE
[update] check schedule.IsPaused() before getRecentUnmetScheduleTime()

### DIFF
--- a/controllers/schedule/cron/controller.go
+++ b/controllers/schedule/cron/controller.go
@@ -56,6 +56,11 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
+	if schedule.IsPaused() {
+		r.Log.Info("not starting chaos as it is paused")
+		return ctrl.Result{}, nil
+	}
+
 	now := time.Now()
 	shouldSpawn := false
 	r.Log.Info("calculate schedule time", "schedule", schedule.Spec.Schedule, "lastScheduleTime", schedule.Status.LastScheduleTime, "now", now)
@@ -79,11 +84,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			})
 			return ctrl.Result{}, nil
 		}
-	}
-
-	if schedule.IsPaused() {
-		r.Log.Info("not starting chaos as it is paused")
-		return ctrl.Result{}, nil
 	}
 
 	r.Log.Info("schedule to spawn new chaos", "missedRun", missedRun, "nextRun", nextRun)


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
If a "schedule" has been suspended for a long time, there may be many errors during the suspension.

### What is changed and how it works?

Check schedule.IsPaused() before getRecentUnmetScheduleTime() . 
After the modification, there will not be many errors during the suspension.

What's Changed:

### Related changes

* None

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
