### PR TITLE
chore: show children of task node

### DIFF
--- a/ui/src/api/workflows.type.ts
+++ b/ui/src/api/workflows.type.ts
@@ -19,13 +19,20 @@ interface MultiNode {
 type SerialNode = MultiNode
 type ParallelNode = MultiNode
 
+interface ConditionalBranch {
+  name: string
+  template: string
+  Expression: string
+}
+
 export interface Node {
   name: string
-  type: 'ChaosNode' | 'SerialNode' | 'ParallelNode' | 'SuspendNode'
+  type: 'ChaosNode' | 'SerialNode' | 'ParallelNode' | 'SuspendNode' | 'TaskNode'
   state: string
   template: string
   serial?: SerialNode
   parallel?: ParallelNode
+  conditional_branches?: Array<ConditionalBranch>
 }
 
 export interface WorkflowSingle extends Workflow {

--- a/ui/src/lib/cytoscape.ts
+++ b/ui/src/lib/cytoscape.ts
@@ -98,7 +98,7 @@ function generateWorkflowEdges(
       generateWorkflowEdges(result, connections, [...source[1], ...nodes.slice(1)])
 
       // connectSerial(result, source[2], source[1])
-    } else if (type === 'ParallelNode') {
+    } else if (type === 'ParallelNode' || type === 'TaskNode') {
       const c = {
         data: {
           id: `parallel-connection-${source[2]}`,

--- a/ui/src/lib/cytoscape.ts
+++ b/ui/src/lib/cytoscape.ts
@@ -21,8 +21,6 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
       return [n.name, n]
     })
   )
-  const mainChildren = entryNode!.serial?.children
-
   function toCytoscapeNode(node: Node): RecursiveNodeDefinition {
     const { name, type, state, template } = node
 
@@ -38,6 +36,12 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
         node.parallel!.children.filter((d) => d.name).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)),
         node.name,
       ]
+    } else if (type === 'TaskNode' && node.conditional_branches!.length) {
+      return [
+        type,
+        node.conditional_branches!.filter((d) => d.name).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)),
+        node.name,
+      ]
     } else {
       return {
         data: {
@@ -51,10 +55,7 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
     }
   }
 
-  return mainChildren!
-    .filter((d) => d.name)
-    .map((d) => nodeMap.get(d.name))
-    .map((d) => toCytoscapeNode(d!))
+  return [toCytoscapeNode(entryNode!)]
 }
 
 function mergeStates(nodes: NodeDefinition[]) {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #2051


### What is changed and how it works?

What's Changed:

- change the way to generate workflow nodes of the graph
- use the same way which draws the PrallelNode to draw TaskNode

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: Yes, release-2.0.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
