### PR TITLE
chaosRecorder: submit events without kubernetes event recorder

### DIFF
--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -46,12 +46,13 @@ type ChaosImplPair struct {
 type Params struct {
 	fx.In
 
-	Mgr      ctrl.Manager
-	Client   client.Client
-	Logger   logr.Logger
-	Selector *selector.Selector
-	Impls    []*ChaosImplPair `group:"impl"`
-	Reader   client.Reader    `name:"no-cache"`
+	Mgr             ctrl.Manager
+	Client          client.Client
+	Logger          logr.Logger
+	Selector        *selector.Selector
+	RecorderBuilder *recorder.RecorderBuilder
+	Impls           []*ChaosImplPair `group:"impl"`
+	Reader          client.Reader    `name:"no-cache"`
 }
 
 func NewController(params Params) (types.Controller, error) {
@@ -61,6 +62,7 @@ func NewController(params Params) (types.Controller, error) {
 	client := params.Client
 	reader := params.Reader
 	selector := params.Selector
+	recorderBuilder := params.RecorderBuilder
 
 	setupLog := logger.WithName("setup-common")
 	for _, pair := range pairs {
@@ -116,7 +118,7 @@ func NewController(params Params) (types.Controller, error) {
 			Object:   pair.Object,
 			Client:   client,
 			Reader:   reader,
-			Recorder: recorder.NewRecorder(mgr, "common", logger),
+			Recorder: recorderBuilder.Build("records"),
 			Selector: selector,
 			Log:      logger.WithName("records"),
 		})

--- a/controllers/desiredphase/fx.go
+++ b/controllers/desiredphase/fx.go
@@ -30,7 +30,7 @@ type Objs struct {
 	Objs []types.Object `group:"objs"`
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, pairs Objs) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, recorderBuilder *recorder.RecorderBuilder, pairs Objs) (types.Controller, error) {
 	for _, obj := range pairs.Objs {
 
 		err := builder.Default(mgr).
@@ -39,7 +39,7 @@ func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, p
 			Complete(&Reconciler{
 				Object:   obj.Object,
 				Client:   client,
-				Recorder: recorder.NewRecorder(mgr, "desiredphase", logger),
+				Recorder: recorderBuilder.Build("desiredphase"),
 				Log:      logger.WithName("desiredphase"),
 			})
 		if err != nil {

--- a/controllers/finalizers/fx.go
+++ b/controllers/finalizers/fx.go
@@ -30,7 +30,7 @@ type Objs struct {
 	Objs []types.Object `group:"objs"`
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, pairs Objs) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, recorderBuilder *recorder.RecorderBuilder, pairs Objs) (types.Controller, error) {
 	for _, obj := range pairs.Objs {
 		err := builder.Default(mgr).
 			For(obj.Object).
@@ -38,7 +38,7 @@ func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, p
 			Complete(&Reconciler{
 				Object:   obj.Object,
 				Client:   client,
-				Recorder: recorder.NewRecorder(mgr, "finalizer", logger),
+				Recorder: recorderBuilder.Build("finalizer"),
 				Log:      logger.WithName("finalizers"),
 			})
 		if err != nil {

--- a/controllers/fx.go
+++ b/controllers/fx.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/podnetworkchaos"
 	"github.com/chaos-mesh/chaos-mesh/controllers/schedule"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 	wfcontrollers "github.com/chaos-mesh/chaos-mesh/pkg/workflow/controllers"
 )
 
@@ -61,6 +62,7 @@ var Module = fx.Options(
 		},
 
 		chaosdaemon.New,
+		recorder.NewRecorderBuilder,
 	),
 	fx.Invoke(wfcontrollers.BootstrapWorkflowControllers),
 	schedule.Module,

--- a/controllers/podnetworkchaos/fx.go
+++ b/controllers/podnetworkchaos/fx.go
@@ -30,7 +30,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 )
 
-func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, b *chaosdaemon.ChaosDaemonClientBuilder) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, b *chaosdaemon.ChaosDaemonClientBuilder, recorderBuilder *recorder.RecorderBuilder) (types.Controller, error) {
 	err := builder.Default(mgr).
 		For(&v1alpha1.PodNetworkChaos{}).
 		Named("podnetworkchaos").
@@ -45,7 +45,7 @@ func NewController(mgr ctrl.Manager, client client.Client, logger logr.Logger, b
 		Complete(&Reconciler{
 			Client:   client,
 			Log:      logger.WithName("podnetworkchaos"),
-			Recorder: recorder.NewRecorder(mgr, "podnetworkchaos", logger),
+			Recorder: recorderBuilder.Build("podnetworkchaos"),
 
 			// TODO:
 			AllowHostNetworkTesting:  config.ControllerCfg.AllowHostNetworkTesting,

--- a/controllers/schedule/active/controller.go
+++ b/controllers/schedule/active/controller.go
@@ -140,7 +140,7 @@ type Objs struct {
 	Objs []types.Object `group:"objs"`
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs Objs, scheme *runtime.Scheme, lister *utils.ActiveLister) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs Objs, scheme *runtime.Scheme, lister *utils.ActiveLister, recorderBuilder *recorder.RecorderBuilder) (types.Controller, error) {
 	builder := builder.Default(mgr).
 		For(&v1alpha1.Schedule{}).
 		Named("schedule-active")
@@ -156,7 +156,7 @@ func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs
 		client,
 		log.WithName("schedule-active"),
 		lister,
-		recorder.NewRecorder(mgr, "schedule-active", log),
+		recorderBuilder.Build("schedule-active"),
 	})
 	return "schedule-active", nil
 }

--- a/controllers/schedule/cron/controller.go
+++ b/controllers/schedule/cron/controller.go
@@ -212,7 +212,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, lister *utils.ActiveLister) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, lister *utils.ActiveLister, recorderBuilder *recorder.RecorderBuilder) (types.Controller, error) {
 	builder.Default(mgr).
 		For(&v1alpha1.Schedule{}).
 		Named("schedule-cron").
@@ -220,7 +220,7 @@ func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, list
 			client,
 			log.WithName("schedule-cron"),
 			lister,
-			recorder.NewRecorder(mgr, "schedule-cron", log),
+			recorderBuilder.Build("schedule-cron"),
 		})
 	return "schedule-cron", nil
 }

--- a/controllers/schedule/gc/controller.go
+++ b/controllers/schedule/gc/controller.go
@@ -139,7 +139,7 @@ type Objs struct {
 	Objs         []types.Object `group:"objs"`
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs Objs, scheme *runtime.Scheme, lister *utils.ActiveLister) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs Objs, scheme *runtime.Scheme, lister *utils.ActiveLister, recorderBuilder *recorder.RecorderBuilder) (types.Controller, error) {
 	builder := builder.Default(mgr).
 		For(&v1alpha1.Schedule{}).
 		Named("schedule-gc")
@@ -154,7 +154,7 @@ func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, objs
 	builder.Complete(&Reconciler{
 		client,
 		log.WithName("schedule-gc"),
-		recorder.NewRecorder(mgr, "schedule-gc", log),
+		recorderBuilder.Build("schedule-gc"),
 		lister,
 	})
 	return "schedule-gc", nil

--- a/controllers/schedule/pause/controller.go
+++ b/controllers/schedule/pause/controller.go
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, lister *utils.ActiveLister) (types.Controller, error) {
+func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, lister *utils.ActiveLister, recorderBuilder *recorder.RecorderBuilder) (types.Controller, error) {
 	builder.Default(mgr).
 		For(&v1alpha1.Schedule{}).
 		Named("schedule-pause").
@@ -117,7 +117,7 @@ func NewController(mgr ctrl.Manager, client client.Client, log logr.Logger, list
 			client,
 			log.WithName("schedule-pause"),
 			lister,
-			recorder.NewRecorder(mgr, "schedule-pause", log),
+			recorderBuilder.Build("schedule-pause"),
 		})
 	return "schedule-pause", nil
 }

--- a/controllers/schedule/suit_test.go
+++ b/controllers/schedule/suit_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/schedule/utils"
 	"github.com/chaos-mesh/chaos-mesh/controllers/types"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/workflow/controllers"
 )
@@ -116,8 +117,9 @@ var _ = AfterSuite(func() {
 type RunParams struct {
 	fx.In
 
-	Mgr    ctrl.Manager
-	Logger logr.Logger
+	Mgr             ctrl.Manager
+	Logger          logr.Logger
+	RecorderBuilder *recorder.RecorderBuilder
 
 	Controllers []types.Controller `group:"controller"`
 	Objs        []types.Object     `group:"objs"`
@@ -125,7 +127,7 @@ type RunParams struct {
 
 func Run(params RunParams) error {
 	lister = utils.NewActiveLister(k8sClient, params.Logger)
-	err := controllers.BootstrapWorkflowControllers(params.Mgr, params.Logger)
+	err := controllers.BootstrapWorkflowControllers(params.Mgr, params.Logger, params.RecorderBuilder)
 	if err != nil {
 		return err
 	}

--- a/controllers/utils/recorder/recorder.go
+++ b/controllers/utils/recorder/recorder.go
@@ -42,9 +42,6 @@ type chaosRecorder struct {
 	scheme *runtime.Scheme
 }
 
-// TODO: make `deadline` configurable
-const deadline = 15 * time.Second
-
 func (r *chaosRecorder) Event(object runtime.Object, ev ChaosEvent) {
 	eventtype := ev.Type()
 	reason := ev.Reason()

--- a/controllers/utils/recorder/recorder.go
+++ b/controllers/utils/recorder/recorder.go
@@ -14,15 +14,21 @@
 package recorder
 
 import (
+	"context"
+	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/iancoleman/strcase"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/client-go/tools/record/util"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ChaosRecorder interface {
@@ -30,17 +36,66 @@ type ChaosRecorder interface {
 }
 
 type chaosRecorder struct {
-	recorder record.EventRecorder
-	log      logr.Logger
+	log    logr.Logger
+	source v1.EventSource
+	client client.Client
+	scheme *runtime.Scheme
 }
 
+// TODO: make `deadline` configurable
+const deadline = 15 * time.Second
+
 func (r *chaosRecorder) Event(object runtime.Object, ev ChaosEvent) {
+	eventtype := ev.Type()
+	reason := ev.Reason()
+	message := ev.Message()
+
 	annotations, err := generateAnnotations(ev)
 	if err != nil {
 		r.log.Error(err, "failed to generate annotations for event", "event", ev)
 	}
 
-	r.recorder.AnnotatedEventf(object, annotations, ev.Type(), ev.Reason(), ev.Message())
+	ref, err := ref.GetReference(r.scheme, object)
+	if err != nil {
+		r.log.Error(err, "fail to construct reference", "object", object)
+		return
+	}
+
+	if !util.ValidateEventType(eventtype) {
+		klog.Errorf("Unsupported event type: '%v'", eventtype)
+		return
+	}
+
+	event := r.makeEvent(ref, annotations, eventtype, reason, message)
+	event.Source = r.source
+	go func() {
+		err := r.client.Create(context.TODO(), event)
+		if err != nil {
+			r.log.Error(err, "fail to submit event", "event", event)
+		}
+	}()
+}
+
+func (r *chaosRecorder) makeEvent(ref *v1.ObjectReference, annotations map[string]string, eventtype, reason, message string) *v1.Event {
+	t := metav1.Time{Time: time.Now()}
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        message,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventtype,
+	}
 }
 
 type ChaosEvent interface {
@@ -60,10 +115,28 @@ func register(ev ...ChaosEvent) {
 	}
 }
 
-func NewRecorder(mgr ctrl.Manager, name string, logger logr.Logger) ChaosRecorder {
+type RecorderBuilder struct {
+	c      client.Client
+	logger logr.Logger
+	scheme *runtime.Scheme
+}
+
+func (b *RecorderBuilder) Build(name string) ChaosRecorder {
 	return &chaosRecorder{
-		mgr.GetEventRecorderFor(name),
-		logger.WithName("event-recorder" + name),
+		log: b.logger.WithName("event-recorder-" + name),
+		source: v1.EventSource{
+			Component: name,
+		},
+		client: b.c,
+		scheme: b.scheme,
+	}
+}
+
+func NewRecorderBuilder(c client.Client, logger logr.Logger, scheme *runtime.Scheme) *RecorderBuilder {
+	return &RecorderBuilder{
+		c,
+		logger,
+		scheme,
 	}
 }
 

--- a/controllers/utils/test/provider.go
+++ b/controllers/utils/test/provider.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/cmd/chaos-controller-manager/provider"
 	ccfg "github.com/chaos-mesh/chaos-mesh/controllers/config"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 )
 
 func NewTestManager(lc fx.Lifecycle, options *ctrl.Options, cfg *rest.Config) (ctrl.Manager, error) {
@@ -70,4 +71,5 @@ var Module = fx.Provide(
 	provider.NewGlobalCacheReader,
 	provider.NewControlPlaneCacheReader,
 	NewTestManager,
+	recorder.NewRecorderBuilder,
 )

--- a/pkg/workflow/controllers/bootstrap.go
+++ b/pkg/workflow/controllers/bootstrap.go
@@ -24,7 +24,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 )
 
-func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error {
+func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger, recorderBuilder *recorder.RecorderBuilder) error {
 	noCacheClient, err := client.New(mgr.GetConfig(), client.Options{
 		Scheme: mgr.GetScheme(),
 		Mapper: mgr.GetRESTMapper(),
@@ -39,7 +39,7 @@ func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error
 		Complete(
 			NewWorkflowEntryReconciler(
 				mgr.GetClient(),
-				recorder.NewRecorder(mgr, "workflow-entry-reconciler", logger.WithName("workflow-entry-reconciler")),
+				recorderBuilder.Build("workflow-entry-reconciler"),
 				logger.WithName("workflow-entry-reconciler"),
 			),
 		)
@@ -56,7 +56,7 @@ func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error
 		Complete(
 			NewSerialNodeReconciler(
 				noCacheClient,
-				recorder.NewRecorder(mgr, "workflow-serial-node-reconciler", logger.WithName("workflow-serial-node-reconciler")),
+				recorderBuilder.Build("workflow-serial-node-reconciler"),
 				logger.WithName("workflow-serial-node-reconciler"),
 			),
 		)
@@ -71,7 +71,7 @@ func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error
 		Complete(
 			NewParallelNodeReconciler(
 				noCacheClient,
-				recorder.NewRecorder(mgr, "workflow-parallel-node-reconciler", logger.WithName("workflow-parallel-node-reconciler")),
+				recorderBuilder.Build("workflow-parallel-node-reconciler"),
 				logger.WithName("workflow-parallel-node-reconciler"),
 			),
 		)
@@ -85,7 +85,7 @@ func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error
 		Complete(
 			NewDeadlineReconciler(
 				mgr.GetClient(),
-				recorder.NewRecorder(mgr, "workflow-deadline-reconciler", logger.WithName("workflow-deadline-reconciler")),
+				recorderBuilder.Build("workflow-deadline-reconciler"),
 				logger.WithName("workflow-deadline-reconciler"),
 			),
 		)
@@ -99,7 +99,7 @@ func BootstrapWorkflowControllers(mgr manager.Manager, logger logr.Logger) error
 		Complete(
 			NewChaosNodeReconciler(
 				mgr.GetClient(),
-				recorder.NewRecorder(mgr, "workflow-chaos-node-reconciler", logger.WithName("workflow-chaos-node-reconciler")),
+				recorderBuilder.Build("workflow-chaos-node-reconciler"),
 				logger.WithName("workflow-chaos-node-reconciler"),
 			),
 		)


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

### What problem does this PR solve?

No events will be aggregated now.

### What is changed and how it works?

Submit every events manually, without the handling of kubernetes client event recorder.