### PR TITLE
fix: the broken webhook for workflow

### DIFF
--- a/api/v1alpha1/common_webhook.go
+++ b/api/v1alpha1/common_webhook.go
@@ -30,7 +30,6 @@ const (
 	ValidateValueParseError = "parse value field error:%s"
 )
 
-
 // FIXME: interface ContainsDuration only used for validating EmbedChaos in Workflow
 
 // +kubebuilder:object:generate=false

--- a/api/v1alpha1/common_webhook.go
+++ b/api/v1alpha1/common_webhook.go
@@ -31,7 +31,7 @@ const (
 )
 
 
-// FIXME: struct ContainsDuration only used for validating EmbedChaos in Workflow
+// FIXME: interface ContainsDuration only used for validating EmbedChaos in Workflow
 
 // +kubebuilder:object:generate=false
 type ContainsDuration interface {

--- a/api/v1alpha1/common_webhook.go
+++ b/api/v1alpha1/common_webhook.go
@@ -30,11 +30,12 @@ const (
 	ValidateValueParseError = "parse value field error:%s"
 )
 
+
+// FIXME: struct ContainsDuration only used for validating EmbedChaos in Workflow
+
 // +kubebuilder:object:generate=false
-type CommonSpec interface {
+type ContainsDuration interface {
 	GetDuration() (*time.Duration, error)
-	Validate() field.ErrorList
-	Default()
 }
 
 type Duration string

--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -201,7 +201,7 @@ func shouldNotSetupDurationInTheChaos(path *field.Path, template Template) field
 			fmt.Sprintf("parse workflow field error: missing chaos spec %s", template.Type)))
 		return result
 	}
-	if commonSpec, ok := spec.Interface().(CommonSpec); !ok {
+	if commonSpec, ok := spec.Interface().(ContainsDuration); !ok {
 		result = append(result, field.Invalid(path, "", fmt.Sprintf("Chaos: %s does not implement CommonSpec", template.Type)))
 	} else {
 		duration, err := commonSpec.GetDuration()

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -401,6 +402,62 @@ func Test_namesCouldNotBeDuplicated(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := namesCouldNotBeDuplicated(tt.args.templatesPath, tt.args.names); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("namesCouldNotBeDuplicated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_shouldNotSetupDurationInTheChaos(t *testing.T) {
+	templatesPath := field.NewPath("spec", "templates")
+	duration20sString := "20s"
+	duration20s := 20 * time.Second
+
+	type args struct {
+		path     *field.Path
+		template Template
+	}
+	tests := []struct {
+		name string
+		args args
+		want field.ErrorList
+	}{
+		{
+			name: "should not set duration in the chaos",
+			args: args{
+				path: templatesPath,
+				template: Template{
+					Name: "invalid-pod-chaos",
+					Type: TypePodChaos,
+					EmbedChaos: &EmbedChaos{
+						PodChaos: &PodChaosSpec{
+							Duration: &duration20sString,
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(templatesPath, &duration20s, "should not define duration in chaos when using Workflow, use Template#Deadline instead."),
+			},
+		}, {
+			name: "should set duration in the template",
+			args: args{
+				path: templatesPath,
+				template: Template{
+					Name:     "invalid-pod-chaos",
+					Type:     TypePodChaos,
+					Deadline: &duration20sString,
+					EmbedChaos: &EmbedChaos{
+						PodChaos: &PodChaosSpec{},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldNotSetupDurationInTheChaos(tt.args.path, tt.args.template); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("shouldNotSetupDurationInTheChaos() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

Issue Number:

Problem Summary:

Thanks to @g1eny0ung for noticing me about this issue.

As #2122 merged, some of the generated methods (`Validate() field.ErrorList` and `Default()`) for interface `CommonSpec` has been purged ``:

```golang
type CommonSpec interface {
	GetDuration() (*time.Duration, error)
	Validate() field.ErrorList
	Default()
}
```

but `GetDuration()` is required for validation in workflow by `shouldNotSetupDurationInTheChaos()`.

So I rename and slim the unimplemented methods of `CommonSpec`.

### What is changed and how it works?

What's Changed:

- delete `Validate() field.ErrorList` and `Default` in interface `CommonSpec`
- rename interface `CommonSpec` to `ContainsDuration`
- add some unit test for this validation webhook

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
