### PR TITLE
ci: add image tag to action

### DIFF
--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Build Chaos Mesh manifest
         env:
           IMAGE: ${{ matrix.image }}
+          IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
         run: |
           docker manifest create ghcr.io/chaos-mesh/chaos-mesh/$IMAGE-env:$IMAGE_TAG \
             ghcr.io/chaos-mesh/chaos-mesh/$IMAGE-env:$IMAGE_TAG-amd64 \


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Add image tag to the action. The CI: https://github.com/chaos-mesh/chaos-mesh/runs/3674089450?check_suite_focus=true has failed, because I didn't set the `IMAGE_TAG` environment variable.
