### PR TITLE
alert when no record has been selected

### DIFF
--- a/controllers/common/controller.go
+++ b/controllers/common/controller.go
@@ -116,6 +116,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// TODO: dynamic upgrade the records when some of these pods/containers stopped
 	}
 
+	if len(records) == 0 {
+		r.Log.Info("no record has been selected")
+		r.Recorder.Event(obj, recorder.Failed{
+			Activity: "select targets",
+			Err:      "no record has been selected",
+		})
+		return ctrl.Result{}, nil
+	}
+
 	needRetry := false
 	for index, record := range records {
 		var err error


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

### What problem does this PR solve?

Problem Summary:

In `PodSelector`, when no pod is selected, an error will be returned. However, in `ContainerSelector`, if no container is selected, there will be no error.

A zero-length check is added under the selection, so that when no records are selected, it will always submit an error event, even if there is no error returned.