### PR TITLE
fix: duplicated field created_at with which in gorm.Model

### DIFF
--- a/pkg/apiserver/archive/archive.go
+++ b/pkg/apiserver/archive/archive.go
@@ -507,18 +507,12 @@ func (s *Service) listWorkflow(c *gin.Context) {
 	archives := make([]Archive, 0)
 
 	for _, meta := range metas {
-		parsedTime, err := time.Parse(time.RFC3339, meta.CreatedAt)
-		if err != nil {
-			c.Status(http.StatusInternalServerError)
-			_ = c.Error(utils.ErrInternalServer.NewWithNoMessage())
-			return
-		}
 		archives = append(archives, Archive{
 			UID:       meta.UID,
 			Kind:      v1alpha1.KindWorkflow,
 			Namespace: meta.Namespace,
 			Name:      meta.Name,
-			CreatedAt: parsedTime,
+			CreatedAt: meta.CreatedAt,
 		})
 	}
 
@@ -565,20 +559,13 @@ func (s *Service) detailWorkflow(c *gin.Context) {
 		return
 	}
 
-	parsedTime, err := time.Parse(time.RFC3339, meta.CreatedAt)
-	if err != nil {
-		c.Status(http.StatusInternalServerError)
-		_ = c.Error(utils.ErrInternalServer.NewWithNoMessage())
-		return
-	}
-
 	detail = Detail{
 		Archive: Archive{
 			UID:       meta.UID,
 			Kind:      v1alpha1.KindWorkflow,
 			Name:      meta.Name,
 			Namespace: meta.Namespace,
-			CreatedAt: parsedTime,
+			CreatedAt: meta.CreatedAt,
 		},
 		KubeObject: core.KubeObjectDesc{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/apiserver/workflow/workflow.go
+++ b/pkg/apiserver/workflow/workflow.go
@@ -113,7 +113,7 @@ func (it *Service) listWorkflows(c *gin.Context) {
 	}
 
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].CreatedAt > result[j].CreatedAt
+		return result[i].CreatedAt.After(result[i].CreatedAt)
 	})
 
 	c.JSON(http.StatusOK, result)

--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -260,7 +260,7 @@ func convertWorkflow(kubeWorkflow v1alpha1.Workflow) WorkflowMeta {
 	}
 
 	if kubeWorkflow.Status.StartTime != nil {
-		result.CreatedAt = kubeWorkflow.Status.StartTime.Format(time.RFC3339)
+		result.CreatedAt = kubeWorkflow.Status.StartTime.Time
 	}
 
 	if kubeWorkflow.Status.EndTime != nil {

--- a/pkg/core/workflow.go
+++ b/pkg/core/workflow.go
@@ -55,7 +55,6 @@ type WorkflowMeta struct {
 	Namespace string         `json:"namespace"`
 	Name      string         `json:"name"`
 	Entry     string         `json:"entry"` // the entry node name
-	CreatedAt string         `json:"created_at"`
 	EndTime   string         `json:"end_time"`
 	Status    WorkflowStatus `json:"status,omitempty"`
 	Archived  bool           `json:"-"`


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #2077

Problem Summary:

A duplicated field `CreatedAt` already exists in `gorm.Model`, remove the outer one. 

### What is changed and how it works?

What's Changed:
- remove field `CreatedAt`

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
