### PR TITLE
fix: use patch instead of update within podfailure

### DIFF
--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -20,7 +20,7 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods", "secrets"]
-    verbs: [ "get", "list", "watch", "delete", "update" ]
+    verbs: [ "get", "list", "watch", "delete", "update", "patch" ]
   - apiGroups:
       - ""
     resources:

--- a/install.sh
+++ b/install.sh
@@ -960,7 +960,7 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods", "secrets"]
-    verbs: [ "get", "list", "watch", "delete", "update" ]
+    verbs: [ "get", "list", "watch", "delete", "update", "patch" ]
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: 

fix #2018 

Problem Summary:

currently, we are using kubernetes v1.17 as the dependency. But the `SeccompProfile` is introduced in v1.19, which causes the problem if we directly update the pod definition: the missing `SeccompProfile` is treated as deleted when we update the Pod.


And this PR should be "cherry-pick" to release 1.x, but it seems hard to do that automatically, I will manually create a PR.

### What is changed and how it works?

What's Changed:

- use patch instead of update within pod-failure

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [x] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
