### PR TITLE
fix data race in client and daemon

### DIFF
--- a/cmd/chaos-controller-manager/provider/updated_client.go
+++ b/cmd/chaos-controller-manager/provider/updated_client.go
@@ -18,7 +18,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	lru "github.com/hashicorp/golang-lru"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/cmd/chaos-controller-manager/provider/updated_client.go
+++ b/cmd/chaos-controller-manager/provider/updated_client.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	lru "github.com/hashicorp/golang-lru"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,8 @@ func (c *UpdatedClient) Get(ctx context.Context, key client.ObjectKey, obj runti
 			return nil
 		}
 		if cachedResourceVersion >= newResourceVersion {
+			cachedObject := cachedObject.(runtime.Object).DeepCopyObject()
+
 			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(cachedObject).Elem())
 		}
 	}
@@ -101,6 +104,15 @@ func (c *UpdatedClient) Update(ctx context.Context, obj runtime.Object, opts ...
 		return err
 	}
 
+	err = c.writeCache(obj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UpdatedClient) writeCache(obj runtime.Object) error {
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
 		return nil
@@ -115,6 +127,7 @@ func (c *UpdatedClient) Update(ctx context.Context, obj runtime.Object, opts ...
 	}
 
 	c.cache.Add(objectKey, obj.DeepCopyObject())
+
 	return nil
 }
 
@@ -127,7 +140,31 @@ func (c *UpdatedClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opt
 }
 
 func (c *UpdatedClient) Status() client.StatusWriter {
-	// TODO: add cache for status client
+	return &UpdatedStatusWriter{
+		statusWriter: c.client.Status(),
+		client:       c,
+	}
+}
 
-	return c.client.Status()
+type UpdatedStatusWriter struct {
+	statusWriter client.StatusWriter
+	client       *UpdatedClient
+}
+
+func (c *UpdatedStatusWriter) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	err := c.statusWriter.Update(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+
+	err = c.client.writeCache(obj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UpdatedStatusWriter) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.statusWriter.Patch(ctx, obj, patch, opts...)
 }

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -113,7 +113,7 @@ var _ = Describe("UpdatedClient", func() {
 			Expect(newObj.Data["test"]).To(Equal("1"))
 			newObj.Data["test"] = "2"
 			anotherCleanClient := mgr.GetClient()
-			err = anotherCleanClient.Update(context.TODO(), obj)
+			err = anotherCleanClient.Update(context.TODO(), newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			newObj = &corev1.ConfigMap{}

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -16,6 +16,7 @@ package provider
 import (
 	"context"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -116,6 +117,7 @@ var _ = Describe("UpdatedClient", func() {
 			err = anotherCleanClient.Update(context.TODO(), newObj)
 			Expect(err).ToNot(HaveOccurred())
 
+			time.Sleep(1 * time.Second)
 			newObj = &corev1.ConfigMap{}
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{
 				Namespace: "default",

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect
+	go.uber.org/atomic v1.6.0
 	go.uber.org/fx v1.12.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/pkg/bpm/buffer.go
+++ b/pkg/bpm/buffer.go
@@ -28,16 +28,6 @@ type blockingBuffer struct {
 	closed *atomic.Bool
 }
 
-type readCtx struct {
-	ret  chan readRet
-	data []byte
-}
-
-type readRet struct {
-	ln  int
-	err error
-}
-
 func NewBlockingBuffer() io.ReadWriteCloser {
 	m := sync.Mutex{}
 	return &blockingBuffer{


### PR DESCRIPTION
Signed-off-by: YangKeao <keao.yang@yahoo.com>

### What problem does this PR solve?

Fix two possible data race and add an `UpdatedStatusClient`:

1. The `blockingBuffer` is full of data race while reading and writing at the same time.
2. The object returned from the `cache` could be the same one, and the reference stored in it will be simply copied out. Run `DeepCopy` before assigning it to the new one.
