### PR TITLE
e2e: fix e2e base image

### DIFF
--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: hub.pingcap.net/yangkeao/chaos-mesh-e2e-base
+    image: hub.pingcap.net/chaos-mesh/chaos-mesh-e2e-base
     command:
     - runner.sh
     # Clean containers on TERM signal in root process to avoid cgroup leaking.


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

The base e2e image has been deleted. We should use `hub.pingcap.net/chaos-mesh/chaos-mesh-e2e-base-image`.
