### PR TITLE
chore: change the status of workflow, keep same with chaos

### DIFF
--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -41,10 +41,10 @@ type WorkflowRepository interface {
 type WorkflowStatus string
 
 const (
-	WorkflowRunning WorkflowStatus = "Running"
-	WorkflowSucceed WorkflowStatus = "Succeed"
-	WorkflowFailed  WorkflowStatus = "Failed"
-	WorkflowUnknown WorkflowStatus = "Unknown"
+	WorkflowRunning WorkflowStatus = "running"
+	WorkflowSucceed WorkflowStatus = "finished"
+	WorkflowFailed  WorkflowStatus = "failed"
+	WorkflowUnknown WorkflowStatus = "unknown"
 )
 
 // Workflow defines the root structure of a workflow.

--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -47,7 +47,7 @@ const (
 	WorkflowUnknown WorkflowStatus = "unknown"
 )
 
-// Workflow defines the root structure of a workflow.
+// WorkflowMeta defines the root structure of a workflow.
 type WorkflowMeta struct {
 	ID        uint   `gorm:"primary_key" json:"id"`
 	Namespace string `json:"namespace"`
@@ -58,7 +58,7 @@ type WorkflowMeta struct {
 	EndTime   string         `json:"end_time"`
 	Status    WorkflowStatus `json:"status,omitempty"`
 	UID       string         `gorm:"index:uid" json:"uid"`
-	Archived  bool           `json:"archived"`
+	Archived  bool           `json:"-"`
 }
 
 type WorkflowDetail struct {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

Problem Summary:

- change values of `WorkflowMeta#WorkflowStatus`, keep the same with chaos' status
- ignore unused value `WorkflowMeta#Archived`

### What is changed and how it works?

What's Changed:

- change string const value of `WorkflowStatus`
- change the struct tag `json` of field `WorkflowStatus#Archived`

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: Yes.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
