### PR TITLE
feat: add junit report xml output

### DIFF
--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -228,8 +228,8 @@ def call(BUILD_BRANCH, CREDENTIALS_ID) {
 		def GLOBALS = "SKIP_BUILD=y SKIP_IMAGE_BUILD=y GINKGO_NO_COLOR=y"
 		def artifacts = "go/src/github.com/chaos-mesh/chaos-mesh/artifacts"
 		def builds = [:]
-		builds["E2E v1.12.10"] = {
-                build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12.10  KIND_VERSION=0.8.1 ./hack/e2e.sh -- --ginkgo.focus='Basic'")
+		builds["E2E on kubernetes 1.12.10"] = {
+                build("v1.12", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.12.10 KIND_VERSION=0.8.1 ./hack/e2e.sh -- --ginkgo.focus='Basic'")
         }
         builds["E2E on kubernetes 1.20.4"] = {
                 build("v1.20", "${GLOBALS} GINKGO_NODES=6 KUBE_VERSION=v1.20.2 ./hack/e2e.sh -- --ginkgo.focus='Basic'")

--- a/e2e-test/e2e/e2e_test.go
+++ b/e2e-test/e2e/e2e_test.go
@@ -18,11 +18,13 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -86,6 +88,7 @@ func RunE2ETests(t *testing.T) {
 
 	// Run tests through the Ginkgo runner with output to console + JUnit for Jenkins
 	var r []ginkgo.Reporter
+	r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%v%02d.xml", framework.TestContext.ReportPrefix, ginkgoconfig.GinkgoConfig.ParallelNode))))
 	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, ginkgoconfig.GinkgoConfig.ParallelNode)
 
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "chaosmesh e2e suit", r)


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

It's a part of https://github.com/chaos-mesh/chaos-mesh/issues/1587.


Problem Summary:

- I am trying to add the junit style output of all the e2e testcases.

### What is changed and how it works?

What's Changed:

- just add a new ginkgo reporter
- contributors could see which and why the e2e tests cases failed more easily.

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: Yes. release-2.0

Preview:

All tests passed:
![image](https://user-images.githubusercontent.com/20221408/127841040-98375282-100f-460e-84ce-7ce576c98a8a.png)

test failed:
![image](https://user-images.githubusercontent.com/20221408/127841003-01807466-3ab0-411c-b76b-55759e8fc9d6.png)


### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [x] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
