### PR TITLE
fix: persist event with UTC Time

### DIFF
--- a/pkg/dashboard/apiserver/event/event.go
+++ b/pkg/dashboard/apiserver/event/event.go
@@ -80,18 +80,8 @@ func (s *Service) list(c *gin.Context) {
 		log.V(1).Info("Replace query namespace with", ns)
 	}
 
-	start, err := time.Parse(time.RFC3339, c.Query("start"))
-	if err != nil {
-		u.SetAPIError(c, u.ErrBadRequest.WrapWithNoMessage(err))
-
-		return
-	}
-	end, err := time.Parse(time.RFC3339, c.Query("end"))
-	if err != nil {
-		u.SetAPIError(c, u.ErrBadRequest.WrapWithNoMessage(err))
-
-		return
-	}
+	start, _ := time.Parse(time.RFC3339, c.Query("start"))
+	end, _ := time.Parse(time.RFC3339, c.Query("end"))
 
 	filter := core.Filter{
 		ObjectID:  c.Query("object_id"),

--- a/pkg/dashboard/apiserver/event/event.go
+++ b/pkg/dashboard/apiserver/event/event.go
@@ -80,8 +80,18 @@ func (s *Service) list(c *gin.Context) {
 		log.V(1).Info("Replace query namespace with", ns)
 	}
 
-	start, _ := time.Parse(time.RFC3339, c.Query("start"))
-	end, _ := time.Parse(time.RFC3339, c.Query("end"))
+	start, err := time.Parse(time.RFC3339, c.Query("start"))
+	if err != nil {
+		u.SetAPIError(c, u.ErrBadRequest.WrapWithNoMessage(err))
+
+		return
+	}
+	end, err := time.Parse(time.RFC3339, c.Query("end"))
+	if err != nil {
+		u.SetAPIError(c, u.ErrBadRequest.WrapWithNoMessage(err))
+
+		return
+	}
 
 	filter := core.Filter{
 		ObjectID:  c.Query("object_id"),

--- a/pkg/dashboard/apiserver/event/event.go
+++ b/pkg/dashboard/apiserver/event/event.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
@@ -55,6 +56,8 @@ func Register(r *gin.RouterGroup, s *Service) {
 	endpoint.GET("/:id", s.get)
 }
 
+const layout = "2006-01-02 15:04:05"
+
 // @Summary list events.
 // @Description Get events from db.
 // @Tags events
@@ -77,10 +80,13 @@ func (s *Service) list(c *gin.Context) {
 		log.V(1).Info("Replace query namespace with", ns)
 	}
 
+	start, _ := time.Parse(time.RFC3339, c.Query("start"))
+	end, _ := time.Parse(time.RFC3339, c.Query("end"))
+
 	filter := core.Filter{
 		ObjectID:  c.Query("object_id"),
-		Start:     c.Query("start"),
-		End:       c.Query("end"),
+		Start:     start.UTC().Format(layout),
+		End:       end.UTC().Format(layout),
 		Namespace: ns,
 		Name:      c.Query("name"),
 		Kind:      c.Query("kind"),

--- a/pkg/dashboard/collector/event_collector.go
+++ b/pkg/dashboard/collector/event_collector.go
@@ -74,7 +74,7 @@ func (r *EventCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	et := core.Event{
-		CreatedAt: event.CreationTimestamp.Time,
+		CreatedAt: event.CreationTimestamp.Time.UTC(),
 		Kind:      event.InvolvedObject.Kind,
 		Type:      event.Type,
 		Reason:    event.Reason,

--- a/pkg/dashboard/core/common.go
+++ b/pkg/dashboard/core/common.go
@@ -62,6 +62,8 @@ func (f *Filter) toMap() map[string]interface{} {
 	return fMap
 }
 
+const zeroTime = "0001-01-01 00:00:00"
+
 func (f *Filter) ConstructQueryArgs() (string, []interface{}) {
 	fMap, query, args := f.toMap(), make([]string, 0), make([]interface{}, 0)
 
@@ -82,19 +84,19 @@ func (f *Filter) ConstructQueryArgs() (string, []interface{}) {
 	}
 
 	startEnd := ""
-	if f.Start != "" && f.End != "" {
+	if f.Start != zeroTime && f.End != zeroTime {
 		startEnd = "created_at BETWEEN ? AND ?"
 		args = append(args, f.Start, f.End)
-	} else if f.Start != "" && f.End == "" {
+	} else if f.Start != zeroTime && f.End == zeroTime {
 		startEnd = "created_at >= ?"
 		args = append(args, f.Start)
-	} else if f.Start == "" && f.End != "" {
+	} else if f.Start == zeroTime && f.End != zeroTime {
 		startEnd = "created_at <= ?"
 		args = append(args, f.End)
 	}
 
 	if startEnd != "" {
-		if len(args) > 0 {
+		if len(query) > 0 {
 			query = append(query, "AND", startEnd)
 		} else {
 			query = append(query, startEnd)

--- a/pkg/dashboard/store/event/event.go
+++ b/pkg/dashboard/store/event/event.go
@@ -118,7 +118,7 @@ func (e *eventStore) DeleteByTime(_ context.Context, start string, end string) e
 }
 
 func (e *eventStore) DeleteByDuration(_ context.Context, duration time.Duration) error {
-	now := time.Now().Add(-duration).Format("2006-01-02 15:04:05")
+	now := time.Now().UTC().Add(-duration).Format("2006-01-02 15:04:05")
 
 	return e.db.Where("created_at <= ?", now).Delete(&core.Event{}).Error
 }

--- a/ui/src/components/NewExperimentNext/Step2.tsx
+++ b/ui/src/components/NewExperimentNext/Step2.tsx
@@ -8,7 +8,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { useStoreDispatch, useStoreSelector } from 'store'
 
 import CheckIcon from '@material-ui/icons/Check'
-import { ExperimentKind } from 'components/NewExperiment/types'
 import OtherOptions from 'components/OtherOptions'
 import Paper from 'components-mui/Paper'
 import PublishIcon from '@material-ui/icons/Publish'
@@ -26,7 +25,7 @@ interface Step2Props {
 
 const Step2: React.FC<Step2Props> = ({ inWorkflow = false, inSchedule = false }) => {
   const { namespaces, step2, kindAction, basic } = useStoreSelector((state) => state.experiments)
-  const [kind, action] = kindAction
+  const [kind] = kindAction
   const scopeDisabled = kind === 'AWSChaos' || kind === 'GCPChaos'
   const schema = basicSchema({ scopeDisabled, scheduled: inSchedule, needDeadline: inWorkflow })
   const dispatch = useStoreDispatch()


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->

Problem Summary:

This PR persists event with UTC time (`CreatedAt` field). Using UTC time helps us to better filter data by time range without considering the time zone.

### What is changed and how it works?

What's Changed:

#### main

- before persist and query events, parse time to UTC

#### other

- fix a condition typo in `ConstructQueryArgs`
- remove unused imports

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
