### PR TITLE
Custom pause image for Pod Failure Chaos

### DIFF
--- a/controllers/chaosimpl/podchaos/podfailure/impl.go
+++ b/controllers/chaosimpl/podchaos/podfailure/impl.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+        "github.com/chaos-mesh/chaos-mesh/controllers/config"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/controller"
 	"github.com/chaos-mesh/chaos-mesh/pkg/annotation"
 )
@@ -58,7 +59,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 			continue
 		}
 		pod.Annotations[key] = originImage
-		pod.Spec.Containers[index].Image = pauseImage
+		pod.Spec.Containers[index].Image = config.ControllerCfg.PodFailurePauseImage
 	}
 
 	for index := range pod.Spec.InitContainers {
@@ -75,7 +76,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 			continue
 		}
 		pod.Annotations[key] = originImage
-		pod.Spec.InitContainers[index].Image = pauseImage
+		pod.Spec.InitContainers[index].Image = config.ControllerCfg.PodFailurePauseImage
 	}
 
 	err = impl.Update(ctx, &pod)

--- a/controllers/chaosimpl/podchaos/podfailure/impl.go
+++ b/controllers/chaosimpl/podchaos/podfailure/impl.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-        "github.com/chaos-mesh/chaos-mesh/controllers/config"
+	"github.com/chaos-mesh/chaos-mesh/controllers/config"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/controller"
 	"github.com/chaos-mesh/chaos-mesh/pkg/annotation"
 )

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -36,6 +36,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `controllerManager.affinity` |  Map of chaos-controller-manager node/pod affinities | `{}` |
 | `controllerManager.podAnnotations` |  Pod annotations of chaos-controller-manager | `{}`|
 | `controllerManager.enableFilterNamespace` | If enabled, only pods in the namespace annotated with `"chaos-mesh.org/inject": "enabled"` will be injected | false |
+| `controllerManager.podChaos.podFailure.pauseImage` | Custom Pause Container Image for Pod Failure Chaos | `gcr.io/google-containers/pause:latest` |
 | `chaosDaemon.image` | docker image for chaos-daemon | `pingcap/chaos-mesh:latest` |
 | `chaosDaemon.imagePullPolicy` | image pull policy | `Always` |
 | `chaosDaemon.grpcPort` | The port which grpc server listens on | `31767` |

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -87,6 +87,10 @@ spec:
           - name: BURST
             value: "50"
           {{- end }}
+          {{- if .Values.controllerManager.podChaos.podFailure.pauseImage }}
+          - name: POD_FAILURE_PAUSE_IMAGE
+            value: {{ .Values.controllerManager.podChaos.podFailure.pauseImage }}
+          {{- end }}
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -71,6 +71,10 @@ controllerManager:
   # This is Dangerous. Run only on temporary clusters.
   allowHostNetworkTesting: false
 
+  podChaos:
+    podFailure:
+      pauseImage: gcr.io/google-containers/pause:latest
+
 chaosDaemon:
   image: pingcap/chaos-daemon:latest
   imagePullPolicy: IfNotPresent

--- a/install.sh
+++ b/install.sh
@@ -1406,6 +1406,8 @@ spec:
             value: !!str 9288
           - name: SECURITY_MODE
             value: "false"
+          - name: POD_FAILURE_PAUSE_IMAGE
+            value: gcr.io/google-containers/pause:latest
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -78,6 +78,9 @@ type ChaosControllerConfig struct {
 
 	// AllowHostNetworkTesting removes the restriction on chaos testing pods with `hostNetwork` set to true
 	AllowHostNetworkTesting bool `envconfig:"ALLOW_HOST_NETWORK_TESTING" default:"false"`
+
+	// PodFailurePauseImage is used to set a custom image for pod failure
+	PodFailurePauseImage string `envconfig:"POD_FAILURE_PAUSE_IMAGE" default:"gcr.io/google-containers/pause:latest"`
 }
 
 // EnvironChaosController returns the settings from the environment.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1925

Problem Summary:

### What is changed and how it works?

Proposal: This PR allows users to specify a pod failure pause image via helm values. This is useful for for organizations who can only pull images from internal registries and also where organizations have policy applied where images can only come from xyz.com

What's Changed:

* Added a new environmental variable (controller deployment) for the pause image to the chaos controller
* Add this new environment variable to the controller config. Defaults to gcr.io pause image
* Add this controller config to the pod failure impl and set the pause image from this config


Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual Tests

Test 1
- Config Controller Mesh Deployment env to 

```
          - name: POD_FAILURE_PAUSE_IMAGE
            value: test.io/google-containers/pause:latest
```
- Install chaos mesh on kind with helm
```
./hack/local-up-chaos-mesh.sh
./install.sh --local kind --dependency-only
```
- Install sample nginx deployment
```
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 1
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
- Install Pod Failure 
```
apiVersion: chaos-mesh.org/v1alpha1
kind: PodChaos
metadata:
  name: pod-failure-example
spec:
  action: pod-failure
  mode: one
  value: ''
  selector:
    labelSelectors:
      'app': 'nginx'
```
- Get pod yaml and check if image is updated "test.io/google-containers/pause:latest"
- Delete pod failure chaos and get image and reverted back to original docker.io/library/nginx:1.14.2

Test 2
- Repeat Test 1, but revert install.sh POD_FAILURE_PAUSE_IMAGE back to the default gcr.io pause container. Get pod yaml of nginx pod and image should be updated to "gcr.io/google-containers/pause:latest". Delete pod failure chaos and get image and reverted back to original docker.io/library/nginx:1.14.2

```
          - name: POD_FAILURE_PAUSE_IMAGE
            value: gcr.io/google-containers/pause:latest
```



