### PR TITLE
chore: remove the detail output of go download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           make ensure-kustomize || echo 0
 
           # preload go modules before goimports
-          go mod download -x
+          go mod download
 
           make groupimports || echo 0
           #use sh function


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
- the output of github actions is toooo large, we need a lot of time to load the full log, only because of the extra `-x` in `go mod download`

### What is changed and how it works?

What's Changed:
- remove `-x` in `go mod download`

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
