### PR TITLE
fix: handle routes without slash

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -78,6 +78,9 @@ func newEngine(config *config.ChaosDashboardConfig) *gin.Engine {
 		// `/:foo/*bar` from https://en.wikipedia.org/wiki/Foobar, the name itself has no meaning.
 		//
 		// This handle just internally redirects all no-exact routes to the root directory of static files because the UI is a single page application and only has one entry (index.html).
+		r.GET("/:foo", func(c *gin.Context) {
+			c.FileFromFS("/", ui)
+		})
 		r.GET("/:foo/*bar", func(c *gin.Context) {
 			c.FileFromFS("/", ui)
 		})


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

### What problem does this PR solve?

Problem Summary:

As the title. This PR complements the missing handler since gin treats routes with and without a slash as two different routes.

### Related changes

* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
