### PR TITLE
enable schedule webhook

### DIFF
--- a/cmd/chaos-controller-manager/main.go
+++ b/cmd/chaos-controller-manager/main.go
@@ -31,6 +31,7 @@ import (
 	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	apiWebhook "github.com/chaos-mesh/chaos-mesh/api/webhook"
 	"github.com/chaos-mesh/chaos-mesh/cmd/chaos-controller-manager/provider"
 	"github.com/chaos-mesh/chaos-mesh/controllers"
@@ -101,6 +102,13 @@ func Run(params RunParams) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	err = ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.Schedule{}).
+		Complete()
+	if err != nil {
+		return err
 	}
 
 	// Init metrics collector

--- a/helm/chaos-mesh/templates/secrets-configuration.yaml
+++ b/helm/chaos-mesh/templates/secrets-configuration.yaml
@@ -163,7 +163,11 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
+          {{- if eq $crd "schedule" }}
+          - schedules
+          {{- else }}
           - {{ $crd }}
+          {{- end }}
   {{- end }}
   {{- end }}
 

--- a/install.sh
+++ b/install.sh
@@ -1869,7 +1869,7 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - schedule
+          - schedules
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

Though we have developed webhook for `Schedule`. It doesn't work as the resources in the validation webhook haven't be configured properly. In this PR, I hard coded a plural form for the `schedule` resource in the webhook definition. 

If you have any better idea on how to generate a plural form of a word in helm, please tell me.