### PR TITLE
Move @siddontang, @zhouqiang-cl, and @Yisaer to emeritus maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,21 +1,20 @@
-# Project Maintainers
-
 This file lists the maintainers and committers of the Chaos Mesh project.
 
 In short, maintainers are people who are in charge of the maintenance of the Chaos Mesh project. Committers are active community members who have shown that they are committed to the continuous development of the project through ongoing engagement with the community. For detailed description of the roles, see [Chaos Mesh Governance](https://github.com/chaos-mesh/chaos-mesh/blob/master/GOVERNANCE.md).
+
+## Maintainers
 
 The Maintainers of Chaos Mesh, along with their emails, are listed below:
 
 | Name                                                          |  Email                                                  |  Org                                       |
 | ------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------ |
-| Siddon Tang ([siddontang](https://github.com/siddontang))     |  [tl@pingcap.com](mailto:tl@pingcap.com)                |  [PingCAP](https://www.pingcap.com/)       |
-| Qiang Zhou ([zhouqiang-cl](https://github.com/zhouqiang-cl))  |  [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com)  |  [PingCAP](https://www.pingcap.com/)       |
 | Cwen Yin ([cwen0](https://github.com/cwen0))                  |  [cwen@pingcap.com](mailto:cwen@pingcap.com)            |  [PingCAP](https://www.pingcap.com/)       |
 | Keao Yang ([YangKeao](https://github.com/YangKeao))           |  [yangkeao@pingcap.com](mailto:yangkeao@pingcap.com)    |  [PingCAP](https://www.pingcap.com/)       |
-| Song Gao ([Yisaer](https://github.com/Yisaer))                |  [gaosong@pingcap.com](mailto:gaosong@pingcap.com)      |  [PingCAP](https://www.pingcap.com/)       |
 | Calvin Weng ([dcalvin](https://github.com/dcalvin))           |  [wenghao@pingcap.com](mailto:wenghao@pingcap.com)      |  [PingCAP](https://www.pingcap.com/)       |
 | Ben Ye ([yeya24](https://github.com/yeya24))                  |  [yb532204897@gmail.com](mailto:yb532204897@gmail.com)  |  Individual                                |
 | Hengliang Tan ([Gallardot](https://github.com/Gallardot))     |  [tttick@gmail.com](mailto:tttick@gmail.com)            |  [Xpeng Motors](https://www.xiaopeng.com/) |
+
+## Committers
 
 The Committers of Chaos Mesh, along with their emails, are listed below:
 
@@ -30,3 +29,13 @@ The Committers of Chaos Mesh, along with their emails, are listed below:
 | Wenbo Zhang ([ethercflow](https://github.com/ethercflow))        | [zhangwenbo@pingcap.com](mailto:zhangwenbo@pingcap.com)                       | [PingCAP](https://www.pingcap.com/)   |
 | Zhiqiang Zhou ([STRRL](https://github.com/STRRL))                | [zhouzhiqiang@pingcap.com](mailto:zhouzhiqiang@pingcap.com)                   | [PingCAP](https://www.pingcap.com/)   |
 | Shivansh Saini ([shivanshs9](https://github.com/shivanshs9))     | [shivansh.saini.cse17@iitbhu.ac.in](mailto:shivansh.saini.cse17@iitbhu.ac.in) | [Headout](https://github.com/headout) |
+
+## Emeritus Maintainers
+
+The Emeritus Maintainers of Chaos Mesh, along with their emails, are listed below:
+
+| Name                                                          |  Email                                                  |  Org                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------ |
+| Siddon Tang ([siddontang](https://github.com/siddontang))     |  [tl@pingcap.com](mailto:tl@pingcap.com)                |  [PingCAP](https://www.pingcap.com/)       |
+| Qiang Zhou ([zhouqiang-cl](https://github.com/zhouqiang-cl))  |  [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com)  |  [PingCAP](https://www.pingcap.com/)       |
+| Song Gao ([Yisaer](https://github.com/Yisaer))                |  [gaosong@pingcap.com](mailto:gaosong@pingcap.com)      |  [PingCAP](https://www.pingcap.com/)       |


### PR DESCRIPTION
As per the [governance doc](https://github.com/chaos-mesh/chaos-mesh/blob/master/GOVERNANCE.md#maintainer), I create this PR on behalf of Chaos Mesh maintainers to move @siddontang, @zhouqiang-cl, and @Yisaer to emeritus maintainers as they haven't been able to stay active in the project for a while due to shift of focus. And they all agree to become emeritus maintainers.  

Thanks for their awesome work on Chaos Mesh! We very much appreciate their contributions but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly and sustained project. 

/cc @chaos-mesh/maintainers 