### PR TITLE
Helm: Update manifests for cert-manager/v1 API

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -138,16 +138,20 @@ helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing -f values.yaml
 
 ### Using cert-manager for certificate management
 
-[Cert-manager](https://github.com/jetstack/cert-manager) may be the default in the K8s world for certificate management now.If you want to install Cert-manager using the [Helm](https://helm.sh) package manager, please refer to the [official documents](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager).
+[Cert-manager](https://github.com/jetstack/cert-manager) may be the default in the K8s world for certificate management now. If you want to install Cert-manager using the [Helm](https://helm.sh) package manager, please refer to the [official documents](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager).
 
 Example for deploy Cert-manager
 
 ```bash
-kubectl create namespace cert-manager
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.13.1/deploy/manifests/00-crds.yaml
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v0.13.1
+
+# if Kubernetes > 1.18/Helm 3.2
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.6.1 --set installCRDs=true
+
+# else
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.crds.yaml
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.6.1
 ```
 
 In case you want to using Cert-manager for certificate management, you can use the `webhook.certManager.enabled` property.

--- a/helm/chaos-mesh/templates/secrets-configuration.yaml
+++ b/helm/chaos-mesh/templates/secrets-configuration.yaml
@@ -368,7 +368,7 @@ metadata:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemon-client-cert
 spec:
-  duration: 43800h #5year
+  duration: 43800h0m0s #5year
   dnsNames:
     - controller-manager.chaos-mesh.org
   isCA: false
@@ -393,7 +393,7 @@ metadata:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-daemontcert
 spec:
-  duration: 43800h #5year
+  duration: 43800h0m0s #5year
   dnsNames:
     - chaos-daemon.chaos-mesh.org
   isCA: false


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Updates the current usage of cert-manager resources to the stable `v1` API.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [x] E2E test (tested on kind with latest cert-manager release)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Helm: Update cert-manager resources to v1
```
