### PR TITLE
build only when dockerfile is modified

### DIFF
--- a/.github/workflows/upload_build_env_image.yml
+++ b/.github/workflows/upload_build_env_image.yml
@@ -1,6 +1,8 @@
 name: Upload Env Images
 on:
   push:
+    paths:
+      - 'images/build-env/Dockerfile'
     branches:
       - master
       - release-*
@@ -36,15 +38,12 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
         run: |
-          export IMAGE_DEV_ENV_BUILD=1
           export IMAGE_BUILD_ENV_BUILD=1
 
           make image-build-env
-          make image-dev-env
 
       - name: Upload Chaos Mesh Env
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
         run: |
           docker push ghcr.io/chaos-mesh/chaos-mesh/build-env:$IMAGE_TAG
-          docker push ghcr.io/chaos-mesh/chaos-mesh/dev-env:$IMAGE_TAG

--- a/.github/workflows/upload_dev_env_image.yml
+++ b/.github/workflows/upload_dev_env_image.yml
@@ -1,0 +1,49 @@
+name: Upload Env Images
+on:
+  push:
+    paths:
+      - 'images/dev-env/Dockerfile'
+    branches:
+      - master
+      - release-*
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          # Must use at least depth 2!
+          fetch-depth: 2
+
+      - name: Extract Image Tag
+        shell: bash
+        run: |
+          IMAGE_TAG=${GITHUB_REF##*/}
+          if [ "${IMAGE_TAG}" = "master" ] ; then
+            IMAGE_TAG=latest; 
+          fi
+
+          echo "##[set-output name=image_tag;]$(echo $IMAGE_TAG)"
+        id: image_tag
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Chaos Mesh Env
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+        run: |
+          export IMAGE_DEV_ENV_BUILD=1
+
+          make image-dev-env
+
+      - name: Upload Chaos Mesh Env
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+        run: |
+          docker push ghcr.io/chaos-mesh/chaos-mesh/dev-env:$IMAGE_TAG


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

The `dev-env` and `build-env` is modified too frequently! We should only upload them when the `Dockerfile` is modified.