### PR TITLE
Remove the duplicated GetObjectMeta method

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -102,9 +101,6 @@ type InnerObject interface {
 // StatefulObject defines a basic Object that can get the status
 type StatefulObject interface {
 	GenericChaos
-	// deprecated, use GetNamepsace() in metav1.Object directly.
-	// TODO: duplicated method, remove GetObjectMeta()
-	GetObjectMeta() *metav1.ObjectMeta
 	GetStatus() *ChaosStatus
 }
 

--- a/controllers/chaosimpl/httpchaos/impl.go
+++ b/controllers/chaosimpl/httpchaos/impl.go
@@ -49,7 +49,7 @@ var _ common.ChaosImpl = (*Impl)(nil)
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
 	// The only possible phase to get in here is "Not Injected" or "Not Injected/Wait"
 
-	impl.Log.Info("httpchaos Apply", "namespace", obj.GetObjectMeta().Namespace, "name", obj.GetObjectMeta().Name)
+	impl.Log.Info("httpchaos Apply", "namespace", obj.GetNamespace(), "name", obj.GetName())
 	httpchaos := obj.(*v1alpha1.HTTPChaos)
 	if httpchaos.Status.Instances == nil {
 		httpchaos.Status.Instances = make(map[string]int64)

--- a/controllers/chaosimpl/iochaos/impl.go
+++ b/controllers/chaosimpl/iochaos/impl.go
@@ -48,7 +48,7 @@ var _ common.ChaosImpl = (*Impl)(nil)
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
 	// The only possible phase to get in here is "Not Injected" or "Not Injected/Wait"
 
-	impl.Log.Info("iochaos Apply", "namespace", obj.GetObjectMeta().Namespace, "name", obj.GetObjectMeta().Name)
+	impl.Log.Info("iochaos Apply", "namespace", obj.GetNamespace(), "name", obj.GetName())
 	iochaos := obj.(*v1alpha1.IOChaos)
 	if iochaos.Status.Instances == nil {
 		iochaos.Status.Instances = make(map[string]int64)

--- a/controllers/chaosimpl/networkchaos/trafficcontrol/impl.go
+++ b/controllers/chaosimpl/networkchaos/trafficcontrol/impl.go
@@ -60,7 +60,7 @@ var _ common.ChaosImpl = (*Impl)(nil)
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
 	// The only possible phase to get in here is "Not Injected" or "Not Injected/Wait"
 
-	impl.Log.Info("traffic control Apply", "namespace", obj.GetObjectMeta().Namespace, "name", obj.GetObjectMeta().Name)
+	impl.Log.Info("traffic control Apply", "namespace", obj.GetNamespace(), "name", obj.GetName())
 	networkchaos := obj.(*v1alpha1.NetworkChaos)
 	if networkchaos.Status.Instances == nil {
 		networkchaos.Status.Instances = make(map[string]int64)

--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -104,8 +104,8 @@ func NewController(params Params) (types.Controller, error) {
 								}
 								if namespacedName == objName {
 									id := k8sTypes.NamespacedName{
-										Namespace: item.GetObjectMeta().Namespace,
-										Name:      item.GetObjectMeta().Name,
+										Namespace: item.GetNamespace(),
+										Name:      item.GetName(),
 									}
 									setupLog.Info("mapping requests", "source", objName, "target", id)
 									reqs = append(reqs, reconcile.Request{

--- a/controllers/desiredphase/controller.go
+++ b/controllers/desiredphase/controller.go
@@ -72,7 +72,7 @@ type reconcileContext struct {
 }
 
 func (ctx *reconcileContext) GetCreationTimestamp() metav1.Time {
-	return ctx.obj.GetObjectMeta().CreationTimestamp
+	return ctx.obj.GetCreationTimestamp()
 }
 
 func (ctx *reconcileContext) CalcDesiredPhase() (v1alpha1.DesiredPhase, []recorder.ChaosEvent) {
@@ -141,7 +141,7 @@ func (ctx *reconcileContext) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 			if obj.GetStatus().Experiment.DesiredPhase != desiredPhase {
 				obj.GetStatus().Experiment.DesiredPhase = desiredPhase
-				ctx.Log.Info("update object", "namespace", obj.GetObjectMeta().GetNamespace(), "name", obj.GetObjectMeta().GetName())
+				ctx.Log.Info("update object", "namespace", obj.GetNamespace(), "name", obj.GetName())
 				return ctx.Client.Update(context.TODO(), obj)
 			}
 

--- a/controllers/finalizers/controller.go
+++ b/controllers/finalizers/controller.go
@@ -63,7 +63,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	finalizers := obj.GetObjectMeta().Finalizers
+	finalizers := obj.GetFinalizers()
 	records := obj.GetStatus().Experiment.Records
 	shouldUpdate := false
 	if obj.IsDeleted() {
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		}
 
-		if obj.GetObjectMeta().Annotations[AnnotationCleanFinalizer] == AnnotationCleanFinalizerForced || (resumed && len(finalizers) != 0) {
+		if obj.GetAnnotations()[AnnotationCleanFinalizer] == AnnotationCleanFinalizerForced || (resumed && len(finalizers) != 0) {
 			r.Recorder.Event(obj, recorder.FinalizerRemoved{})
 			finalizers = []string{}
 			shouldUpdate = true
@@ -83,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if !ContainsFinalizer(obj.(metav1.Object), RecordFinalizer) {
 			r.Recorder.Event(obj, recorder.FinalizerInited{})
 			shouldUpdate = true
-			finalizers = append(obj.GetObjectMeta().Finalizers, RecordFinalizer)
+			finalizers = append(obj.GetFinalizers(), RecordFinalizer)
 		}
 	}
 
@@ -96,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				return err
 			}
 
-			obj.GetObjectMeta().Finalizers = finalizers
+			obj.SetFinalizers(finalizers)
 			return r.Client.Update(context.TODO(), obj)
 		})
 		if updateError != nil {

--- a/controllers/schedule/cron/controller.go
+++ b/controllers/schedule/cron/controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if !controller.IsChaosFinished(item, now) {
 					shouldSpawn = false
 					r.Recorder.Event(schedule, recorder.ScheduleForbid{
-						RunningName: item.GetObjectMeta().Name,
+						RunningName: item.GetName(),
 					})
 					r.Log.Info("forbid to spawn new chaos", "running", item.GetName())
 					break

--- a/controllers/schedule/pause/controller.go
+++ b/controllers/schedule/pause/controller.go
@@ -74,8 +74,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		item := items.Index(i).Addr().Interface().(v1alpha1.InnerObject)
 		if item.IsPaused() != schedule.IsPaused() {
 			key := k8sTypes.NamespacedName{
-				Namespace: item.GetObjectMeta().GetNamespace(),
-				Name:      item.GetObjectMeta().GetName(),
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
 			}
 			pause := strconv.FormatBool(schedule.IsPaused())
 
@@ -86,10 +86,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					r.Log.Error(err, "unable to get schedule")
 					return err
 				}
-				if item.GetObjectMeta().Annotations == nil {
-					item.GetObjectMeta().Annotations = make(map[string]string)
+				annotations := item.GetAnnotations()
+				if annotations == nil {
+					annotations = make(map[string]string)
 				}
-				item.GetObjectMeta().Annotations[v1alpha1.PauseAnnotationKey] = pause
+				annotations[v1alpha1.PauseAnnotationKey] = pause
+				item.SetAnnotations(annotations)
 
 				return r.Client.Update(ctx, item)
 			})


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->
Problem Summary: 

Since `GenericChaos` interface implements the `metav1.Object` interface, there is no need to  add the `GetObjectMeta` method.

### What is changed and how it works?

What's Changed:

Remove the duplicated `GetObjectMeta` method in the `StatefulObject` interface.

### Related changes

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```

/assign @STRRL for review since you add the duplicated note.