### PR TITLE
use `host-sys` in fusedev device priviledge granting

### DIFF
--- a/pkg/fusedev/fusedev_linux.go
+++ b/pkg/fusedev/fusedev_linux.go
@@ -58,7 +58,8 @@ func GrantAccess() error {
 		return errors.Errorf("fail to find device cgroup")
 	}
 
-	deviceCgroupPath = "/sys/fs/cgroup/devices" + deviceCgroupPath + "/devices.allow"
+	// It's hard to use /pkg/chaosdaemon/cgroups to wrap this logic.
+	deviceCgroupPath = "/host-sys/fs/cgroup/devices" + deviceCgroupPath + "/devices.allow"
 	f, err := os.OpenFile(deviceCgroupPath, os.O_WRONLY, 0)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

As the `chaos-daemon` tried to write `device.allow` in cgroup, but used the `/sys/fs/cgroup` as the root path, it will give an error. The root path of host cgroup should be `/host-sys/fs/cgroup`.

### What is changed and how it works?

Modify `sys` to `host-sys`.