### PR TITLE
fix: add max validation to workers in stress chaos

### DIFF
--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -134,6 +134,8 @@ func (in *Stressors) Normalize() (string, error) {
 // Stressor defines common configurations of a stressor
 type Stressor struct {
 	// Workers specifies N workers to apply the stressor.
+	// Maximum 8192 workers can run by stress-ng
+	// +kubebuilder:validation:Maximum=8192
 	Workers int `json:"workers"`
 }
 

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -1397,7 +1397,8 @@ spec:
                               type: string
                             type: array
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -1414,7 +1415,8 @@ spec:
                             description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                             type: string
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -4174,7 +4176,8 @@ spec:
                                             type: string
                                           type: array
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -4191,7 +4194,8 @@ spec:
                                           description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                           type: string
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -4419,7 +4423,8 @@ spec:
                                         type: string
                                       type: array
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -4436,7 +4441,8 @@ spec:
                                       description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                       type: string
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers

--- a/config/crd/bases/chaos-mesh.org_stresschaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_stresschaos.yaml
@@ -134,7 +134,8 @@ spec:
                           type: string
                         type: array
                       workers:
-                        description: Workers specifies N workers to apply the stressor.
+                        description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers
@@ -151,7 +152,8 @@ spec:
                         description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                         type: string
                       workers:
-                        description: Workers specifies N workers to apply the stressor.
+                        description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -2665,7 +2665,8 @@ spec:
                                   type: string
                                 type: array
                               workers:
-                                description: Workers specifies N workers to apply the stressor.
+                                description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -2682,7 +2683,8 @@ spec:
                                 description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                 type: string
                               workers:
-                                description: Workers specifies N workers to apply the stressor.
+                                description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -5442,7 +5444,8 @@ spec:
                                                 type: string
                                               type: array
                                             workers:
-                                              description: Workers specifies N workers to apply the stressor.
+                                              description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -5459,7 +5462,8 @@ spec:
                                               description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                               type: string
                                             workers:
-                                              description: Workers specifies N workers to apply the stressor.
+                                              description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -5687,7 +5691,8 @@ spec:
                                             type: string
                                           type: array
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -5704,7 +5709,8 @@ spec:
                                           description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                           type: string
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -7461,7 +7467,8 @@ spec:
                               type: string
                             type: array
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -7478,7 +7485,8 @@ spec:
                             description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                             type: string
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -2672,7 +2672,8 @@ spec:
                                         type: string
                                       type: array
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -2689,7 +2690,8 @@ spec:
                                       description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                       type: string
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -2917,7 +2919,8 @@ spec:
                                     type: string
                                   type: array
                                 workers:
-                                  description: Workers specifies N workers to apply the stressor.
+                                  description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers
@@ -2934,7 +2937,8 @@ spec:
                                   description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                   type: string
                                 workers:
-                                  description: Workers specifies N workers to apply the stressor.
+                                  description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -1397,7 +1397,8 @@ spec:
                               type: string
                             type: array
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -1414,7 +1415,8 @@ spec:
                             description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                             type: string
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -4174,7 +4176,8 @@ spec:
                                             type: string
                                           type: array
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -4191,7 +4194,8 @@ spec:
                                           description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                           type: string
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -4419,7 +4423,8 @@ spec:
                                         type: string
                                       type: array
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -4436,7 +4441,8 @@ spec:
                                       description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                       type: string
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers

--- a/helm/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
@@ -134,7 +134,8 @@ spec:
                           type: string
                         type: array
                       workers:
-                        description: Workers specifies N workers to apply the stressor.
+                        description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers
@@ -151,7 +152,8 @@ spec:
                         description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                         type: string
                       workers:
-                        description: Workers specifies N workers to apply the stressor.
+                        description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -2665,7 +2665,8 @@ spec:
                                   type: string
                                 type: array
                               workers:
-                                description: Workers specifies N workers to apply the stressor.
+                                description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -2682,7 +2683,8 @@ spec:
                                 description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                 type: string
                               workers:
-                                description: Workers specifies N workers to apply the stressor.
+                                description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -5442,7 +5444,8 @@ spec:
                                                 type: string
                                               type: array
                                             workers:
-                                              description: Workers specifies N workers to apply the stressor.
+                                              description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -5459,7 +5462,8 @@ spec:
                                               description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                               type: string
                                             workers:
-                                              description: Workers specifies N workers to apply the stressor.
+                                              description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -5687,7 +5691,8 @@ spec:
                                             type: string
                                           type: array
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -5704,7 +5709,8 @@ spec:
                                           description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                           type: string
                                         workers:
-                                          description: Workers specifies N workers to apply the stressor.
+                                          description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -7461,7 +7467,8 @@ spec:
                               type: string
                             type: array
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -7478,7 +7485,8 @@ spec:
                             description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                             type: string
                           workers:
-                            description: Workers specifies N workers to apply the stressor.
+                            description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -2672,7 +2672,8 @@ spec:
                                         type: string
                                       type: array
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -2689,7 +2690,8 @@ spec:
                                       description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                       type: string
                                     workers:
-                                      description: Workers specifies N workers to apply the stressor.
+                                      description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -2917,7 +2919,8 @@ spec:
                                     type: string
                                   type: array
                                 workers:
-                                  description: Workers specifies N workers to apply the stressor.
+                                  description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers
@@ -2934,7 +2937,8 @@ spec:
                                   description: Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
                                   type: string
                                 workers:
-                                  description: Workers specifies N workers to apply the stressor.
+                                  description: Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers

--- a/manifests/crd-v1beta1.yaml
+++ b/manifests/crd-v1beta1.yaml
@@ -4872,6 +4872,8 @@ spec:
                           type: array
                         workers:
                           description: Workers specifies N workers to apply the stressor.
+                            Maximum 8192 workers can run by stress-ng
+                          maximum: 8192
                           type: integer
                       required:
                       - workers
@@ -4892,6 +4894,8 @@ spec:
                           type: string
                         workers:
                           description: Workers specifies N workers to apply the stressor.
+                            Maximum 8192 workers can run by stress-ng
+                          maximum: 8192
                           type: integer
                       required:
                       - workers
@@ -8674,7 +8678,9 @@ spec:
                                         type: array
                                       workers:
                                         description: Workers specifies N workers to
-                                          apply the stressor.
+                                          apply the stressor. Maximum 8192 workers
+                                          can run by stress-ng
+                                        maximum: 8192
                                         type: integer
                                     required:
                                     - workers
@@ -8697,7 +8703,9 @@ spec:
                                         type: string
                                       workers:
                                         description: Workers specifies N workers to
-                                          apply the stressor.
+                                          apply the stressor. Maximum 8192 workers
+                                          can run by stress-ng
+                                        maximum: 8192
                                         type: integer
                                     required:
                                     - workers
@@ -9029,7 +9037,9 @@ spec:
                                     type: array
                                   workers:
                                     description: Workers specifies N workers to apply
-                                      the stressor.
+                                      the stressor. Maximum 8192 workers can run by
+                                      stress-ng
+                                    maximum: 8192
                                     type: integer
                                 required:
                                 - workers
@@ -9052,7 +9062,9 @@ spec:
                                     type: string
                                   workers:
                                     description: Workers specifies N workers to apply
-                                      the stressor.
+                                      the stressor. Maximum 8192 workers can run by
+                                      stress-ng
+                                    maximum: 8192
                                     type: integer
                                 required:
                                 - workers
@@ -11993,6 +12005,8 @@ spec:
                       type: array
                     workers:
                       description: Workers specifies N workers to apply the stressor.
+                        Maximum 8192 workers can run by stress-ng
+                      maximum: 8192
                       type: integer
                   required:
                   - workers
@@ -12013,6 +12027,8 @@ spec:
                       type: string
                     workers:
                       description: Workers specifies N workers to apply the stressor.
+                        Maximum 8192 workers can run by stress-ng
+                      maximum: 8192
                       type: integer
                   required:
                   - workers
@@ -15777,7 +15793,8 @@ spec:
                               type: array
                             workers:
                               description: Workers specifies N workers to apply the
-                                stressor.
+                                stressor. Maximum 8192 workers can run by stress-ng
+                              maximum: 8192
                               type: integer
                           required:
                           - workers
@@ -15798,7 +15815,8 @@ spec:
                               type: string
                             workers:
                               description: Workers specifies N workers to apply the
-                                stressor.
+                                stressor. Maximum 8192 workers can run by stress-ng
+                              maximum: 8192
                               type: integer
                           required:
                           - workers
@@ -19702,7 +19720,9 @@ spec:
                                             type: array
                                           workers:
                                             description: Workers specifies N workers
-                                              to apply the stressor.
+                                              to apply the stressor. Maximum 8192
+                                              workers can run by stress-ng
+                                            maximum: 8192
                                             type: integer
                                         required:
                                         - workers
@@ -19726,7 +19746,9 @@ spec:
                                             type: string
                                           workers:
                                             description: Workers specifies N workers
-                                              to apply the stressor.
+                                              to apply the stressor. Maximum 8192
+                                              workers can run by stress-ng
+                                            maximum: 8192
                                             type: integer
                                         required:
                                         - workers
@@ -20069,7 +20091,9 @@ spec:
                                         type: array
                                       workers:
                                         description: Workers specifies N workers to
-                                          apply the stressor.
+                                          apply the stressor. Maximum 8192 workers
+                                          can run by stress-ng
+                                        maximum: 8192
                                         type: integer
                                     required:
                                     - workers
@@ -20092,7 +20116,9 @@ spec:
                                         type: string
                                       workers:
                                         description: Workers specifies N workers to
-                                          apply the stressor.
+                                          apply the stressor. Maximum 8192 workers
+                                          can run by stress-ng
+                                        maximum: 8192
                                         type: integer
                                     required:
                                     - workers
@@ -23068,6 +23094,8 @@ spec:
                           type: array
                         workers:
                           description: Workers specifies N workers to apply the stressor.
+                            Maximum 8192 workers can run by stress-ng
+                          maximum: 8192
                           type: integer
                       required:
                       - workers
@@ -23088,6 +23116,8 @@ spec:
                           type: string
                         workers:
                           description: Workers specifies N workers to apply the stressor.
+                            Maximum 8192 workers can run by stress-ng
+                          maximum: 8192
                           type: integer
                       required:
                       - workers
@@ -29215,7 +29245,9 @@ spec:
                                     type: array
                                   workers:
                                     description: Workers specifies N workers to apply
-                                      the stressor.
+                                      the stressor. Maximum 8192 workers can run by
+                                      stress-ng
+                                    maximum: 8192
                                     type: integer
                                 required:
                                 - workers
@@ -29238,7 +29270,9 @@ spec:
                                     type: string
                                   workers:
                                     description: Workers specifies N workers to apply
-                                      the stressor.
+                                      the stressor. Maximum 8192 workers can run by
+                                      stress-ng
+                                    maximum: 8192
                                     type: integer
                                 required:
                                 - workers
@@ -29561,7 +29595,8 @@ spec:
                                 type: array
                               workers:
                                 description: Workers specifies N workers to apply
-                                  the stressor.
+                                  the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -29582,7 +29617,8 @@ spec:
                                 type: string
                               workers:
                                 description: Workers specifies N workers to apply
-                                  the stressor.
+                                  the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4877,7 +4877,8 @@ spec:
                             type: array
                           workers:
                             description: Workers specifies N workers to apply the
-                              stressor.
+                              stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -4898,7 +4899,8 @@ spec:
                             type: string
                           workers:
                             description: Workers specifies N workers to apply the
-                              stressor.
+                              stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -8762,7 +8764,9 @@ spec:
                                           type: array
                                         workers:
                                           description: Workers specifies N workers
-                                            to apply the stressor.
+                                            to apply the stressor. Maximum 8192 workers
+                                            can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -8785,7 +8789,9 @@ spec:
                                           type: string
                                         workers:
                                           description: Workers specifies N workers
-                                            to apply the stressor.
+                                            to apply the stressor. Maximum 8192 workers
+                                            can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -9124,7 +9130,9 @@ spec:
                                       type: array
                                     workers:
                                       description: Workers specifies N workers to
-                                        apply the stressor.
+                                        apply the stressor. Maximum 8192 workers can
+                                        run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -9147,7 +9155,9 @@ spec:
                                       type: string
                                     workers:
                                       description: Workers specifies N workers to
-                                        apply the stressor.
+                                        apply the stressor. Maximum 8192 workers can
+                                        run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -12148,6 +12158,8 @@ spec:
                         type: array
                       workers:
                         description: Workers specifies N workers to apply the stressor.
+                          Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers
@@ -12168,6 +12180,8 @@ spec:
                         type: string
                       workers:
                         description: Workers specifies N workers to apply the stressor.
+                          Maximum 8192 workers can run by stress-ng
+                        maximum: 8192
                         type: integer
                     required:
                     - workers
@@ -15954,7 +15968,8 @@ spec:
                                 type: array
                               workers:
                                 description: Workers specifies N workers to apply
-                                  the stressor.
+                                  the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -15975,7 +15990,8 @@ spec:
                                 type: string
                               workers:
                                 description: Workers specifies N workers to apply
-                                  the stressor.
+                                  the stressor. Maximum 8192 workers can run by stress-ng
+                                maximum: 8192
                                 type: integer
                             required:
                             - workers
@@ -19957,7 +19973,9 @@ spec:
                                               type: array
                                             workers:
                                               description: Workers specifies N workers
-                                                to apply the stressor.
+                                                to apply the stressor. Maximum 8192
+                                                workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -19981,7 +19999,9 @@ spec:
                                               type: string
                                             workers:
                                               description: Workers specifies N workers
-                                                to apply the stressor.
+                                                to apply the stressor. Maximum 8192
+                                                workers can run by stress-ng
+                                              maximum: 8192
                                               type: integer
                                           required:
                                           - workers
@@ -20333,7 +20353,9 @@ spec:
                                           type: array
                                         workers:
                                           description: Workers specifies N workers
-                                            to apply the stressor.
+                                            to apply the stressor. Maximum 8192 workers
+                                            can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -20356,7 +20378,9 @@ spec:
                                           type: string
                                         workers:
                                           description: Workers specifies N workers
-                                            to apply the stressor.
+                                            to apply the stressor. Maximum 8192 workers
+                                            can run by stress-ng
+                                          maximum: 8192
                                           type: integer
                                       required:
                                       - workers
@@ -23410,7 +23434,8 @@ spec:
                             type: array
                           workers:
                             description: Workers specifies N workers to apply the
-                              stressor.
+                              stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -23431,7 +23456,8 @@ spec:
                             type: string
                           workers:
                             description: Workers specifies N workers to apply the
-                              stressor.
+                              stressor. Maximum 8192 workers can run by stress-ng
+                            maximum: 8192
                             type: integer
                         required:
                         - workers
@@ -29659,7 +29685,9 @@ spec:
                                       type: array
                                     workers:
                                       description: Workers specifies N workers to
-                                        apply the stressor.
+                                        apply the stressor. Maximum 8192 workers can
+                                        run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -29682,7 +29710,9 @@ spec:
                                       type: string
                                     workers:
                                       description: Workers specifies N workers to
-                                        apply the stressor.
+                                        apply the stressor. Maximum 8192 workers can
+                                        run by stress-ng
+                                      maximum: 8192
                                       type: integer
                                   required:
                                   - workers
@@ -30012,7 +30042,9 @@ spec:
                                   type: array
                                 workers:
                                   description: Workers specifies N workers to apply
-                                    the stressor.
+                                    the stressor. Maximum 8192 workers can run by
+                                    stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers
@@ -30035,7 +30067,9 @@ spec:
                                   type: string
                                 workers:
                                   description: Workers specifies N workers to apply
-                                    the stressor.
+                                    the stressor. Maximum 8192 workers can run by
+                                    stress-ng
+                                  maximum: 8192
                                   type: integer
                               required:
                               - workers


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #1931

Problem Summary: stress-ng can launch at max 8192 workers, so StressChaos will fail silently in the case where workers is outside this range.

What's Changed:

Added a kubebuilder validation to force a maximum limit of 8192 for `spec.stressors.cpu.workers`.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
validation for number of cpu workers in stress chaos
```
