### PR TITLE
fix(StressChaos): containerNames problem

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -373,14 +373,11 @@ func (s *Service) createStressChaos(exp *core.ExperimentInfo, kubeCli client.Cli
 					Mode:     v1alpha1.PodMode(exp.Scope.Mode),
 					Value:    exp.Scope.Value,
 				},
+				ContainerNames: exp.Target.StressChaos.ContainerNames,
 			},
 			Stressors:         stressors,
 			StressngStressors: exp.Target.StressChaos.StressngStressors,
 		},
-	}
-
-	if exp.Target.StressChaos.ContainerName != nil {
-		chaos.Spec.ContainerNames = []string{*exp.Target.StressChaos.ContainerName}
 	}
 
 	if exp.Scheduler.Duration != "" {

--- a/pkg/apiserver/schedule/schedule.go
+++ b/pkg/apiserver/schedule/schedule.go
@@ -388,14 +388,11 @@ func parseStressChaos(exp *core.ScheduleInfo) v1alpha1.ScheduleItem {
 					Mode:     v1alpha1.PodMode(exp.Scope.Mode),
 					Value:    exp.Scope.Value,
 				},
+				ContainerNames: exp.Target.StressChaos.ContainerNames,
 			},
 			Stressors:         stressors,
 			StressngStressors: exp.Target.StressChaos.StressngStressors,
 		},
-	}
-
-	if exp.Target.StressChaos.ContainerName != nil {
-		chaos.Spec.ContainerSelector.ContainerNames = []string{*exp.Target.StressChaos.ContainerName}
 	}
 
 	if exp.Duration != "" {

--- a/pkg/core/experiment.go
+++ b/pkg/core/experiment.go
@@ -212,7 +212,7 @@ type TimeChaosInfo struct {
 type StressChaosInfo struct {
 	Stressors         *v1alpha1.Stressors `json:"stressors"`
 	StressngStressors string              `json:"stressng_stressors,omitempty"`
-	ContainerName     *string             `json:"container_name,omitempty"`
+	ContainerNames    []string            `json:"container_names,omitempty"`
 }
 
 // DNSChaosInfo defines the basic information of dns chaos for creating a new DNSChaos.

--- a/ui/src/components/NewExperimentNext/data/target.ts
+++ b/ui/src/components/NewExperimentNext/data/target.ts
@@ -416,7 +416,7 @@ const data: Record<Kind, Target> = {
         },
       },
       stressng_stressors: '',
-      container_name: '',
+      container_names: [],
     } as any,
   },
   // Kernel Fault

--- a/ui/src/components/NewExperimentNext/form/Stress.tsx
+++ b/ui/src/components/NewExperimentNext/form/Stress.tsx
@@ -98,10 +98,10 @@ const Stress: React.FC<StressProps> = ({ onSubmit }) => {
               label="Options of stress-ng"
               helperText="The options of stress-ng, treated as a string"
             />
-            <TextField
-              name="container_name"
-              label="Container Name"
-              helperText="Optional. Fill the container name you want to inject stress in"
+            <LabelField
+              name="container_names"
+              label="Container Names"
+              helperText="Optional. Type string and end with a space to generate the container names. If it's empty, all containers will be injected"
             />
           </AdvancedOptions>
 


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Unify the `containerNames` field on front-end and back-end.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
