### PR TITLE
fix: fix broken CI "Script Test" and "Intergration Test"

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.2.0
 
       - name: Install Chaos Mesh
         run: |

--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Chaos Mesh
         run: |
-          bash install.sh --local kind --crd ./manifests/crd.yaml
+          bash install.sh --runtime containerd --crd ./manifests/crd.yaml
 
       - name: Run integration test
         run: |

--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
 
       - name: Creating kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.2.0
 
       - name: Install Chaos Mesh
         run: |

--- a/pkg/workflow/controllers/serial_node_reconciler_test.go
+++ b/pkg/workflow/controllers/serial_node_reconciler_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Workflow", func() {
 				stressChaosDuration := 9 * time.Second
 				stressChaosDurationString := stressChaosDuration.String()
 
-				toleratedJitter := 3 * time.Second
+				toleratedJitter := 10 * time.Second
 
 				simpleSerialWorkflow := v1alpha1.Workflow{
 					ObjectMeta: metav1.ObjectMeta{

--- a/test/integration_test/aws/run.sh
+++ b/test/integration_test/aws/run.sh
@@ -20,9 +20,11 @@ cd $cur
 
 # wait localstash pod status to running
 for ((k=0; k<30; k++)); do
-    not_run_num=`kubectl get pods -l app.kubernetes.io/name=localstack --no-headers | grep -v Running | wc -l`
 
-    if [ $not_run_num == 0 ]; then
+    JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{"\n"}{end}'
+    not_ready_num=`kubectl get pods -l app.kubernetes.io/name=localstack --no-headers -o jsonpath="$JSONPATH" | grep "Ready=False" | wc -l`
+
+    if [ $not_ready_num == 0 ]; then
         break
     fi
 


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

trying to fix the broken Github action in #2066 #2062 #2036

What I see is the pod of chaos-controller-manager stuck in `Pending`, then timeout:


```
...

chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     14m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     15m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     16m
Waiting for pod running
chaos-controller-manager-5974547cd9-gfbsm   0/1   Pending   0     17m
Waiting for pod status running timeout
Error: Process completed with exit code 1.
```
**I still not figure out the reason, but I think this issue is caused by the lack of resources.**

I find that we actually start up **2** (not one) kind cluster on the GitHub machine:

- helm/kind-action will create one
- `install.sh --local kind` will create another one

so I am trying to remove the second kind cluster which is duplicated.

It seems worked!

For "Intergration test", it seems localstack is not READY when we try to set up `kubectl forwarding`. We should update the polling check for that, not only `Running`, but also `READY`.