### PR TITLE
Imagepullsecrets feature

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -22,6 +22,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `rbac.create` |  | `true`                                                |
 | `timezone` | The timezone where controller-manager, chaos-daemon and dashboard uses. For example: `UTC`, `Asia/Shanghai` | `UTC` |
 | `enableProfiling` | A flag to enable pprof in controller-manager and chaos-daemon  | `true` |
+| `imagePullSecrets` | Global Docker registry secret names as an array  | [] (does not add image pull secrets to deployed pods) |
 | `controllerManager.hostNetwork` | running chaos-controller-manager on host network | `false` |
 | `controllerManager.allowHostNetworkTesting`   | Allow testing on `hostNetwork` pods | `false` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -33,6 +33,9 @@ spec:
       hostIPC: true
       hostPID: true
       priorityClassName: {{ .Values.chaosDaemon.priorityClassName}}
+  {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+  {{- end }}
       containers:
         - name: chaos-daemon
           image: {{template "registry-prefix" .}}{{ .Values.chaosDaemon.image }}

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -34,6 +34,9 @@ spec:
       {{- if .Values.chaosDlv.enable }}
       shareProcessNamespace: true
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: chaos-dashboard
           image: {{template "registry-prefix" .}}{{ .Values.dashboard.image }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- if .Values.chaosDlv.enable }}
       shareProcessNamespace: true
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: chaos-mesh
         image: {{template "registry-prefix" .}}{{ .Values.controllerManager.image }}

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -51,6 +51,9 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       priorityClassName: {{ .Values.dnsServer.priorityClassName}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: chaos-dns-server
         image: {{template "registry-prefix" .}}{{ .Values.dnsServer.image }}

--- a/helm/chaos-mesh/templates/prometheus-deployment.yaml
+++ b/helm/chaos-mesh/templates/prometheus-deployment.yaml
@@ -28,6 +28,9 @@ spec:
       serviceAccount: {{ .Values.prometheus.serviceAccount }}
       {{- end }}
       priorityClassName: {{ .Values.prometheus.priorityClassName}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: data-permission-fix
           image: busybox

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -28,6 +28,11 @@ enableProfiling: true
 
 registry: ""
 
+## Optional array of imagePullSecrets containing private registry credentials
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# - name: secretName
+
 controllerManager:
   hostNetwork: false
   serviceAccount: chaos-controller-manager


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. helm chart: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #2199

Problem Summary:
When your chaos mesh images reside in a private registry, one may need the ability to configure a docker secret via imagePullSecrets in the helm values file which can be enabled and overridden as required.

### What is changed and how it works?

Proposal/What's Changed:
Specify an imagePullSecrets parameter in the values file, which can be overridden with a docker secret. If this imagePullSecrets value is present, it can be used in the 4 deployment files and 1 daemonset file to pull images from a private registry

### Related changes
N/A

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

#### Manual Steps to Test
* Create a new private azure container registry i.e. chaosmeshtest.azurecr.io
* Publish chaos mesh images to chaosmeshtest.azurecr.io
* * pingcap/chaos-daemon
* * pingcap/chaos-dashboard
* * pingcap/chaos-kernel
* * pingcap/chaos-mesh
* * pingcap/coredns
* * prom/prometheus

* Deploy kind cluster locally
* Create Docker Secret to access chaosmeshtest.azurecr.io
```
kubectl create secret docker-registry regcred --docker-server=chaosmeshtest.azurecr.io --docker-username=*** --docker-password=*** --docker-email=adrian.hynes@fmr.com
```
* Install helm chart with new registry, imagePullSecrets and enabling dashboard, dns server and prometheus
```
helm install chaos-mesh helm/chaos-mesh/ --set registry=chaosmeshtest.azurecr.io --set dashboard.create=true --set dnsServer.create=true --set prometheus.create=true --set imagePullSecrets[0].name=regcred
```
* All chaos pods images pulled down successfully from private registry and running as expected
* Simple test
* * Deploy nginx Pod
* * Deploy simple pod failure


Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
New imagePullSecrets parameter added to the values file, which can be overridden with a docker secret. If this imagePullSecrets value is present, it can be used in the 4 deployment files and 1 daemonset file to pull images from a private registry
```
