### PR TITLE
refactor: add SpawnObject and SpawnList for ChaosKind

### DIFF
--- a/api/v1alpha1/kinds.go
+++ b/api/v1alpha1/kinds.go
@@ -33,6 +33,7 @@ func (c *chaosKindMap) register(name string, kind *ChaosKind) {
 	c.kinds[name] = kind
 }
 
+// clone will build a new map with kinds, so if user add or delete entries of the map, the origin global map will not be affected.
 func (c *chaosKindMap) clone() map[string]*ChaosKind {
 	c.RLock()
 	defer c.RUnlock()
@@ -40,15 +41,15 @@ func (c *chaosKindMap) clone() map[string]*ChaosKind {
 	out := make(map[string]*ChaosKind)
 	for key, kind := range c.kinds {
 		out[key] = &ChaosKind{
-			Chaos:            kind.Chaos,
-			GenericChaosList: kind.GenericChaosList,
+			chaos: kind.chaos,
+			list:  kind.list,
 		}
 	}
 
 	return out
 }
 
-// AllKinds returns all chaos kinds.
+// AllKinds returns all chaos kinds, key is name of Kind, value is an accessor for spawning Object and List
 func AllKinds() map[string]*ChaosKind {
 	return all.clone()
 }
@@ -62,8 +63,18 @@ var all = &chaosKindMap{
 
 // ChaosKind includes one kind of chaos and its list type
 type ChaosKind struct {
-	Chaos client.Object
-	GenericChaosList
+	chaos client.Object
+	list  GenericChaosList
+}
+
+// SpawnObject will deepcopy a clean struct for the acquired kind as placeholder
+func (it *ChaosKind) SpawnObject() client.Object {
+	return it.chaos.DeepCopyObject().(client.Object)
+}
+
+// SpawnList will deepcopy a clean list for the acquired kind of chaos as placeholder
+func (it *ChaosKind) SpawnList() GenericChaosList {
+	return it.list.DeepCopyList()
 }
 
 // AllKinds returns all chaos kinds.

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -185,7 +185,7 @@ func init() {
 
 func FetchChaosByTemplateType(templateType TemplateType) (runtime.Object, error) {
 	if kind, ok := all.kinds[string(templateType)]; ok {
-		return kind.Chaos.DeepCopyObject(), nil
+		return kind.SpawnObject(), nil
 	}
 	return nil, fmt.Errorf("no such kind refers to template type %s", templateType)
 }

--- a/api/v1alpha1/zz_generated.chaosmesh.go
+++ b/api/v1alpha1/zz_generated.chaosmesh.go
@@ -1531,129 +1531,129 @@ func init() {
 
 	SchemeBuilder.Register(&AWSChaos{}, &AWSChaosList{})
 	all.register(KindAWSChaos, &ChaosKind{
-		Chaos:     &AWSChaos{},
-		GenericChaosList: &AWSChaosList{},
+		chaos: &AWSChaos{},
+		list:  &AWSChaosList{},
 	})
 
 	SchemeBuilder.Register(&DNSChaos{}, &DNSChaosList{})
 	all.register(KindDNSChaos, &ChaosKind{
-		Chaos:     &DNSChaos{},
-		GenericChaosList: &DNSChaosList{},
+		chaos: &DNSChaos{},
+		list:  &DNSChaosList{},
 	})
 
 	SchemeBuilder.Register(&GCPChaos{}, &GCPChaosList{})
 	all.register(KindGCPChaos, &ChaosKind{
-		Chaos:     &GCPChaos{},
-		GenericChaosList: &GCPChaosList{},
+		chaos: &GCPChaos{},
+		list:  &GCPChaosList{},
 	})
 
 	SchemeBuilder.Register(&HTTPChaos{}, &HTTPChaosList{})
 	all.register(KindHTTPChaos, &ChaosKind{
-		Chaos:     &HTTPChaos{},
-		GenericChaosList: &HTTPChaosList{},
+		chaos: &HTTPChaos{},
+		list:  &HTTPChaosList{},
 	})
 
 	SchemeBuilder.Register(&IOChaos{}, &IOChaosList{})
 	all.register(KindIOChaos, &ChaosKind{
-		Chaos:     &IOChaos{},
-		GenericChaosList: &IOChaosList{},
+		chaos: &IOChaos{},
+		list:  &IOChaosList{},
 	})
 
 	SchemeBuilder.Register(&JVMChaos{}, &JVMChaosList{})
 	all.register(KindJVMChaos, &ChaosKind{
-		Chaos:     &JVMChaos{},
-		GenericChaosList: &JVMChaosList{},
+		chaos: &JVMChaos{},
+		list:  &JVMChaosList{},
 	})
 
 	SchemeBuilder.Register(&KernelChaos{}, &KernelChaosList{})
 	all.register(KindKernelChaos, &ChaosKind{
-		Chaos:     &KernelChaos{},
-		GenericChaosList: &KernelChaosList{},
+		chaos: &KernelChaos{},
+		list:  &KernelChaosList{},
 	})
 
 	SchemeBuilder.Register(&NetworkChaos{}, &NetworkChaosList{})
 	all.register(KindNetworkChaos, &ChaosKind{
-		Chaos:     &NetworkChaos{},
-		GenericChaosList: &NetworkChaosList{},
+		chaos: &NetworkChaos{},
+		list:  &NetworkChaosList{},
 	})
 
 	SchemeBuilder.Register(&PodChaos{}, &PodChaosList{})
 	all.register(KindPodChaos, &ChaosKind{
-		Chaos:     &PodChaos{},
-		GenericChaosList: &PodChaosList{},
+		chaos: &PodChaos{},
+		list:  &PodChaosList{},
 	})
 
 	SchemeBuilder.Register(&StressChaos{}, &StressChaosList{})
 	all.register(KindStressChaos, &ChaosKind{
-		Chaos:     &StressChaos{},
-		GenericChaosList: &StressChaosList{},
+		chaos: &StressChaos{},
+		list:  &StressChaosList{},
 	})
 
 	SchemeBuilder.Register(&TimeChaos{}, &TimeChaosList{})
 	all.register(KindTimeChaos, &ChaosKind{
-		Chaos:     &TimeChaos{},
-		GenericChaosList: &TimeChaosList{},
+		chaos: &TimeChaos{},
+		list:  &TimeChaosList{},
 	})
 
 
 	allScheduleItem.register(KindAWSChaos, &ChaosKind{
-		Chaos:     &AWSChaos{},
-		GenericChaosList: &AWSChaosList{},
+		chaos: &AWSChaos{},
+		list:  &AWSChaosList{},
 	})
 
 	allScheduleItem.register(KindDNSChaos, &ChaosKind{
-		Chaos:     &DNSChaos{},
-		GenericChaosList: &DNSChaosList{},
+		chaos: &DNSChaos{},
+		list:  &DNSChaosList{},
 	})
 
 	allScheduleItem.register(KindGCPChaos, &ChaosKind{
-		Chaos:     &GCPChaos{},
-		GenericChaosList: &GCPChaosList{},
+		chaos: &GCPChaos{},
+		list:  &GCPChaosList{},
 	})
 
 	allScheduleItem.register(KindHTTPChaos, &ChaosKind{
-		Chaos:     &HTTPChaos{},
-		GenericChaosList: &HTTPChaosList{},
+		chaos: &HTTPChaos{},
+		list:  &HTTPChaosList{},
 	})
 
 	allScheduleItem.register(KindIOChaos, &ChaosKind{
-		Chaos:     &IOChaos{},
-		GenericChaosList: &IOChaosList{},
+		chaos: &IOChaos{},
+		list:  &IOChaosList{},
 	})
 
 	allScheduleItem.register(KindJVMChaos, &ChaosKind{
-		Chaos:     &JVMChaos{},
-		GenericChaosList: &JVMChaosList{},
+		chaos: &JVMChaos{},
+		list:  &JVMChaosList{},
 	})
 
 	allScheduleItem.register(KindKernelChaos, &ChaosKind{
-		Chaos:     &KernelChaos{},
-		GenericChaosList: &KernelChaosList{},
+		chaos: &KernelChaos{},
+		list:  &KernelChaosList{},
 	})
 
 	allScheduleItem.register(KindNetworkChaos, &ChaosKind{
-		Chaos:     &NetworkChaos{},
-		GenericChaosList: &NetworkChaosList{},
+		chaos: &NetworkChaos{},
+		list:  &NetworkChaosList{},
 	})
 
 	allScheduleItem.register(KindPodChaos, &ChaosKind{
-		Chaos:     &PodChaos{},
-		GenericChaosList: &PodChaosList{},
+		chaos: &PodChaos{},
+		list:  &PodChaosList{},
 	})
 
 	allScheduleItem.register(KindStressChaos, &ChaosKind{
-		Chaos:     &StressChaos{},
-		GenericChaosList: &StressChaosList{},
+		chaos: &StressChaos{},
+		list:  &StressChaosList{},
 	})
 
 	allScheduleItem.register(KindTimeChaos, &ChaosKind{
-		Chaos:     &TimeChaos{},
-		GenericChaosList: &TimeChaosList{},
+		chaos: &TimeChaos{},
+		list:  &TimeChaosList{},
 	})
 
 	allScheduleItem.register(KindWorkflow, &ChaosKind{
-		Chaos:     &Workflow{},
-		GenericChaosList: &WorkflowList{},
+		chaos: &Workflow{},
+		list:  &WorkflowList{},
 	})
 
 }

--- a/api/webhook/validate_auth.go
+++ b/api/webhook/validate_auth.go
@@ -91,7 +91,7 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 		err := fmt.Errorf("kind %s is not support", requestKind)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	chaos := kind.Chaos.DeepCopyObject().(common.InnerObjectWithSelector)
+	chaos := kind.SpawnObject().(common.InnerObjectWithSelector)
 	if chaos == nil {
 		err := fmt.Errorf("kind %s is not support", requestKind)
 		return admission.Errored(http.StatusBadRequest, err)

--- a/cmd/chaos-builder/init.go
+++ b/cmd/chaos-builder/init.go
@@ -21,8 +21,8 @@ import (
 const initTemplate = `
 	SchemeBuilder.Register(&{{.Type}}{}, &{{.Type}}List{})
 	all.register(Kind{{.Type}}, &ChaosKind{
-		Chaos:     &{{.Type}}{},
-		GenericChaosList: &{{.Type}}List{},
+		chaos: &{{.Type}}{},
+		list:  &{{.Type}}List{},
 	})
 `
 

--- a/cmd/chaos-builder/schedule.go
+++ b/cmd/chaos-builder/schedule.go
@@ -21,8 +21,8 @@ import (
 
 const scheduleTemplate = `
 	allScheduleItem.register(Kind{{.Type}}, &ChaosKind{
-		Chaos:     &{{.Type}}{},
-		GenericChaosList: &{{.Type}}List{},
+		chaos: &{{.Type}}{},
+		list:  &{{.Type}}List{},
 	})
 `
 

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -120,12 +120,13 @@ func (c *ChaosCollector) collect() {
 
 	for kind, obj := range v1alpha1.AllKinds() {
 		expCache := map[string]map[string]int{}
-		if err := c.store.List(context.TODO(), obj.GenericChaosList); err != nil {
+		chaosList := obj.SpawnList()
+		if err := c.store.List(context.TODO(), chaosList); err != nil {
 			log.Error(err, "failed to list chaos", "kind", kind)
 			return
 		}
 
-		items := reflect.ValueOf(obj.GenericChaosList).Elem().FieldByName("Items")
+		items := reflect.ValueOf(chaosList).Elem().FieldByName("Items")
 		for i := 0; i < items.Len(); i++ {
 			item := items.Index(i).Addr().Interface().(v1alpha1.InnerObject)
 			if _, ok := expCache[item.GetNamespace()]; !ok {

--- a/controllers/schedule/utils/list.go
+++ b/controllers/schedule/utils/list.go
@@ -36,7 +36,7 @@ func (lister *ActiveLister) ListActiveJobs(ctx context.Context, schedule *v1alph
 		return nil, errors.Errorf("Unknown type: %s", schedule.Spec.Type)
 	}
 
-	list := kind.GenericChaosList.DeepCopyList()
+	list := kind.SpawnList()
 	err := lister.List(ctx, list, client.MatchingLabels{"managed-by": schedule.Name})
 	if err != nil {
 		lister.Log.Error(err, "fail to list chaos")

--- a/pkg/apiserver/schedule/schedule.go
+++ b/pkg/apiserver/schedule/schedule.go
@@ -616,7 +616,7 @@ func (s *Service) getScheduleDetail(c *gin.Context) {
 		return
 	}
 
-	list := kind.GenericChaosList.DeepCopyList()
+	list := kind.SpawnList()
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{"managed-by": schedule.Name},
 	})

--- a/pkg/chaosctl/common/common.go
+++ b/pkg/chaosctl/common/common.go
@@ -217,7 +217,7 @@ func GetPods(ctx context.Context, chaosName string, status v1alpha1.ChaosStatus,
 func GetChaosList(ctx context.Context, chaosType string, chaosName string, ns string, c client.Client) ([]runtime.Object, []string, error) {
 	chaosType = upperCaseChaos(strings.ToLower(chaosType))
 	allKinds := v1alpha1.AllKinds()
-	chaosListInterface := allKinds[chaosType].GenericChaosList
+	chaosListInterface := allKinds[chaosType].SpawnList()
 
 	if err := c.List(ctx, chaosListInterface, client.InNamespace(ns)); err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to get chaosList with namespace %s", ns)
@@ -248,7 +248,7 @@ func GetChaosList(ctx context.Context, chaosType string, chaosName string, ns st
 
 func getChaos(ctx context.Context, chaosType string, chaosName string, ns string, c client.Client) (runtime.Object, error) {
 	allKinds := v1alpha1.AllKinds()
-	chaos := allKinds[chaosType].Chaos
+	chaos := allKinds[chaosType].SpawnObject()
 	objectKey := client.ObjectKey{
 		Namespace: ns,
 		Name:      chaosName,

--- a/pkg/collector/event_collector.go
+++ b/pkg/collector/event_collector.go
@@ -55,11 +55,12 @@ func (r *EventCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	chaosKind, ok := v1alpha1.AllKinds()[event.InvolvedObject.Kind]
+	chaosObject := chaosKind.SpawnObject()
 	if ok {
 		if err = r.Get(ctx, types.NamespacedName{
 			Namespace: event.InvolvedObject.Namespace,
 			Name:      event.InvolvedObject.Name,
-		}, chaosKind.Chaos); err != nil {
+		}, chaosObject); err != nil {
 			return ctrl.Result{}, nil
 		}
 	} else {

--- a/pkg/collector/server.go
+++ b/pkg/collector/server.go
@@ -99,7 +99,7 @@ func NewServer(
 			Log:     ctrl.Log.WithName("collector").WithName(kind),
 			archive: experimentArchive,
 			event:   event,
-		}).Setup(s.Manager, chaosKind.Chaos); err != nil {
+		}).Setup(s.Manager, chaosKind.SpawnObject()); err != nil {
 			log.Error(err, "unable to create collector", "collector", kind)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>


### What problem does this PR solve?

Issue Number: close #2253

Problem Summary:

- developers might forget to use `DeepCopy` after fetching the Object of List of Kind

### What is changed and how it works?

What's Changed:

- do not use the struct Kind and List anymore
- new method `SpawnObject()` and `SpawnList()` will call `DeepCopy` automaticlly.

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
