### PR TITLE
add label to skip script test

### DIFF
--- a/.github/workflows/script_test.yml
+++ b/.github/workflows/script_test.yml
@@ -11,6 +11,7 @@ jobs:
   run:
     name: Script Test
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-script-test') }}
     steps:
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Some modifications on CRD or deployment will cause the script test failed, but the PR should also get merged. Therefore, a `skip-script-test` label is added to skip the test.
