### PR TITLE
chore(api): use direct routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ endif
 
 ui: yarn_dependencies
 ifeq (${UI},1)
-	# cd ui &&\
-	# yarn build
+	cd ui &&\
+	yarn build
 	hack/embed_ui_assets.sh
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ endif
 
 # Enable GO111MODULE=on explicitly, disable it with GO111MODULE=off when necessary.
 export GO111MODULE := on
-GOOS := $(if $(GOOS),$(GOOS),"")
+GOOS   := $(if $(GOOS),$(GOOS),"")
 GOARCH := $(if $(GOARCH),$(GOARCH),"")
 GOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
-CGOENV  := GO15VENDOREXPERIMENT="1" CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH)
+CGOENV := GO15VENDOREXPERIMENT="1" CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO     := $(GOENV) go
 CGO    := $(CGOENV) go
 GOTEST := TEST_USE_EXISTING_CLUSTER=false NO_PROXY="${NO_PROXY},testhost" go test
-SHELL    := bash
+SHELL  := bash
 
 PACKAGE_LIST := echo $$(go list ./... | grep -vE "chaos-mesh/test|pkg/ptrace|zz_generated|vendor") github.com/chaos-mesh/chaos-mesh/api/v1alpha1
 
@@ -115,8 +115,8 @@ endif
 
 ui: yarn_dependencies
 ifeq (${UI},1)
-	cd ui &&\
-	yarn build
+	# cd ui &&\
+	# yarn build
 	hack/embed_ui_assets.sh
 endif
 

--- a/pkg/apiserver/archive/archive_test.go
+++ b/pkg/apiserver/archive/archive_test.go
@@ -55,10 +55,6 @@ func (m *MockExperimentStore) ListMeta(ctx context.Context, kind, namespace, nam
 	var err error
 	if kind == "testKind" {
 		expMeta := &core.ExperimentMeta{
-			ID:         0,
-			CreatedAt:  time.Time{},
-			UpdatedAt:  time.Time{},
-			DeletedAt:  nil,
 			UID:        "testUID",
 			Kind:       "testKind",
 			Name:       "testName",
@@ -84,10 +80,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindPodChaos,
 				Name:       "testName",
@@ -104,10 +96,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindIOChaos,
 				Name:       "testName",
@@ -124,10 +112,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindNetworkChaos,
 				Name:       "testName",
@@ -144,10 +128,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindTimeChaos,
 				Name:       "testName",
@@ -164,10 +144,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindKernelChaos,
 				Name:       "testName",
@@ -184,10 +160,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 		jsonStr, _ := json.Marshal(chaos)
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindStressChaos,
 				Name:       "testName",
@@ -202,10 +174,6 @@ func (m *MockExperimentStore) FindByUID(ctx context.Context, UID string) (*core.
 	case "testOtherChaos":
 		res = &core.Experiment{
 			ExperimentMeta: core.ExperimentMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       "OtherChaos",
 				Name:       "testName",
@@ -231,10 +199,6 @@ func (m *MockExperimentStore) FindMetaByUID(ctx context.Context, UID string) (*c
 	switch UID {
 	case "tsetUID":
 		res = &core.ExperimentMeta{
-			ID:         0,
-			CreatedAt:  time.Time{},
-			UpdatedAt:  time.Time{},
-			DeletedAt:  nil,
 			UID:        "testUID",
 			Kind:       "testKind",
 			Name:       "testName",
@@ -281,10 +245,6 @@ func (m *MockScheduleStore) ListMeta(ctx context.Context, namespace, name string
 	var err error
 	if name == "testScheduleName" {
 		schMeta := &core.ScheduleMeta{
-			ID:         0,
-			CreatedAt:  time.Time{},
-			UpdatedAt:  time.Time{},
-			DeletedAt:  nil,
 			UID:        "testUID",
 			Kind:       "testKind",
 			Name:       "testScheduleName",
@@ -310,10 +270,6 @@ func (m *MockScheduleStore) FindByUID(ctx context.Context, UID string) (*core.Sc
 		jsonStr, _ := json.Marshal(sch)
 		res = &core.Schedule{
 			ScheduleMeta: core.ScheduleMeta{
-				ID:         0,
-				CreatedAt:  time.Time{},
-				UpdatedAt:  time.Time{},
-				DeletedAt:  nil,
 				UID:        UID,
 				Kind:       v1alpha1.KindPodChaos,
 				Name:       "testName",

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -75,6 +75,9 @@ func newEngine(config *config.ChaosDashboardConfig) *gin.Engine {
 		r.GET("/", func(c *gin.Context) {
 			c.FileFromFS("/", ui)
 		})
+		// `/:foo/*bar` from https://en.wikipedia.org/wiki/Foobar, the name itself has no meaning.
+		//
+		// This handle just internally redirects all no-exact routes to the root directory of static files because the UI is a single page application and only has one entry (index.html).
 		r.GET("/:foo/*bar", func(c *gin.Context) {
 			c.FileFromFS("/", ui)
 		})

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -37,7 +37,6 @@ type ChaosDashboardConfig struct {
 	// EnableFilterNamespace will filter namespace with annotation. Only the pods/containers in namespace
 	// annotated with `chaos-mesh.org/inject=enabled` will be injected
 	EnableFilterNamespace bool `envconfig:"ENABLE_FILTER_NAMESPACE" default:"false"`
-
 	// SecurityMode will use the token login by the user if set to true
 	SecurityMode    bool   `envconfig:"SECURITY_MODE" default:"true" json:"security_mode"`
 	DNSServerCreate bool   `envconfig:"DNS_SERVER_CREATE" default:"false" json:"dns_server_create"`
@@ -60,8 +59,8 @@ type DatabaseConfig struct {
 	Secret     string `envconfig:"DATABASE_SECRET"`
 }
 
-// EnvironChaosDashboard returns the settings from the environment.
-func EnvironChaosDashboard() (*ChaosDashboardConfig, error) {
+// GetChaosDashboardEnv gets all env variables related to dashboard.
+func GetChaosDashboardEnv() (*ChaosDashboardConfig, error) {
 	cfg := ChaosDashboardConfig{}
 	err := envconfig.Process("", &cfg)
 	return &cfg, err

--- a/pkg/core/experiment.go
+++ b/pkg/core/experiment.go
@@ -20,8 +20,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/jinzhu/gorm"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
 // ExperimentStore defines operations for working with experiments.

--- a/pkg/core/experiment.go
+++ b/pkg/core/experiment.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/jinzhu/gorm"
 )
 
 // ExperimentStore defines operations for working with experiments.
@@ -64,18 +65,15 @@ type Experiment struct {
 
 // ExperimentMeta defines the metadata of an experiment. Use in db.
 type ExperimentMeta struct {
-	ID         uint       `gorm:"primary_key" json:"id"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
-	DeletedAt  *time.Time `sql:"index" json:"deleted_at"`
-	UID        string     `gorm:"index:uid" json:"uid"`
-	Kind       string     `json:"kind"`
-	Name       string     `json:"name"`
-	Namespace  string     `json:"namespace"`
-	Action     string     `json:"action"`
-	StartTime  time.Time  `json:"start_time"`
-	FinishTime time.Time  `json:"finish_time"`
-	Archived   bool       `json:"archived"`
+	gorm.Model
+	UID        string    `gorm:"index:uid" json:"uid"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace"`
+	Action     string    `json:"action"`
+	StartTime  time.Time `json:"start_time"`
+	FinishTime time.Time `json:"finish_time"`
+	Archived   bool      `json:"archived"`
 }
 
 // ExperimentInfo defines a form data of Experiment from API.

--- a/pkg/core/schedule.go
+++ b/pkg/core/schedule.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/jinzhu/gorm"
 )
 
 // ScheduleStore defines operations for working with schedules.
@@ -61,18 +62,15 @@ type Schedule struct {
 
 // ScheduleMeta defines the metadata of a schedule instance. Use in db.
 type ScheduleMeta struct {
-	ID         uint       `gorm:"primary_key" json:"id"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
-	DeletedAt  *time.Time `sql:"index" json:"deleted_at"`
-	UID        string     `gorm:"index:uid" json:"uid"`
-	Kind       string     `json:"kind"`
-	Name       string     `json:"name"`
-	Namespace  string     `json:"namespace"`
-	Action     string     `json:"action"`
-	StartTime  time.Time  `json:"start_time"`
-	FinishTime time.Time  `json:"finish_time"`
-	Archived   bool       `json:"archived"`
+	gorm.Model
+	UID        string    `gorm:"index:schedule_uid" json:"uid"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace"`
+	Action     string    `json:"action"`
+	StartTime  time.Time `json:"start_time"`
+	FinishTime time.Time `json:"finish_time"`
+	Archived   bool      `json:"archived"`
 }
 
 // ScheduleInfo defines a form data of schedule from API.

--- a/pkg/core/schedule.go
+++ b/pkg/core/schedule.go
@@ -17,8 +17,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/jinzhu/gorm"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
 // ScheduleStore defines operations for working with schedules.

--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,15 +50,14 @@ const (
 
 // WorkflowMeta defines the root structure of a workflow.
 type WorkflowMeta struct {
-	ID        uint   `gorm:"primary_key" json:"id"`
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	// the entry node name
-	Entry     string         `json:"entry"`
+	gorm.Model
+	UID       string         `gorm:"index:workflow_uid" json:"uid"`
+	Namespace string         `json:"namespace"`
+	Name      string         `json:"name"`
+	Entry     string         `json:"entry"` // the entry node name
 	CreatedAt string         `json:"created_at"`
 	EndTime   string         `json:"end_time"`
 	Status    WorkflowStatus `json:"status,omitempty"`
-	UID       string         `gorm:"index:uid" json:"uid"`
 	Archived  bool           `json:"-"`
 }
 

--- a/pkg/store/event/event.go
+++ b/pkg/store/event/event.go
@@ -21,20 +21,16 @@ import (
 	"time"
 
 	"github.com/jinzhu/gorm"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/core"
 	"github.com/chaos-mesh/chaos-mesh/pkg/store/dbstore"
 )
 
-var log = ctrl.Log.WithName("store/event")
-
 // NewStore return a new EventStore.
 func NewStore(db *dbstore.DB) core.EventStore {
 	db.AutoMigrate(&core.Event{})
 
-	es := &eventStore{db}
-	return es
+	return &eventStore{db}
 }
 
 type eventStore struct {
@@ -249,24 +245,4 @@ func constructQueryArgs(experimentName, experimentNamespace, uid, kind, createTi
 	}
 
 	return query, args
-}
-
-func splitArray(arr []uint, num int) [][]uint {
-	max := int(len(arr))
-	if max < num {
-		return nil
-	}
-	var segments = make([][]uint, 0)
-	quantity := max / num
-	end := int(0)
-	for i := int(1); i <= num; i++ {
-		point := i * quantity
-		if i != num {
-			segments = append(segments, arr[i-1+end:point])
-		} else {
-			segments = append(segments, arr[i-1+end:])
-		}
-		end = point - i
-	}
-	return segments
 }

--- a/pkg/store/experiment/experiment.go
+++ b/pkg/store/experiment/experiment.go
@@ -30,9 +30,7 @@ var log = ctrl.Log.WithName("store/experiment")
 func NewStore(db *dbstore.DB) core.ExperimentStore {
 	db.AutoMigrate(&core.Experiment{})
 
-	es := &experimentStore{db}
-
-	return es
+	return &experimentStore{db}
 }
 
 // DeleteIncompleteExperiments call core.ExperimentStore.DeleteIncompleteExperiments to deletes all incomplete experiments.

--- a/pkg/store/schedule/schedule.go
+++ b/pkg/store/schedule/schedule.go
@@ -30,9 +30,7 @@ var log = ctrl.Log.WithName("store/schedule")
 func NewStore(db *dbstore.DB) core.ScheduleStore {
 	db.AutoMigrate(&core.Schedule{})
 
-	es := &ScheduleStore{db}
-
-	return es
+	return &ScheduleStore{db}
 }
 
 // DeleteIncompleteSchedules call core.ScheduleStore.DeleteIncompleteSchedules to deletes all incomplete schedules.

--- a/pkg/store/workflow/workflow.go
+++ b/pkg/store/workflow/workflow.go
@@ -28,7 +28,8 @@ type WorkflowStore struct {
 
 func NewStore(db *dbstore.DB) core.WorkflowStore {
 	db.AutoMigrate(&core.WorkflowEntity{})
-	return &WorkflowStore{db: db}
+
+	return &WorkflowStore{db}
 }
 
 func (it *WorkflowStore) List(ctx context.Context, namespace, name string, archived bool) ([]*core.WorkflowEntity, error) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-mesh-dashboard",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A Web UI for Chaos Mesh",
   "private": true,
   "dependencies": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,7 +6,7 @@ import store from './store'
 
 const App = () => (
   <Provider store={store}>
-    <Router basename="/dashboard">
+    <Router>
       <ThemeProvider>
         <TopContainer />
       </ThemeProvider>


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?

Close #1500.

#### Problem Summary

Since the https://github.com/gin-gonic/gin/pull/2706 be merged. Now gin allows param and exact paths to existing on the same route level.

So all of the UI assets can be safely routed by `/` and `/:foo/*bar`. This is almost the same as the `/*any`.

### What is changed and how it works?

Except for all descriptions above, this PR also introduces some bug fixes and so on:

- Fix the problem of duplicate `uid` indices in SQLite
- Use `gorm.Model` to replace dummy fields
- Bump API server and UI versions
- Some code formats

### Related changes

* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
