### PR TITLE
Replace fake.NewFakeClient with NewClientBuilder since the NewFakeClient method is already deprecated

### DIFF
--- a/controllers/podnetworkchaos/types_test.go
+++ b/controllers/podnetworkchaos/types_test.go
@@ -88,7 +88,7 @@ func TestHostNetworkOption(t *testing.T) {
 		}
 		objs = append(objs, chaos)
 
-		fakeClient := fake.NewFakeClientWithScheme(provider.NewScheme(), objs...)
+		fakeClient := fake.NewClientBuilder().WithScheme(provider.NewScheme()).WithRuntimeObjects(objs...).Build()
 
 		recorder := recorder.NewDebugRecorder()
 		h := &Reconciler{

--- a/pkg/chaosctl/common/common_test.go
+++ b/pkg/chaosctl/common/common_test.go
@@ -57,7 +57,7 @@ func TestGetChaosList(t *testing.T) {
 
 	g.Expect(v1alpha1.SchemeBuilder.AddToScheme(kubectlscheme.Scheme)).To(BeNil())
 
-	client := fake.NewFakeClientWithScheme(kubectlscheme.Scheme, &chaos1, &chaos2)
+	client := fake.NewClientBuilder().WithScheme(kubectlscheme.Scheme).WithRuntimeObjects(&chaos1, &chaos2).Build()
 
 	tests := []struct {
 		name        string
@@ -139,7 +139,7 @@ func TestGetPods(t *testing.T) {
 
 	allObjects := append(nodeObjects, daemonObjects0[0], podObjects0[0], daemonObjects1[0], podObjects1[0])
 	g.Expect(v1alpha1.SchemeBuilder.AddToScheme(kubectlscheme.Scheme)).To(BeNil())
-	client := fake.NewFakeClientWithScheme(kubectlscheme.Scheme, allObjects...)
+	client := fake.NewClientBuilder().WithScheme(kubectlscheme.Scheme).WithRuntimeObjects(allObjects...).Build()
 
 	tests := []struct {
 		name              string

--- a/pkg/chaosctl/debug/stresschaos/stresschaos.go
+++ b/pkg/chaosctl/debug/stresschaos/stresschaos.go
@@ -82,7 +82,7 @@ func debugEachPod(ctx context.Context, pod v1.Pod, daemon v1.Pod, chaos *v1alpha
 		cmd = fmt.Sprintf("cat /proc/%s/cgroup", pids[i])
 		out, err = cm.ExecBypass(ctx, pod, daemon, cmd, c.KubeCli)
 		if err != nil {
-			cm.L().WithName("stress-chaos").V(2).Info("failed to fetch cgroup ofr certain process",
+			cm.L().WithName("stress-chaos").V(2).Info("failed to fetch cgroup for certain process",
 				"pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 				"pid", i,
 			)

--- a/pkg/selector/pod/selector_test.go
+++ b/pkg/selector/pod/selector_test.go
@@ -47,7 +47,7 @@ func TestSelectPods(t *testing.T) {
 
 	pods = append(pods, pods2...)
 
-	c := fake.NewFakeClient(objects...)
+	c := fake.NewClientBuilder().WithRuntimeObjects(objects...).Build()
 	var r client.Reader
 
 	type TestCase struct {


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->

Problem Summary:

Both `NewFakeClient` and `NewFakeClientWithScheme` has been deprecated:

```go
// NewFakeClient creates a new fake client for testing.
// You can choose to initialize it with a slice of runtime.Object.
//
// Deprecated: Please use NewClientBuilder instead.
func NewFakeClient(initObjs ...runtime.Object) client.WithWatch

// NewFakeClientWithScheme creates a new fake client with the given scheme
// for testing.
// You can choose to initialize it with a slice of runtime.Object.
//
// Deprecated: Please use NewClientBuilder instead.
func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.WithWatch
```

### What is changed and how it works?

What's Changed:

* Replace deprecated methods with the new `NewClientBuilder` method.
* Fixed a typo.

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
