### PR TITLE
Make the managed-by label a const value

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -24,6 +24,7 @@ import (
 const (
 	// PauseAnnotationKey defines the annotation used to pause a chaos
 	PauseAnnotationKey = "experiment.chaos-mesh.org/pause"
+	LabelManagedBy     = "managed-by"
 )
 
 type ChaosStatus struct {

--- a/controllers/schedule/cron/controller.go
+++ b/controllers/schedule/cron/controller.go
@@ -144,7 +144,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			},
 		})
 		newObj.SetLabels(map[string]string{
-			"managed-by": schedule.Name,
+			v1alpha1.LabelManagedBy: schedule.Name,
 		})
 		newObj.SetNamespace(schedule.Namespace)
 		newObj.SetName(names.SimpleNameGenerator.GenerateName(schedule.Name + "-"))

--- a/controllers/schedule/utils/list.go
+++ b/controllers/schedule/utils/list.go
@@ -37,7 +37,7 @@ func (lister *ActiveLister) ListActiveJobs(ctx context.Context, schedule *v1alph
 	}
 
 	list := kind.SpawnList()
-	err := lister.List(ctx, list, client.MatchingLabels{"managed-by": schedule.Name})
+	err := lister.List(ctx, list, client.MatchingLabels{v1alpha1.LabelManagedBy: schedule.Name})
 	if err != nil {
 		lister.Log.Error(err, "fail to list chaos")
 		return nil, nil

--- a/pkg/dashboard/apiserver/schedule/schedule.go
+++ b/pkg/dashboard/apiserver/schedule/schedule.go
@@ -248,7 +248,7 @@ func (s *Service) findScheduleInCluster(c *gin.Context, kubeCli client.Client, n
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: map[string]string{"managed-by": sch.Name},
+		MatchLabels: map[string]string{v1alpha1.LabelManagedBy: sch.Name},
 	})
 	if err != nil {
 		u.SetAPIError(c, u.ErrInternalServer.WrapWithNoMessage(err))

--- a/pkg/dashboard/collector/collector.go
+++ b/pkg/dashboard/collector/collector.go
@@ -65,7 +65,7 @@ func (r *ChaosCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if chaosMeta, ok = obj.(metav1.Object); !ok {
 			r.Log.Error(nil, "failed to get chaos meta information")
 		}
-		if chaosMeta.GetLabels()["managed-by"] != "" {
+		if chaosMeta.GetLabels()[v1alpha1.LabelManagedBy] != "" {
 			manageFlag = true
 		}
 		if !manageFlag {
@@ -89,7 +89,7 @@ func (r *ChaosCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		r.Log.Error(nil, "failed to get chaos meta information")
 	}
 
-	if chaosMeta.GetLabels()["managed-by"] != "" {
+	if chaosMeta.GetLabels()[v1alpha1.LabelManagedBy] != "" {
 		manageFlag = true
 	}
 


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->
Issue Number: close #1930

Problem Summary:

the `managed-by` label has been used in several places, so this PR turns it into a constant value.

### What is changed and how it works?

What's Changed:

Make the managed-by label a const value

### Related changes

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```

NOTE: this PR is similar to #2204, but that PR has not been updated for a long time, so I submitted this PR.

/cc @STRRL 