### PR TITLE
fix the dependency of `generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,8 +401,8 @@ define generate-make
 	cd ./api/v1alpha1 ;\
 		controller-gen object:headerFile=../../hack/boilerplate/boilerplate.generatego.txt paths="./..." ;
 endef
-$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate,chaos-build,generate-ctrl,swagger_spec))
-check: fmt vet boilerplate lint generate yaml tidy install.sh
+$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate,chaos-build generate-ctrl swagger_spec))
+check: generate yaml vet boilerplate lint tidy install.sh fmt
 
 CLEAN_TARGETS+=e2e-test/image/e2e/bin/ginkgo
 define e2e-test/image/e2e/bin/ginkgo-make
@@ -463,6 +463,6 @@ $(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate-mock))
 	install.sh $(GO_TARGET_PHONY) \
 	manager chaosfs chaosdaemon chaos-dashboard \
 	dashboard dashboard-server-frontend gosec-scan \
-	failpoint-enable failpoint-disable \
+	failpoint-enable failpoint-disable swagger_spec \
 	proto bin/chaos-builder go_build_cache_directory schedule-migration enter-buildenv enter-devenv \
 	manifests/crd.yaml


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

I should use `space` but not `,` in the arguments of dependency. Some dependencies of `generate` hasn't been added successfully.

This PR is also related to https://github.com/chaos-mesh/chaos-mesh/pull/2274.