### PR TITLE
helm: fix environment variable name

### DIFF
--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             value: "{{ .Values.clusterScoped }}"
           - name: TZ
             value: {{ .Values.timezone | default "UTC" }}
-          - name: CHAOS_DAEMON_PORT
+          - name: CHAOS_DAEMON_SERVICE_PORT
             value: !!str {{ .Values.chaosDaemon.grpcPort }}
           - name: BPFKI_PORT
             value: !!str {{ .Values.bpfki.grpcPort }}

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   type: {{ .Values.controllerManager.service.type }}
   ports:
+    - port: 443
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
   {{- if .Values.enableProfiling }}
     - port: 10081
       targetPort: pprof
@@ -19,10 +23,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 443
-      targetPort: webhook
-      protocol: TCP
-      name: webhook
   selector:
     {{- include "chaos-mesh.selectors" . | nindent 4 }}
     app.kubernetes.io/component: controller-manager

--- a/install.sh
+++ b/install.sh
@@ -1164,6 +1164,10 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 443
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
     - port: 10081
       targetPort: pprof
       protocol: TCP
@@ -1172,10 +1176,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 443
-      targetPort: webhook
-      protocol: TCP
-      name: webhook
   selector:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
@@ -1388,7 +1388,7 @@ spec:
             value: "true"
           - name: TZ
             value: ${timezone}
-          - name: CHAOS_DAEMON_PORT
+          - name: CHAOS_DAEMON_SERVICE_PORT
             value: !!str 31767
           - name: BPFKI_PORT
             value: !!str 50051

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -34,7 +34,7 @@ type TLSConfig struct {
 // ChaosControllerConfig defines the configuration for Chaos Controller
 type ChaosControllerConfig struct {
 	// ChaosDaemonPort is the port which grpc server listens on
-	ChaosDaemonPort int `envconfig:"CHAOS_DAEMON_PORT" default:"31767"`
+	ChaosDaemonPort int `envconfig:"CHAOS_DAEMON_SERVICE_PORT" default:"31767"`
 
 	TLSConfig
 


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

### What problem does this PR solve?

According to the [environment variable](https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables) section in kubernetes docs, these environment variables are set like:

```
REDIS_MASTER_SERVICE_HOST=10.0.0.11
REDIS_MASTER_SERVICE_PORT=6379
REDIS_MASTER_PORT=tcp://10.0.0.11:6379
REDIS_MASTER_PORT_6379_TCP=tcp://10.0.0.11:6379
REDIS_MASTER_PORT_6379_TCP_PROTO=tcp
REDIS_MASTER_PORT_6379_TCP_PORT=6379
REDIS_MASTER_PORT_6379_TCP_ADDR=10.0.0.11
```

Therefore, the `CHAOS_DAEMON_PORT` would be `tcp://xxx.xxx.xxx.xxx:xxxx` but not the direct port number. 

### What is changed and how it works?

Change the name of environment variable from `CHAOS_DAEMON_PORT` to `CHAOS_DAEMON_SERVICE_PORT`.