### PR TITLE
Update PSP RoleBinding to respect release namespace

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -16,7 +16,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-daemon-target-namespace
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemon

--- a/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-rbac.yaml
@@ -16,7 +16,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-chaos-daemon-target-namespace
-  namespace: chaos-testing
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemon


### PR DESCRIPTION
Currently, this value is hardcoded, which means that deploying with a
PSP to any namespace other than 'chaos-testing' will cause the daemonset
pods to fail to be admitted, because there is no valid PSP that matches
them.

Signed-off-by: Nikolas Skoufis <nskoufis@seek.com.au>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #2095 

Problem Summary: Hardcoded namespace in PSP RoleBinding

### What is changed and how it works?

What's Changed: Set the namespace of this RoleBinding to the same as the overall release namespace

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixes the namespace of the PSP RoleBinding so that it matches the release namespace
```
