### PR TITLE
HTTPChaos: fix bugs in replace or patch body; add validators and (e2e) tests

### DIFF
--- a/api/v1alpha1/httpchaos_types.go
+++ b/api/v1alpha1/httpchaos_types.go
@@ -39,7 +39,7 @@ type HTTPChaosSpec struct {
 	PodHttpChaosActions `json:",inline"`
 
 	// Port represents the target port to be proxy of.
-	Port int32 `json:"port,omitempty"`
+	Port int32 `json:"port,omitempty" webhook:"Port"`
 
 	// Path is a rule to select target by uri path in http request.
 	// +optional
@@ -47,7 +47,7 @@ type HTTPChaosSpec struct {
 
 	// Method is a rule to select target by http method in request.
 	// +optional
-	Method *string `json:"method,omitempty"`
+	Method *string `json:"method,omitempty" webhook:"HTTPMethod"`
 
 	// Code is a rule to select target by http status code in response.
 	// +optional

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1/genericwebhook"
+)
+
+type Port int32
+
+func (in *Port) Validate(root interface{}, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	// in cannot be zero or negative
+	if *in <= 0 {
+		allErrs = append(allErrs, field.Invalid(path, in, fmt.Sprintf("port %d is not supported", in)))
+	}
+	return allErrs
+}
+
+type HTTPMethod string
+
+func (in *HTTPMethod) Validate(root interface{}, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if in != nil && root.(*HTTPChaos).Spec.Target == PodHttpRequest {
+		switch *in {
+		case http.MethodGet:
+		case http.MethodPost:
+		case http.MethodPut:
+		case http.MethodDelete:
+		case http.MethodPatch:
+		case http.MethodHead:
+		case http.MethodOptions:
+		case http.MethodTrace:
+		case http.MethodConnect:
+		default:
+			allErrs = append(allErrs, field.Invalid(path, in, fmt.Sprintf("method %s is not supported", *in)))
+		}
+	}
+	return allErrs
+}
+
+func (in *PodHttpChaosTarget) Validate(root interface{}, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	switch *in {
+	case PodHttpRequest:
+	case PodHttpResponse:
+	default:
+		allErrs = append(allErrs, field.Invalid(path, in, fmt.Sprintf("target %s is not supported", *in)))
+	}
+	return allErrs
+}
+
+func init() {
+	genericwebhook.Register("Port", reflect.PtrTo(reflect.TypeOf(Port(0))))
+	genericwebhook.Register("HTTPMethod", reflect.PtrTo(reflect.TypeOf(HTTPMethod(""))))
+}

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -70,4 +70,5 @@ func (in *PodHttpChaosTarget) Validate(root interface{}, path *field.Path) field
 func init() {
 	genericwebhook.Register("Port", reflect.PtrTo(reflect.TypeOf(Port(0))))
 	genericwebhook.Register("HTTPMethod", reflect.PtrTo(reflect.TypeOf(HTTPMethod(""))))
+	genericwebhook.Register("PodHttpChaosTarget", reflect.PtrTo(reflect.TypeOf(PodHttpChaosTarget(""))))
 }

--- a/api/v1alpha1/httpchaos_webhook.go
+++ b/api/v1alpha1/httpchaos_webhook.go
@@ -29,7 +29,7 @@ func (in *Port) Validate(root interface{}, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// in cannot be zero or negative
 	if *in <= 0 {
-		allErrs = append(allErrs, field.Invalid(path, in, fmt.Sprintf("port %d is not supported", in)))
+		allErrs = append(allErrs, field.Invalid(path, in, fmt.Sprintf("port %d is not supported", *in)))
 	}
 	return allErrs
 }

--- a/api/v1alpha1/httpchaos_webhook_test.go
+++ b/api/v1alpha1/httpchaos_webhook_test.go
@@ -1,0 +1,344 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("HTTPChaos Webhook", func() {
+	Context("webhook.Validator of httpchaos", func() {
+		It("Validate", func() {
+			type TestCase struct {
+				name    string
+				chaos   HTTPChaos
+				execute func(chaos *HTTPChaos) error
+				expect  string
+			}
+			errorDuration := "400S"
+			errorMethod := "gET"
+			validMethod := http.MethodGet
+
+			tcs := []TestCase{
+				{
+					name: "simple ValidateCreate",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo1",
+						},
+						Spec: HTTPChaosSpec{
+							Target: PodHttpRequest,
+							Port:   80,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "",
+				},
+				{
+					name: "simple ValidateUpdate",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo2",
+						},
+						Spec: HTTPChaosSpec{
+							Target: PodHttpRequest,
+							Port:   80,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateUpdate(chaos)
+					},
+					expect: "",
+				},
+				{
+					name: "simple ValidateDelete",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo3",
+						},
+						Spec: HTTPChaosSpec{
+							Target: PodHttpRequest,
+							Port:   80,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateDelete()
+					},
+					expect: "",
+				},
+				{
+					name: "parse the duration error",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo6",
+						},
+						Spec: HTTPChaosSpec{
+							Duration: &errorDuration,
+							Target:   PodHttpRequest,
+							Port:     80,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate value with FixedPercentPodMode",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo7",
+						},
+						Spec: HTTPChaosSpec{
+							PodSelector: PodSelector{
+								Value: "0",
+								Mode:  FixedPodMode,
+							},
+							Port:   80,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate value with FixedPercentPodMode, parse value error",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo8",
+						},
+						Spec: HTTPChaosSpec{
+							PodSelector: PodSelector{
+								Value: "num",
+								Mode:  FixedPodMode,
+							},
+							Port:   80,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate value with RandomMaxPercentPodMode",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo9",
+						},
+						Spec: HTTPChaosSpec{
+							PodSelector: PodSelector{
+								Value: "0",
+								Mode:  RandomMaxPercentPodMode,
+							},
+							Port:   80,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate value with RandomMaxPercentPodMode ,parse value error",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo10",
+						},
+						Spec: HTTPChaosSpec{
+							PodSelector: PodSelector{
+								Value: "num",
+								Mode:  RandomMaxPercentPodMode,
+							},
+							Port:   80,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate value with FixedPercentPodMode",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo11",
+						},
+						Spec: HTTPChaosSpec{
+							PodSelector: PodSelector{
+								Value: "101",
+								Mode:  FixedPercentPodMode,
+							},
+							Port:   80,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate port 1",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo12",
+						},
+						Spec: HTTPChaosSpec{
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate port 2",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo13",
+						},
+						Spec: HTTPChaosSpec{
+							Port:   -1,
+							Target: PodHttpRequest,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate target 1",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo14",
+						},
+						Spec: HTTPChaosSpec{
+							Port: 80,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "validate target 2",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo15",
+						},
+						Spec: HTTPChaosSpec{
+							Port:   80,
+							Target: "request",
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+				{
+					name: "valid method 1",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo16",
+						},
+						Spec: HTTPChaosSpec{
+							Port:   80,
+							Target: PodHttpRequest,
+							Method: &validMethod,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "ok",
+				},
+				{
+					name: "valid method 2",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo17",
+						},
+						Spec: HTTPChaosSpec{
+							Port:   80,
+							Target: PodHttpResponse,
+							Method: &errorMethod,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "ok",
+				},
+				{
+					name: "invalid method",
+					chaos: HTTPChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo18",
+						},
+						Spec: HTTPChaosSpec{
+							Port:   80,
+							Target: PodHttpRequest,
+							Method: &errorMethod,
+						},
+					},
+					execute: func(chaos *HTTPChaos) error {
+						return chaos.ValidateCreate()
+					},
+					expect: "error",
+				},
+			}
+
+			for _, tc := range tcs {
+				err := tc.execute(&tc.chaos)
+				if tc.expect == "error" {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+		})
+	})
+})

--- a/e2e-test/cmd/e2e_helper/main.go
+++ b/e2e-test/cmd/e2e_helper/main.go
@@ -287,12 +287,11 @@ func (s *server) httpEcho(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
+	w.Header().Set("Secret", secret)
 	defer r.Body.Close()
 	_, err := io.Copy(w, r.Body)
 	if err != nil {
 		http.Error(w, "fail to copy body between request and response", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Secret", secret)
-	w.WriteHeader(http.StatusOK)
 }

--- a/e2e-test/cmd/e2e_helper/main.go
+++ b/e2e-test/cmd/e2e_helper/main.go
@@ -282,12 +282,15 @@ func (s *server) stressCondition(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) httpEcho(w http.ResponseWriter, r *http.Request) {
-	secret := r.Header.Get("Secret")
-	if secret == "" {
+	secrets := r.Header["Secret"]
+	if len(secrets) == 0 {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
-	w.Header().Set("Secret", secret)
+
+	for _, secret := range secrets {
+		w.Header().Add("Secret", secret)
+	}
 	defer r.Body.Close()
 	_, err := io.Copy(w, r.Body)
 	if err != nil {

--- a/e2e-test/e2e/chaos/basic.go
+++ b/e2e-test/e2e/chaos/basic.go
@@ -274,6 +274,16 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			})
 		})
 
+		// http chaos case in [HTTPReplace] context
+		ginkgo.Context("[HTTPReplace]", func() {
+			ginkgo.It("[Schedule]", func() {
+				httpchaostestcases.TestcaseHttpReplaceThenRecover(ns, cli, c, port)
+			})
+			ginkgo.It("[Pause]", func() {
+				httpchaostestcases.TestcaseHttpReplacePauseAndUnPause(ns, cli, c, port)
+			})
+		})
+
 	})
 
 	ginkgo.Context("[Sidecar Config]", func() {

--- a/e2e-test/e2e/chaos/basic.go
+++ b/e2e-test/e2e/chaos/basic.go
@@ -284,6 +284,15 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			})
 		})
 
+		// http chaos case in [HTTPPatch] context
+		ginkgo.Context("[HTTPPatch]", func() {
+			ginkgo.It("[Schedule]", func() {
+				httpchaostestcases.TestcaseHttpPatchThenRecover(ns, cli, c, port)
+			})
+			ginkgo.It("[Pause]", func() {
+				httpchaostestcases.TestcaseHttpPatchPauseAndUnPause(ns, cli, c, port)
+			})
+		})
 	})
 
 	ginkgo.Context("[Sidecar Config]", func() {

--- a/e2e-test/e2e/chaos/httpchaos/http_patch.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_patch.go
@@ -1,0 +1,390 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpchaos
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
+)
+
+func TestcaseHttpPatchThenRecover(
+	ns string,
+	cli client.Client,
+	c http.Client,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitE2EHelperReady(c, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
+	body := `{"msg":"Hello","target":"World"}`
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http patch chaos CRD objects")
+
+	patchbody := `{"target": "Chaos Mesh"}`
+	patchSecret := "Foo!"
+	expectedSecret := "Bar; Foo!"
+	expectedBody := `{"msg":"Hello","target":"Chaos Mesh"}`
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					Namespaces:     []string{ns},
+					LabelSelectors: map[string]string{"app": "http"},
+				},
+				Mode: v1alpha1.OnePodMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Patch: &v1alpha1.PodHttpChaosPatchActions{
+					Headers: [][]string{
+						{SECRET, patchSecret},
+					},
+					Body: &v1alpha1.PodHttpChaosPatchBodyAction{
+						Type:  "JSON",
+						Value: patchbody,
+					},
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	By("waiting for assertion HTTP patch")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == expectedSecret && string(b) == expectedBody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+	By("apply http chaos successfully")
+
+	By("delete chaos CRD objects")
+	// delete chaos CRD
+	err = cli.Delete(ctx, httpChaos)
+	framework.ExpectNoError(err, "failed to delete http chaos")
+
+	By("waiting for assertion recovering")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+}
+
+func TestcaseHttpPatchPauseAndUnPause(
+	ns string,
+	cli client.Client,
+	c http.Client,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitE2EHelperReady(c, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
+	body := `{"msg":"Hello","target":"World"}`
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http patch chaos CRD objects")
+	patchbody := `{"target": "Chaos Mesh"}`
+	patchSecret := "Foo!"
+	expectedSecret := "Bar; Foo!"
+	expectedBody := `{"msg":"Hello","target":"Chaos Mesh"}`
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					Namespaces:     []string{ns},
+					LabelSelectors: map[string]string{"app": "http"},
+				},
+				Mode: v1alpha1.OnePodMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Patch: &v1alpha1.PodHttpChaosPatchActions{
+					Headers: [][]string{
+						{SECRET, patchSecret},
+					},
+					Body: &v1alpha1.PodHttpChaosPatchBodyAction{
+						Type:  "JSON",
+						Value: patchbody,
+					},
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	chaosKey := types.NamespacedName{
+		Namespace: ns,
+		Name:      "http-chaos",
+	}
+
+	By("waiting for assertion http chaos")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == expectedSecret && string(b) == expectedBody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+
+	By("pause http patch chaos experiment")
+	// pause experiment
+	err = util.PauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "pause chaos error")
+
+	By("waiting for assertion about pause")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllRecovered {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check paused chaos failed")
+
+	// wait 1 min to check whether io patch still exists
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+
+	By("resume http patch chaos experiment")
+	// resume experiment
+	err = util.UnPauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "resume chaos error")
+
+	By("assert that http patch is effective again")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check resumed chaos failed")
+
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := strings.Join(resp.Header[SECRET], "; ")
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == expectedSecret && string(b) == expectedBody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "HTTP chaos doesn't work as expected")
+
+	By("cleanup")
+	// cleanup
+	cli.Delete(ctx, httpChaos)
+}

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -1,0 +1,378 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpchaos
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
+)
+
+func TestcaseHttpReplaceThenRecover(
+	ns string,
+	cli client.Client,
+	c http.Client,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitE2EHelperReady(c, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
+	body := "Hello World"
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http replace chaos CRD objects")
+	replacebody := "Hello Chaos Mesh"
+	replaceSecret := "Foo!"
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					Namespaces:     []string{ns},
+					LabelSelectors: map[string]string{"app": "http"},
+				},
+				Mode: v1alpha1.OnePodMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Replace: &v1alpha1.PodHttpChaosReplaceActions{
+					Headers: map[string]string{
+						SECRET: replaceSecret,
+					},
+					Body: []byte(replacebody),
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	By("waiting for assertion HTTP replace")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret && string(b) == replacebody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+	By("apply http chaos successfully")
+
+	By("delete chaos CRD objects")
+	// delete chaos CRD
+	err = cli.Delete(ctx, httpChaos)
+	framework.ExpectNoError(err, "failed to delete http chaos")
+
+	By("waiting for assertion recovering")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+}
+
+func TestcaseHttpReplacePauseAndUnPause(
+	ns string,
+	cli client.Client,
+	c http.Client,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitE2EHelperReady(c, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
+	body := "Hello World"
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http replace chaos CRD objects")
+	replacebody := "Hello Chaos Mesh"
+	replaceSecret := "Foo!"
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					Namespaces:     []string{ns},
+					LabelSelectors: map[string]string{"app": "http"},
+				},
+				Mode: v1alpha1.OnePodMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Replace: &v1alpha1.PodHttpChaosReplaceActions{
+					Headers: map[string]string{
+						SECRET: replaceSecret,
+					},
+					Body: []byte(replacebody),
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	chaosKey := types.NamespacedName{
+		Namespace: ns,
+		Name:      "http-chaos",
+	}
+
+	By("waiting for assertion http chaos")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret && string(b) == replacebody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+
+	By("pause http replace chaos experiment")
+	// pause experiment
+	err = util.PauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "pause chaos error")
+
+	By("waiting for assertion about pause")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllRecovered {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check paused chaos failed")
+
+	// wait 1 min to check whether io replace still exists
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret && string(b) == body {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+
+	By("resume http replace chaos experiment")
+	// resume experiment
+	err = util.UnPauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "resume chaos error")
+
+	By("assert that http replace is effective again")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check resumed chaos failed")
+
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, body)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret && string(b) == replacebody {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "HTTP chaos doesn't work as expected")
+
+	By("cleanup")
+	// cleanup
+	cli.Delete(ctx, httpChaos)
+}

--- a/e2e-test/e2e/chaos/httpchaos/misc.go
+++ b/e2e-test/e2e/chaos/httpchaos/misc.go
@@ -20,12 +20,14 @@ import (
 	"time"
 )
 
+const SECRET = "Secret"
+
 func getPodHttp(c http.Client, port uint16, secret, body string) (*http.Response, error) {
 	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/http", port), strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set("Secret", time.Now().Format(time.RFC3339))
+	request.Header.Set(SECRET, secret)
 	client := &http.Client{
 		Transport: &http.Transport{},
 	}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -363,6 +363,7 @@ webhook:
     - jvmchaos
     - schedule
     - workflow
+    - httpchaos
 
 bpfki:
   create: false

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -14,7 +14,7 @@ ENV RUST_BACKTRACE 1
 
 RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.2.0/toda-linux-amd64.tar.gz -o /usr/local/bin/toda.tar.gz
 RUN curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.5/nsexec-linux-amd64.tar.gz -o /usr/local/bin/nsexec.tar.gz
-RUN curl -L https://github.com/chaos-mesh/rs-tproxy/releases/download/v0.2.1/tproxy-linux-amd64.tar.gz -o /usr/local/bin/tproxy.tar.gz
+RUN curl -L https://github.com/chaos-mesh/rs-tproxy/releases/download/v0.2.3/tproxy-linux-amd64.tar.gz -o /usr/local/bin/tproxy.tar.gz
 
 RUN tar xvf /usr/local/bin/toda.tar.gz -C /usr/local/bin
 RUN rm /usr/local/bin/toda.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -1683,6 +1683,25 @@ webhooks:
           - UPDATE
         resources:
           - workflow
+  - clientConfig:
+      caBundle: "${CA_BUNDLE}"
+      service:
+        name: chaos-mesh-controller-manager
+        namespace: "chaos-testing"
+        path: /mutate-chaos-mesh-org-v1alpha1-httpchaos
+    failurePolicy: Fail
+    name: mhttpchaos.kb.io
+    timeoutSeconds: 5
+    rules:
+      - apiGroups:
+          - chaos-mesh.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1924,6 +1943,25 @@ webhooks:
           - UPDATE
         resources:
           - workflows
+  - clientConfig:
+      caBundle: "${CA_BUNDLE}"
+      service:
+        name: chaos-mesh-controller-manager
+        namespace: "chaos-testing"
+        path: /validate-chaos-mesh-org-v1alpha1-httpchaos
+    failurePolicy: Fail
+    name: vhttpchaos.kb.io
+    timeoutSeconds: 5
+    rules:
+      - apiGroups:
+          - chaos-mesh.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #2152 <!-- REMOVE this line if no issue to close -->

Problem Summary:

HTTPChaos patch or replace response not worked as expected, HTTP Header content-length is not updated.

### What is changed and how it works?

What's Changed:

Upgrade rs-tproxy to v0.2.3

### Related changes

* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [x] E2E test

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
