### PR TITLE
chore: rename Tasks to Children

### DIFF
--- a/api/v1alpha1/workflownode_types.go
+++ b/api/v1alpha1/workflownode_types.go
@@ -49,7 +49,7 @@ type WorkflowNodeSpec struct {
 	// +optional
 	Task *Task `json:"task,omitempty"`
 	// +optional
-	Tasks []string `json:"tasks,omitempty"`
+	Children []string `json:"children,omitempty"`
 	// +optional
 	ConditionalBranches []ConditionalBranch `json:"conditionalBranches,omitempty"`
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3105,8 +3105,8 @@ func (in *WorkflowNodeSpec) DeepCopyInto(out *WorkflowNodeSpec) {
 		*out = new(Task)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Tasks != nil {
-		in, out := &in.Tasks, &out.Tasks
+	if in.Children != nil {
+		in, out := &in.Children, &out.Children
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -69,6 +69,10 @@ spec:
                 - awsRegion
                 - ec2Instance
                 type: object
+              children:
+                items:
+                  type: string
+                type: array
               conditionalBranches:
                 items:
                   properties:
@@ -9004,10 +9008,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              tasks:
-                items:
-                  type: string
-                type: array
               templateName:
                 type: string
               timeChaos:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -69,6 +69,10 @@ spec:
                 - awsRegion
                 - ec2Instance
                 type: object
+              children:
+                items:
+                  type: string
+                type: array
               conditionalBranches:
                 items:
                   properties:
@@ -9004,10 +9008,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              tasks:
-                items:
-                  type: string
-                type: array
               templateName:
                 type: string
               timeChaos:

--- a/manifests/crd-v1beta1.yaml
+++ b/manifests/crd-v1beta1.yaml
@@ -12417,6 +12417,10 @@ spec:
               - awsRegion
               - ec2Instance
               type: object
+            children:
+              items:
+                type: string
+              type: array
             conditionalBranches:
               items:
                 properties:
@@ -25396,10 +25400,6 @@ spec:
                     type: object
                   type: array
               type: object
-            tasks:
-              items:
-                type: string
-              type: array
             templateName:
               type: string
             timeChaos:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -12568,6 +12568,10 @@ spec:
                 - awsRegion
                 - ec2Instance
                 type: object
+              children:
+                items:
+                  type: string
+                type: array
               conditionalBranches:
                 items:
                   properties:
@@ -25775,10 +25779,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              tasks:
-                items:
-                  type: string
-                type: array
               templateName:
                 type: string
               timeChaos:

--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -98,12 +98,12 @@ type NodeNameWithTemplate struct {
 
 // NodeSerial defines SerialNode's specific fields.
 type NodeSerial struct {
-	Tasks []NodeNameWithTemplate `json:"tasks"`
+	Children []NodeNameWithTemplate `json:"children"`
 }
 
 // NodeParallel defines ParallelNode's specific fields.
 type NodeParallel struct {
-	Tasks []NodeNameWithTemplate `json:"tasks"`
+	Children []NodeNameWithTemplate `json:"children"`
 }
 
 // NodeType represents the type of a workflow node.
@@ -329,7 +329,7 @@ func convertWorkflowNode(kubeWorkflowNode v1alpha1.WorkflowNode) (Node, error) {
 			nodes = append(nodes, child.Name)
 		}
 		result.Serial = &NodeSerial{
-			Tasks: composeSerialTaskAndNodes(kubeWorkflowNode.Spec.Tasks, nodes),
+			Children: composeSerialTaskAndNodes(kubeWorkflowNode.Spec.Children, nodes),
 		}
 	} else if kubeWorkflowNode.Spec.Type == v1alpha1.TypeParallel {
 		var nodes []string
@@ -340,7 +340,7 @@ func convertWorkflowNode(kubeWorkflowNode v1alpha1.WorkflowNode) (Node, error) {
 			nodes = append(nodes, child.Name)
 		}
 		result.Parallel = &NodeParallel{
-			Tasks: composeParallelTaskAndNodes(kubeWorkflowNode.Spec.Tasks, nodes),
+			Children: composeParallelTaskAndNodes(kubeWorkflowNode.Spec.Children, nodes),
 		}
 	}
 
@@ -354,22 +354,22 @@ func convertWorkflowNode(kubeWorkflowNode v1alpha1.WorkflowNode) (Node, error) {
 }
 
 // composeSerialTaskAndNodes need nodes to be ordered with its creation time
-func composeSerialTaskAndNodes(tasks []string, nodes []string) []NodeNameWithTemplate {
+func composeSerialTaskAndNodes(children []string, nodes []string) []NodeNameWithTemplate {
 	var result []NodeNameWithTemplate
 	for _, node := range nodes {
 		// TODO: that reverse the generated name, maybe we could use WorkflowNode.TemplateName in the future
 		templateName := node[0:strings.LastIndex(node, "-")]
 		result = append(result, NodeNameWithTemplate{Name: node, Template: templateName})
 	}
-	for _, task := range tasks[len(nodes):] {
+	for _, task := range children[len(nodes):] {
 		result = append(result, NodeNameWithTemplate{Template: task})
 	}
 	return result
 }
 
-func composeParallelTaskAndNodes(tasks []string, nodes []string) []NodeNameWithTemplate {
+func composeParallelTaskAndNodes(children []string, nodes []string) []NodeNameWithTemplate {
 	var result []NodeNameWithTemplate
-	for _, task := range tasks {
+	for _, task := range children {
 		result = append(result, NodeNameWithTemplate{
 			Name:     "",
 			Template: task,

--- a/pkg/core/workflow_test.go
+++ b/pkg/core/workflow_test.go
@@ -343,7 +343,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 						TemplateName: "fake-serial-node",
 						WorkflowName: "fake-workflow-0",
 						Type:         v1alpha1.TypeSerial,
-						Tasks:        []string{"child-0", "child-1"},
+						Children:     []string{"child-0", "child-1"},
 					},
 					Status: v1alpha1.WorkflowNodeStatus{},
 				},
@@ -352,7 +352,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 				Name: "fake-serial-node-0",
 				Type: SerialNode,
 				Serial: &NodeSerial{
-					Tasks: []NodeNameWithTemplate{
+					Children: []NodeNameWithTemplate{
 						{Name: "", Template: "child-0"},
 						{Name: "", Template: "child-1"},
 					},
@@ -375,7 +375,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 						TemplateName: "parallel-node",
 						WorkflowName: "another-fake-workflow",
 						Type:         v1alpha1.TypeParallel,
-						Tasks:        []string{"child-1", "child-0"},
+						Children:     []string{"child-1", "child-0"},
 					},
 					Status: v1alpha1.WorkflowNodeStatus{},
 				},
@@ -385,7 +385,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 				Type:   ParallelNode,
 				Serial: nil,
 				Parallel: &NodeParallel{
-					Tasks: []NodeNameWithTemplate{
+					Children: []NodeNameWithTemplate{
 						{Name: "", Template: "child-1"},
 						{Name: "", Template: "child-0"},
 					},
@@ -447,7 +447,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 						TemplateName: "the-entry",
 						WorkflowName: "fake-workflow-0",
 						Type:         v1alpha1.TypeSerial,
-						Tasks:        []string{"unimportant-task-0"},
+						Children:     []string{"unimportant-task-0"},
 					},
 					Status: v1alpha1.WorkflowNodeStatus{
 						Conditions: []v1alpha1.WorkflowNodeCondition{
@@ -465,7 +465,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 				Type:  SerialNode,
 				State: NodeSucceed,
 				Serial: &NodeSerial{
-					Tasks: []NodeNameWithTemplate{
+					Children: []NodeNameWithTemplate{
 						{Name: "", Template: "unimportant-task-0"},
 					},
 				},
@@ -518,7 +518,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 						TemplateName: "the-entry",
 						WorkflowName: "fake-workflow-0",
 						Type:         v1alpha1.TypeSerial,
-						Tasks:        []string{"unimportant-task-0"},
+						Children:     []string{"unimportant-task-0"},
 					},
 					Status: v1alpha1.WorkflowNodeStatus{
 						Conditions: []v1alpha1.WorkflowNodeCondition{
@@ -536,7 +536,7 @@ func Test_convertWorkflowNode(t *testing.T) {
 				Type:  SerialNode,
 				State: NodeSucceed,
 				Serial: &NodeSerial{
-					Tasks: []NodeNameWithTemplate{
+					Children: []NodeNameWithTemplate{
 						{Name: "", Template: "unimportant-task-0"},
 					},
 				},
@@ -562,8 +562,8 @@ func Test_convertWorkflowNode(t *testing.T) {
 
 func Test_composeTaskAndNodes(t *testing.T) {
 	type args struct {
-		tasks []string
-		nodes []string
+		children []string
+		nodes    []string
 	}
 	tests := []struct {
 		name string
@@ -573,8 +573,8 @@ func Test_composeTaskAndNodes(t *testing.T) {
 		{
 			name: "ordered with serial",
 			args: args{
-				tasks: []string{"node-0", "node-1", "node-0", "node-2", "node-3"},
-				nodes: []string{"node-0-instance", "node-1-instance", "node-0-another_instance"},
+				children: []string{"node-0", "node-1", "node-0", "node-2", "node-3"},
+				nodes:    []string{"node-0-instance", "node-1-instance", "node-0-another_instance"},
 			},
 			want: []NodeNameWithTemplate{
 				{
@@ -598,7 +598,7 @@ func Test_composeTaskAndNodes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := composeSerialTaskAndNodes(tt.args.tasks, tt.args.nodes); !reflect.DeepEqual(got, tt.want) {
+			if got := composeSerialTaskAndNodes(tt.args.children, tt.args.nodes); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("composeSerialTaskAndNodes() = %v, want %v", got, tt.want)
 			}
 		})
@@ -607,8 +607,8 @@ func Test_composeTaskAndNodes(t *testing.T) {
 
 func Test_composeParallelTaskAndNodes(t *testing.T) {
 	type args struct {
-		tasks []string
-		nodes []string
+		children []string
+		nodes    []string
 	}
 	tests := []struct {
 		name string
@@ -618,8 +618,8 @@ func Test_composeParallelTaskAndNodes(t *testing.T) {
 		{
 			name: "parallel",
 			args: args{
-				tasks: []string{"node-a", "node-b", "node-a", "node-c", "node-d"},
-				nodes: []string{"node-a-instance", "node-a-another_instance", "node-d-instance"},
+				children: []string{"node-a", "node-b", "node-a", "node-c", "node-d"},
+				nodes:    []string{"node-a-instance", "node-a-another_instance", "node-d-instance"},
 			},
 			want: []NodeNameWithTemplate{
 				{
@@ -643,7 +643,7 @@ func Test_composeParallelTaskAndNodes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := composeParallelTaskAndNodes(tt.args.tasks, tt.args.nodes); !reflect.DeepEqual(got, tt.want) {
+			if got := composeParallelTaskAndNodes(tt.args.children, tt.args.nodes); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("composeParallelTaskAndNodes() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/workflow/controllers/new_node.go
+++ b/pkg/workflow/controllers/new_node.go
@@ -64,7 +64,7 @@ func renderNodesByTemplates(workflow *v1alpha1.Workflow, parent *v1alpha1.Workfl
 					Type:                template.Type,
 					StartTime:           &now,
 					Deadline:            deadline,
-					Tasks:               template.Children,
+					Children:            template.Children,
 					Task:                template.Task,
 					ConditionalBranches: template.ConditionalBranches,
 					EmbedChaos:          template.EmbedChaos,

--- a/pkg/workflow/controllers/parallel_node_reconciler.go
+++ b/pkg/workflow/controllers/parallel_node_reconciler.go
@@ -107,7 +107,7 @@ func (it *ParallelNodeReconciler) Reconcile(request reconcile.Request) (reconcil
 		}
 
 		// TODO: also check the consistent between spec in task and the spec in child node
-		if len(finishedChildren) == len(nodeNeedUpdate.Spec.Tasks) {
+		if len(finishedChildren) == len(nodeNeedUpdate.Spec.Children) {
 			SetCondition(&nodeNeedUpdate.Status, v1alpha1.WorkflowNodeCondition{
 				Type:   v1alpha1.ConditionAccomplished,
 				Status: corev1.ConditionTrue,
@@ -135,7 +135,7 @@ func (it *ParallelNodeReconciler) Reconcile(request reconcile.Request) (reconcil
 func (it *ParallelNodeReconciler) syncChildNodes(ctx context.Context, node v1alpha1.WorkflowNode) error {
 
 	// empty parallel node
-	if len(node.Spec.Tasks) == 0 {
+	if len(node.Spec.Children) == 0 {
 		it.logger.V(4).Info("empty parallel node, NOOP",
 			"node", fmt.Sprintf("%s/%s", node.Namespace, node.Name),
 		)
@@ -157,9 +157,9 @@ func (it *ParallelNodeReconciler) syncChildNodes(ctx context.Context, node v1alp
 
 	// TODO: check the specific of task and workflow nodes
 	// the definition of Spec.Children changed, remove all the existed nodes
-	if len(setDifference(taskNamesOfNodes, node.Spec.Tasks)) > 0 ||
-		len(setDifference(node.Spec.Tasks, taskNamesOfNodes)) > 0 {
-		tasksToStartup = node.Spec.Tasks
+	if len(setDifference(taskNamesOfNodes, node.Spec.Children)) > 0 ||
+		len(setDifference(node.Spec.Children, taskNamesOfNodes)) > 0 {
+		tasksToStartup = node.Spec.Children
 		for _, childNode := range existsChildNodes {
 			// best effort deletion
 			err := it.kubeClient.Delete(ctx, &childNode)

--- a/pkg/workflow/controllers/serial_node_reconciler.go
+++ b/pkg/workflow/controllers/serial_node_reconciler.go
@@ -127,7 +127,7 @@ func (it *SerialNodeReconciler) Reconcile(request reconcile.Request) (reconcile.
 		}
 
 		// TODO: also check the consistent between spec in task and the spec in child node
-		if len(finishedChildren) == len(nodeNeedUpdate.Spec.Tasks) {
+		if len(finishedChildren) == len(nodeNeedUpdate.Spec.Children) {
 			SetCondition(&nodeNeedUpdate.Status, v1alpha1.WorkflowNodeCondition{
 				Type:   v1alpha1.ConditionAccomplished,
 				Status: corev1.ConditionTrue,
@@ -160,7 +160,7 @@ func (it *SerialNodeReconciler) Reconcile(request reconcile.Request) (reconcile.
 func (it *SerialNodeReconciler) syncChildNodes(ctx context.Context, node v1alpha1.WorkflowNode) error {
 
 	// empty serial node
-	if len(node.Spec.Tasks) == 0 {
+	if len(node.Spec.Children) == 0 {
 		it.logger.V(4).Info("empty serial node, NOOP",
 			"node", fmt.Sprintf("%s/%s", node.Namespace, node.Name),
 		)
@@ -174,7 +174,7 @@ func (it *SerialNodeReconciler) syncChildNodes(ctx context.Context, node v1alpha
 	var taskToStartup string
 	if len(activeChildNodes) == 0 {
 		// no active children, trying to spawn a new one
-		for index, task := range node.Spec.Tasks {
+		for index, task := range node.Spec.Children {
 			// Walking through on the Spec.Children, each one of task SHOULD has one corresponding workflow node;
 			// If the spec of one task has been changed, the corresponding workflow node and other
 			// workflow nodes **behinds** that workflow node will be deleted.


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?


### What is changed and how it works?

The reset part of #1984.

What's Changed:
- rename field `WorkflowNodeSpec#Tasks` -> `WorkflowNodeSpec#Children`
- rename `Tasks` to `Children` in `pkg/core/workflow.go`
### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: Yes.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
