### PR TITLE
fix: the download url of kubebuilder

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -123,7 +123,7 @@ function hack::ensure_kubebuilder() {
     fi
     tmpfile=$(mktemp)
     trap "test -f $tmpfile && rm $tmpfile" RETURN
-    curl --retry 10 -L -o ${tmpfile} https://go.kubebuilder.io/dl/$KUBEBUILDER_VERSION/$OS/$ARCH
+    curl --retry 10 -L -o ${tmpfile} https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_${OS}_${ARCH}.tar.gz
     tar -C ${OUTPUT_BIN} -xzf ${tmpfile}
     mv ${OUTPUT_BIN}/kubebuilder_${KUBEBUILDER_VERSION}_${OS}_${ARCH} ${KUBEBUILDER_PATH}
 }

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -123,6 +123,10 @@ function hack::ensure_kubebuilder() {
     fi
     tmpfile=$(mktemp)
     trap "test -f $tmpfile && rm $tmpfile" RETURN
+
+    # reference: https://github.com/kubernetes-sigs/kubebuilder/issues/2311#issuecomment-903940052
+    # and https://github.com/chaos-mesh/chaos-mesh/issues/2248
+    # kubebuilder_${KUBEBUILDER_VERSION}_${OS}_${ARCH}.tar.gz only works for kubebuilder v2.x, if we upgrade to v3 one day, we need to change the filename, remove the ${KUBEBUILDER_VERSION}
     curl --retry 10 -L -o ${tmpfile} https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_${OS}_${ARCH}.tar.gz
     tar -C ${OUTPUT_BIN} -xzf ${tmpfile}
     mv ${OUTPUT_BIN}/kubebuilder_${KUBEBUILDER_VERSION}_${OS}_${ARCH} ${KUBEBUILDER_PATH}


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/chaos-mesh/chaos-mesh/issues/2248

Problem Summary:

- URL for downloading kubebuilder broken

### What is changed and how it works?

What's Changed:
- use github release instead of go.kubebuilder.io/dl

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
