### PR TITLE
Use v1 rather than v1beta1 for admissionregistration.k8s.io apiVersion in webhooks

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -15,6 +15,8 @@ webhooks:
   failurePolicy: Fail
   name: vpod.kb.io
   timeoutSeconds: 5
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
   rules:
   - apiGroups:
     - ""

--- a/helm/chaos-mesh/templates/secrets-configuration.yaml
+++ b/helm/chaos-mesh/templates/secrets-configuration.yaml
@@ -6,6 +6,12 @@
 {{- $crtPEM := .Values.webhook.crtPEM }}
 {{- $keyPEM := .Values.webhook.keyPEM }}
 
+{{- $webhookApiVersion := "v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  {{- $webhookApiVersion = "v1" }}
+{{- end }}
+
+
 {{- $supportTimeoutSeconds := false }}
 {{- if ge .Capabilities.KubeVersion.Minor "14" }}
 {{- $supportTimeoutSeconds = true }}
@@ -61,7 +67,11 @@ data:
 
 {{- end }}
 ---
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "chaos-mesh.mutation" . }}
@@ -76,7 +86,11 @@ webhooks:
   - name: {{ template "chaos-mesh.webhook" . }}
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
-    {{- end}}
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+    {{- end }}
+    {{- end }}
     clientConfig:
       {{- if $certManagerEnabled }}
       caBundle: Cg==
@@ -111,7 +125,11 @@ webhooks:
     name: m{{ $crd }}.kb.io
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
-    {{- end}}
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+    {{- end }}
+    {{- end }}
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -125,7 +143,11 @@ webhooks:
   {{- end }}
 ---
 
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ template "chaos-mesh.validation" . }}
@@ -153,7 +175,11 @@ webhooks:
     name: v{{ $crd }}.kb.io
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
-    {{- end}}
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+    {{- end }}
+    {{- end }}
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -175,7 +201,11 @@ webhooks:
 
 ---
 
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validate-auth
@@ -199,6 +229,13 @@ webhooks:
         path: /validate-auth
     failurePolicy: Fail
     name: vauth.kb.io
+    {{- if $supportTimeoutSeconds }}
+    timeoutSeconds: {{ $timeoutSeconds }}
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+    {{- end }}
+    {{- end }}
     rules:
       - apiGroups:
           - chaos-mesh.org

--- a/install.sh
+++ b/install.sh
@@ -1437,7 +1437,7 @@ spec:
             secretName: chaos-mesh-webhook-certs
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: chaos-mesh-mutation
@@ -1450,6 +1450,8 @@ metadata:
 webhooks:
   - name: admission-webhook.chaos-mesh.org
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: "${CA_BUNDLE}"
       service:
@@ -1474,6 +1476,8 @@ webhooks:
     failurePolicy: Fail
     name: mpodchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1493,6 +1497,8 @@ webhooks:
     failurePolicy: Fail
     name: miochaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1512,6 +1518,8 @@ webhooks:
     failurePolicy: Fail
     name: mtimechaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1531,6 +1539,8 @@ webhooks:
     failurePolicy: Fail
     name: mnetworkchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1550,6 +1560,8 @@ webhooks:
     failurePolicy: Fail
     name: mkernelchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1569,6 +1581,8 @@ webhooks:
     failurePolicy: Fail
     name: mstresschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1588,6 +1602,8 @@ webhooks:
     failurePolicy: Fail
     name: mawschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1607,6 +1623,8 @@ webhooks:
     failurePolicy: Fail
     name: mgcpchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1626,6 +1644,8 @@ webhooks:
     failurePolicy: Fail
     name: mdnschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1645,6 +1665,8 @@ webhooks:
     failurePolicy: Fail
     name: mjvmchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1664,6 +1686,8 @@ webhooks:
     failurePolicy: Fail
     name: mschedule.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1683,6 +1707,8 @@ webhooks:
     failurePolicy: Fail
     name: mworkflow.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1702,6 +1728,8 @@ webhooks:
     failurePolicy: Fail
     name: mhttpchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1714,7 +1742,7 @@ webhooks:
           - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: chaos-mesh-validation
@@ -1734,6 +1762,8 @@ webhooks:
     failurePolicy: Fail
     name: vpodchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1753,6 +1783,8 @@ webhooks:
     failurePolicy: Fail
     name: viochaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1772,6 +1804,8 @@ webhooks:
     failurePolicy: Fail
     name: vtimechaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1791,6 +1825,8 @@ webhooks:
     failurePolicy: Fail
     name: vnetworkchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1810,6 +1846,8 @@ webhooks:
     failurePolicy: Fail
     name: vkernelchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1829,6 +1867,8 @@ webhooks:
     failurePolicy: Fail
     name: vstresschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1848,6 +1888,8 @@ webhooks:
     failurePolicy: Fail
     name: vawschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1867,6 +1909,8 @@ webhooks:
     failurePolicy: Fail
     name: vgcpchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1886,6 +1930,8 @@ webhooks:
     failurePolicy: Fail
     name: vdnschaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1905,6 +1951,8 @@ webhooks:
     failurePolicy: Fail
     name: vjvmchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1924,6 +1972,8 @@ webhooks:
     failurePolicy: Fail
     name: vschedule.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1943,6 +1993,8 @@ webhooks:
     failurePolicy: Fail
     name: vworkflow.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1962,6 +2014,8 @@ webhooks:
     failurePolicy: Fail
     name: vhttpchaos.kb.io
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org
@@ -1974,7 +2028,7 @@ webhooks:
           - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validate-auth
@@ -1993,6 +2047,9 @@ webhooks:
         path: /validate-auth
     failurePolicy: Fail
     name: vauth.kb.io
+    timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->

As per k8s release `1.16` notes (Refer: https://v1-16.docs.kubernetes.io/docs/setup/release/notes/ ):

The `admissionregistration.k8s.io/v1beta1` versions of `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` are deprecated and will no longer be served in v1.19. Use admissionregistration.k8s.io/v1 instead.

### What is changed and how does it work?
There is no change from functionality point of view with new apiVersion.
 
### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
