### PR TITLE
setup another cache which would be updated if "Update" function is called

### DIFF
--- a/cmd/chaos-controller-manager/provider/controller.go
+++ b/cmd/chaos-controller-manager/provider/controller.go
@@ -104,7 +104,7 @@ func NewAuthCli(cfg *rest.Config) (*authorizationv1.AuthorizationV1Client, error
 
 func NewClient(mgr ctrl.Manager, scheme *runtime.Scheme) (client.Client, error) {
 	// TODO: make this size configurable
-	cache, err := lru.New(20)
+	cache, err := lru.New(100)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/chaos-controller-manager/provider/suit_test.go
+++ b/cmd/chaos-controller-manager/provider/suit_test.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/fx"
+	k8sScheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test/manager"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var app *fx.App
+var cfg *rest.Config
+var k8sClient client.Client
+var mgr ctrl.Manager
+var testEnv *envtest.Environment
+var setupLog = ctrl.Log.WithName("setup")
+
+func TestSchedule(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Provider suit",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	By("bootstrapping test environment")
+	t := true
+	if os.Getenv("TEST_USE_EXISTING_CLUSTER") == "true" {
+		testEnv = &envtest.Environment{
+			UseExistingCluster: &t,
+		}
+	} else {
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		}
+	}
+
+	err := v1alpha1.SchemeBuilder.AddToScheme(k8sScheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	app = fx.New(
+		fx.Options(
+			fx.Supply(cfg),
+			fx.Provide(
+				NewOption,
+				NewClient,
+				manager.NewTestManager,
+				NewLogger,
+				NewAuthCli,
+				NewScheme,
+			),
+		),
+		fx.Populate(&k8sClient),
+		fx.Populate(&mgr),
+		fx.Invoke(Run),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), app.StartTimeout())
+	defer cancel()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	if err := app.Start(startCtx); err != nil {
+		setupLog.Error(err, "fail to start manager")
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	stopCtx, cancel := context.WithTimeout(context.Background(), app.StopTimeout())
+	defer cancel()
+
+	if err := app.Stop(stopCtx); err != nil {
+		setupLog.Error(err, "fail to stop manager")
+	}
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+type RunParams struct {
+	fx.In
+
+	Mgr    ctrl.Manager
+	Logger logr.Logger
+	Client client.Client
+}
+
+func Run(params RunParams) error {
+	return nil
+}

--- a/cmd/chaos-controller-manager/provider/suit_test.go
+++ b/cmd/chaos-controller-manager/provider/suit_test.go
@@ -46,7 +46,7 @@ var mgr ctrl.Manager
 var testEnv *envtest.Environment
 var setupLog = ctrl.Log.WithName("setup")
 
-func TestSchedule(t *testing.T) {
+func TestClient(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,

--- a/cmd/chaos-controller-manager/provider/suit_test.go
+++ b/cmd/chaos-controller-manager/provider/suit_test.go
@@ -46,7 +46,7 @@ var mgr ctrl.Manager
 var testEnv *envtest.Environment
 var setupLog = ctrl.Log.WithName("setup")
 
-func TestClient(t *testing.T) {
+func TestProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,

--- a/cmd/chaos-controller-manager/provider/updated_client.go
+++ b/cmd/chaos-controller-manager/provider/updated_client.go
@@ -65,7 +65,8 @@ func (c *UpdatedClient) Get(ctx context.Context, key client.ObjectKey, obj runti
 		if err != nil {
 			return nil
 		}
-		if cachedMeta.GetGeneration() > objMeta.GetGeneration() {
+
+		if cachedMeta.GetResourceVersion() == objMeta.GetResourceVersion() {
 			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(cachedObject).Elem())
 		}
 	}
@@ -103,12 +104,6 @@ func (c *UpdatedClient) Update(ctx context.Context, obj runtime.Object, opts ...
 	if err != nil {
 		return err
 	}
-
-	objMeta, err = meta.Accessor(obj)
-	if err != nil {
-		return nil
-	}
-	objMeta.SetGeneration(objMeta.GetGeneration() + 1)
 
 	c.cache.Add(objectKey, obj)
 	return nil

--- a/cmd/chaos-controller-manager/provider/updated_client.go
+++ b/cmd/chaos-controller-manager/provider/updated_client.go
@@ -1,0 +1,129 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"reflect"
+
+	lru "github.com/hashicorp/golang-lru"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var _ client.Client = &UpdatedClient{}
+
+type UpdatedClient struct {
+	client client.Client
+	scheme *runtime.Scheme
+
+	cache *lru.Cache
+}
+
+func (c *UpdatedClient) objectKey(key client.ObjectKey, obj runtime.Object) (string, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return "", err
+	}
+
+	return gvk.String() + "/" + key.String(), nil
+}
+
+func (c *UpdatedClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	err := c.client.Get(ctx, key, obj)
+	if err != nil {
+		return err
+	}
+
+	objectKey, err := c.objectKey(key, obj)
+	if err != nil {
+		return err
+	}
+
+	cachedObject, ok := c.cache.Get(objectKey)
+	if ok {
+		cachedMeta, err := meta.Accessor(cachedObject)
+		if err != nil {
+			return nil
+		}
+
+		objMeta, err := meta.Accessor(obj)
+		if err != nil {
+			return nil
+		}
+		if cachedMeta.GetGeneration() > objMeta.GetGeneration() {
+			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(cachedObject).Elem())
+		}
+	}
+
+	return nil
+}
+
+func (c *UpdatedClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c *UpdatedClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	err := c.client.Update(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil
+	}
+
+	objectKey, err := c.objectKey(types.NamespacedName{
+		Namespace: objMeta.GetNamespace(),
+		Name:      objMeta.GetName(),
+	}, obj)
+	if err != nil {
+		return err
+	}
+
+	objMeta, err = meta.Accessor(obj)
+	if err != nil {
+		return nil
+	}
+	objMeta.SetGeneration(objMeta.GetGeneration() + 1)
+
+	c.cache.Add(objectKey, obj)
+	return nil
+}
+
+func (c *UpdatedClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *UpdatedClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Status() client.StatusWriter {
+	// TODO: add cache for status client
+
+	return c.client.Status()
+}

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -53,31 +53,6 @@ var _ = Describe("UpdatedClient", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Update should update the generation number", func() {
-			obj := &corev1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "default",
-					Name:      "test-configmap-generation-number",
-				},
-				Data: map[string]string{
-					"test": "1",
-				},
-			}
-			err := k8sClient.Create(context.TODO(), obj)
-			Expect(err).ToNot(HaveOccurred())
-
-			originalGenerationNumber := obj.Generation
-
-			obj.Data["test"] = "2"
-			err = k8sClient.Update(context.TODO(), obj)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(obj.Generation).To(BeNumerically(">", originalGenerationNumber))
-
-			err = k8sClient.Delete(context.TODO(), obj)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("Data should always be updated", func() {
 			obj := &corev1.ConfigMap{
 				ObjectMeta: v1.ObjectMeta{
@@ -91,7 +66,7 @@ var _ = Describe("UpdatedClient", func() {
 			err := k8sClient.Create(context.TODO(), obj)
 			Expect(err).ToNot(HaveOccurred())
 
-			for i := 0; i <= 100; i++ {
+			for i := 0; i <= 200; i++ {
 				data := strconv.Itoa(i)
 
 				obj.Data["test"] = data

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -1,0 +1,154 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("UpdatedClient", func() {
+
+	BeforeEach(func() {
+		// Add any setup steps that needs to be executed before each test
+	})
+
+	AfterEach(func() {
+		// Add any teardown steps that needs to be executed after each test
+	})
+
+	Context(("UpdatedClient"), func() {
+		It(("Should create and delete successfully"), func() {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-configmap-create-delete",
+				},
+				Data: map[string]string{
+					"test": "1",
+				},
+			}
+			err := k8sClient.Create(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = k8sClient.Delete(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Update should update the generation number", func() {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-configmap-generation-number",
+				},
+				Data: map[string]string{
+					"test": "1",
+				},
+			}
+			err := k8sClient.Create(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			originalGenerationNumber := obj.Generation
+
+			obj.Data["test"] = "2"
+			err = k8sClient.Update(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(obj.Generation).To(BeNumerically(">", originalGenerationNumber))
+
+			err = k8sClient.Delete(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Data should always be updated", func() {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-configmap-update",
+				},
+				Data: map[string]string{
+					"test": "0",
+				},
+			}
+			err := k8sClient.Create(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i <= 100; i++ {
+				data := strconv.Itoa(i)
+
+				obj.Data["test"] = data
+				err = k8sClient.Update(context.TODO(), obj)
+				Expect(err).ToNot(HaveOccurred())
+
+				newObj := &corev1.ConfigMap{}
+				err = k8sClient.Get(context.TODO(), types.NamespacedName{
+					Namespace: "default",
+					Name:      "test-configmap-update",
+				}, newObj)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(newObj.Data["test"]).To(Equal(data))
+			}
+
+			err = k8sClient.Delete(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Newer data should be returned", func() {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-configmap-update",
+				},
+				Data: map[string]string{
+					"test": "0",
+				},
+			}
+			err := k8sClient.Create(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			obj.Data["test"] = "1"
+			err = k8sClient.Update(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			newObj := &corev1.ConfigMap{}
+			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-configmap-update",
+			}, newObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(newObj.Data["test"]).To(Equal("1"))
+			newObj.Data["test"] = "2"
+			anotherCleanClient := mgr.GetClient()
+			err = anotherCleanClient.Update(context.TODO(), obj)
+			Expect(err).ToNot(HaveOccurred())
+
+			newObj = &corev1.ConfigMap{}
+			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-configmap-update",
+			}, newObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newObj.Data["test"]).To(Equal("2"))
+		})
+	})
+})

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -73,14 +73,13 @@ var _ = Describe("UpdatedClient", func() {
 				err = k8sClient.Update(context.TODO(), obj)
 				Expect(err).ToNot(HaveOccurred())
 
-				newObj := &corev1.ConfigMap{}
 				err = k8sClient.Get(context.TODO(), types.NamespacedName{
 					Namespace: "default",
 					Name:      "test-configmap-update",
-				}, newObj)
+				}, obj)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(newObj.Data["test"]).To(Equal(data))
+				Expect(obj.Data["test"]).To(Equal(data))
 			}
 
 			err = k8sClient.Delete(context.TODO(), obj)
@@ -91,7 +90,7 @@ var _ = Describe("UpdatedClient", func() {
 			obj := &corev1.ConfigMap{
 				ObjectMeta: v1.ObjectMeta{
 					Namespace: "default",
-					Name:      "test-configmap-update",
+					Name:      "test-configmap-another-update",
 				},
 				Data: map[string]string{
 					"test": "0",

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -106,7 +106,7 @@ var _ = Describe("UpdatedClient", func() {
 			newObj := &corev1.ConfigMap{}
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{
 				Namespace: "default",
-				Name:      "test-configmap-update",
+				Name:      "test-configmap-another-update",
 			}, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -119,7 +119,7 @@ var _ = Describe("UpdatedClient", func() {
 			newObj = &corev1.ConfigMap{}
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{
 				Namespace: "default",
-				Name:      "test-configmap-update",
+				Name:      "test-configmap-another-update",
 			}, newObj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newObj.Data["test"]).To(Equal("2"))

--- a/controllers/common/controller.go
+++ b/controllers/common/controller.go
@@ -17,11 +17,9 @@ import (
 	"context"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -235,23 +233,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		r.Recorder.Event(obj, recorder.Updated{
 			Field: "records",
 		})
-
-		// TODO: make the interval and total time configurable
-		// The following codes ensure the Schedule in cache has the latest lastScheduleTime
-		ensureLatestError := wait.Poll(100*time.Millisecond, 2*time.Second, func() (bool, error) {
-			obj := r.Object.DeepCopyObject().(InnerObjectWithSelector)
-
-			if err := r.Client.Get(context.TODO(), req.NamespacedName, obj); err != nil {
-				r.Log.Error(err, "unable to get object")
-				return false, err
-			}
-
-			return reflect.DeepEqual(obj.GetStatus().Experiment.Records, records), nil
-		})
-		if ensureLatestError != nil {
-			r.Log.Error(ensureLatestError, "Fail to ensure that the resource in cache has the latest records")
-			return ctrl.Result{Requeue: needRetry}, nil
-		}
 	}
 	return ctrl.Result{Requeue: needRetry}, nil
 }

--- a/controllers/schedule/active/controller.go
+++ b/controllers/schedule/active/controller.go
@@ -17,14 +17,12 @@ import (
 	"context"
 	"reflect"
 	"sort"
-	"time"
 
 	"github.com/go-logr/logr"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -115,22 +113,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	// TODO: make the interval and total time configurable
-	// The following codes ensure the Schedule in cache has the latest lastScheduleTime
-	ensureLatestError := wait.Poll(100*time.Millisecond, 2*time.Second, func() (bool, error) {
-		schedule = schedule.DeepCopyObject().(*v1alpha1.Schedule)
-
-		if err := r.Client.Get(ctx, req.NamespacedName, schedule); err != nil {
-			r.Log.Error(err, "unable to get schedule")
-			return false, err
-		}
-
-		return reflect.DeepEqual(schedule.Status.Active, active), nil
-	})
-	if ensureLatestError != nil {
-		r.Log.Error(ensureLatestError, "Fail to ensure that the resource in cache has the latest .Status.Active")
-		return ctrl.Result{}, nil
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/utils/test/manager/test_manager.go
+++ b/controllers/utils/test/manager/test_manager.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/fx"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	ccfg "github.com/chaos-mesh/chaos-mesh/controllers/config"
+)
+
+func NewTestManager(lc fx.Lifecycle, options *ctrl.Options, cfg *rest.Config) (ctrl.Manager, error) {
+	if ccfg.ControllerCfg.QPS > 0 {
+		cfg.QPS = ccfg.ControllerCfg.QPS
+	}
+	if ccfg.ControllerCfg.Burst > 0 {
+		cfg.Burst = ccfg.ControllerCfg.Burst
+	}
+	ch := make(chan struct{})
+
+	mgr, err := ctrl.NewManager(cfg, *options)
+
+	if err != nil {
+		return nil, err
+	}
+	lc.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			fmt.Println("Starting manager")
+			go func() {
+				if err := mgr.Start(ch); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			fmt.Println("Stopping manager")
+			close(ch)
+			return nil
+		},
+	})
+	return mgr, nil
+}

--- a/controllers/utils/test/provider.go
+++ b/controllers/utils/test/provider.go
@@ -14,52 +14,12 @@
 package test
 
 import (
-	"context"
-	"fmt"
-	"os"
-
 	"go.uber.org/fx"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/cmd/chaos-controller-manager/provider"
-	ccfg "github.com/chaos-mesh/chaos-mesh/controllers/config"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test/manager"
 )
-
-func NewTestManager(lc fx.Lifecycle, options *ctrl.Options, cfg *rest.Config) (ctrl.Manager, error) {
-	if ccfg.ControllerCfg.QPS > 0 {
-		cfg.QPS = ccfg.ControllerCfg.QPS
-	}
-	if ccfg.ControllerCfg.Burst > 0 {
-		cfg.Burst = ccfg.ControllerCfg.Burst
-	}
-	ch := make(chan struct{})
-
-	mgr, err := ctrl.NewManager(cfg, *options)
-
-	if err != nil {
-		return nil, err
-	}
-	lc.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			fmt.Println("Starting manager")
-			go func() {
-				if err := mgr.Start(ch); err != nil {
-					fmt.Println(err)
-					os.Exit(1)
-				}
-			}()
-			return nil
-		},
-		OnStop: func(ctx context.Context) error {
-			fmt.Println("Stopping manager")
-			close(ch)
-			return nil
-		},
-	})
-	return mgr, nil
-}
 
 var Module = fx.Provide(
 	provider.NewOption,
@@ -70,6 +30,6 @@ var Module = fx.Provide(
 	provider.NewNoCacheReader,
 	provider.NewGlobalCacheReader,
 	provider.NewControlPlaneCacheReader,
-	NewTestManager,
+	manager.NewTestManager,
 	recorder.NewRecorderBuilder,
 )


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

### What problem does this PR solve?

There are some mechanism to avoid outdated fields in chaos resource. However, the following codes may actually timeout:

```go
// TODO: make the interval and total time configurable
// The following codes ensure the Schedule in cache has the latest lastScheduleTime
ensureLatestError := wait.Poll(100*time.Millisecond, 2*time.Second, func() (bool, error) {
	schedule = schedule.DeepCopyObject().(*v1alpha1.Schedule)

	if err := r.Client.Get(ctx, req.NamespacedName, schedule); err != nil {
		r.Log.Error(err, "unable to get schedule")
		return false, err
	}

	return schedule.Status.LastScheduleTime.Time == lastScheduleTime, nil
})
```

### What is changed and how it works?

I developed a new client, which includes another cache. So that we could store the newest resource in the cache temporarily. And it's really hard to decide when it could be removed from the cache, so an LRU is used. 

It cannot 100% ensure the data is newest, because:

1. The resource may have been removed from the LRU
2. The user has modified it manually, and it hasn't been synced with the cache inside controller-runtime's client.
