### PR TITLE
add schedule and workflow to a special kinds map

### DIFF
--- a/api/v1alpha1/kinds.go
+++ b/api/v1alpha1/kinds.go
@@ -54,6 +54,22 @@ func AllKinds() map[string]*ChaosKind {
 	return all.clone()
 }
 
+func AllKindsIncludeScheduleAndWorkflow() map[string]*ChaosKind {
+	all := chaosKindMap{
+		kinds: all.clone(),
+	}
+	all.register(KindSchedule, &ChaosKind{
+		chaos: &Schedule{},
+		list:  &ScheduleList{},
+	})
+	all.register(KindWorkflow, &ChaosKind{
+		chaos: &Workflow{},
+		list:  &WorkflowList{},
+	})
+
+	return all.kinds
+}
+
 // all is a ChaosKindMap instance.
 var all = &chaosKindMap{
 	kinds: make(map[string]*ChaosKind),

--- a/api/v1alpha1/schedule_types.go
+++ b/api/v1alpha1/schedule_types.go
@@ -100,6 +100,19 @@ type ScheduleList struct {
 	Items           []Schedule `json:"items"`
 }
 
+func (in *ScheduleList) GetItems() []GenericChaos {
+	var result []GenericChaos
+	for _, item := range in.Items {
+		item := item
+		result = append(result, &item)
+	}
+	return result
+}
+
+func (in *ScheduleList) DeepCopyList() GenericChaosList {
+	return in.DeepCopy()
+}
+
 func init() {
 	SchemeBuilder.Register(&Schedule{})
 	SchemeBuilder.Register(&ScheduleList{})

--- a/api/webhook/validate_auth.go
+++ b/api/webhook/validate_auth.go
@@ -80,16 +80,12 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 		return admission.Allowed(fmt.Sprintf("skip the RBAC check for type %s", requestKind))
 	}
 
-	kind, ok := v1alpha1.AllKinds()[requestKind]
+	kind, ok := v1alpha1.AllKindsIncludeScheduleAndWorkflow()[requestKind]
 	if !ok {
 		err := fmt.Errorf("kind %s is not support", requestKind)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	chaos := kind.SpawnObject().(v1alpha1.InnerObjectWithSelector)
-	if chaos == nil {
-		err := fmt.Errorf("kind %s is not support", requestKind)
-		return admission.Errored(http.StatusBadRequest, err)
-	}
+	chaos := kind.SpawnObject()
 
 	err := v.decoder.Decode(req, chaos)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #2278 

Problem Summary: The original `AllKinds()` map doesn't include `Schedule` and `Workflow`. However, we cannot simply add these two kinds to the `AllKinds()` because some codes expect all of them are `*Chaos`.

### What is changed and how it works?

Add a new function to record all types containing `Schedule` and `Workflow`. The function is implemented by cloning the original map and add two new resources into it.