### PR TITLE
Update the coredns image version for helm value

### DIFF
--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -266,7 +266,7 @@ dnsServer:
 
   serviceAccount: chaos-dns-server
 
-  image: pingcap/coredns:v0.2.0
+  image: pingcap/coredns:v0.2.1
 
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION

Update helm coredns version from 0.2.0 to 0.2.1

### What problem does this PR solve?

bug of codns chaos serve rpc retrun nil 

### What is changed and how it works?


What's Changed:

from  image: pingcap/coredns:v0.2.0
to   image: pingcap/coredns:v0.2.1
according to https://github.com/chaos-mesh/chaos-mesh/issues/2163#issuecomment-899354774
### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch


Tests
<!-- At least one of them must be included. -->

- [ ] E2E test


Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
update coredns image to 0.2.1