### PR TITLE
Better way to gen command.

### DIFF
--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"os/exec"
+	"reflect"
+	"strings"
+)
+
+const ExecTag = "exec"
+const SubCommandTag = "sub_command"
+const ParaTag = "para"
+
+type Exec struct {
+	option string
+}
+
+func NewExec() Exec {
+	return Exec{option: "OK"}
+}
+
+func ToCommand(i interface{}) *exec.Cmd {
+	path, args := Unmarshal(i)
+	return exec.Command(path, args...)
+}
+
+func Unmarshal(i interface{}) (string, []string) {
+	value := reflect.ValueOf(i)
+	return unmarshal(value)
+}
+
+func unmarshal(value reflect.Value) (string, []string) {
+	//var options []string
+	if path, ok := SearchKey(value); ok {
+		// Field(0).String is Exec.Path
+
+		if path == "" {
+			return "", nil
+		}
+		args := make([]string, 0)
+		for i := 0; i < value.NumField(); i++ {
+			if _, ok := value.Type().Field(i).Tag.Lookup(SubCommandTag); ok {
+				subPath, subArgs := unmarshal(value.Field(i))
+				if subPath != "" {
+					args = append(args, subPath)
+				}
+				args = append(args, subArgs...)
+			}
+			if paraName, ok := value.Type().Field(i).Tag.Lookup(ParaTag); ok {
+				if value.Type().Field(i).Type.Name() == "string" {
+					if value.Field(i).String() != "" {
+						if paraName != "" {
+							args = append(args, paraName)
+						}
+						args = append(args, value.Field(i).String())
+					}
+				}
+				if value.Field(i).Kind() == reflect.Slice {
+					if slicePara, ok := value.Field(i).Interface().([]string); ok {
+						if strings.Join(slicePara, "") != "" {
+							args = append(args, paraName)
+							args = append(args, slicePara...)
+						}
+
+					}
+				}
+			}
+		}
+		return path, args
+	} else {
+		return "", nil
+	}
+}
+
+func SearchKey(value reflect.Value) (string, bool) {
+	for i := 0; i < value.NumField(); i++ {
+		if path, ok := value.Type().Field(i).Tag.Lookup(ExecTag); ok {
+			if value.Field(i).Field(0).String() == "" {
+				return "", false
+			}
+			return path, ok
+		}
+	}
+	return "", false
+}

--- a/pkg/utils/command_test.go
+++ b/pkg/utils/command_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+type IptablesTest struct {
+	Exec   `exec:"iptables"`
+	Port   string   `para:"-p"`
+	Ports  []string `para:"--ports"`
+	EPort  string   `para:"-ep"`
+	EPorts []string `para:"--e_ports"`
+	Match  `sub_command:""`
+	Match_ `sub_command:""`
+}
+
+type Match struct {
+	Exec   `exec:"-m"`
+	Helper string `para:"--helper"`
+}
+
+type Match_ struct {
+	Exec   `exec:"-m"`
+	Helper string `para:"--helper"`
+}
+
+func TestUnmarshal(t *testing.T) {
+	n := IptablesTest{
+		NewExec(),
+		"20",
+		[]string{"2021", "2023"},
+		"",
+		[]string{"", ""},
+		Match{NewExec(), "help"},
+		Match_{},
+	}
+	path, args := Unmarshal(n)
+
+	assert.Equal(t, "iptables -p 20 --ports 2021 2023 -m --helper help",
+		path+" "+strings.Join(args, " "))
+}
+
+type Iptables struct {
+	Exec           `exec:"iptables"`
+	Tables         string `para:"-t"`
+	Command        string `para:""`
+	Chain          string `para:""`
+	JumpTarget     string `para:"-j"`
+	Protocol       string `para:"--protocol"`
+	MatchExtension string `para:"-m"`
+	SPorts         string `para:"--source-ports"`
+	DPorts         string `para:"--destination-ports"`
+	SPort          string `para:"--source-port"`
+	DPort          string `para:"--destination-port"`
+	TcpFlags       string `para:"--tcp-flags"`
+}
+
+func TestUnmarshalExample(t *testing.T) {
+	n := Iptables{
+		Exec:           NewExec(),
+		Command:        "-A",
+		Chain:          "Chaos_Chain",
+		JumpTarget:     "Chaos_Target",
+		Protocol:       "tcp",
+		MatchExtension: "multiport",
+		SPorts:         "2021,2022",
+		TcpFlags:       "SYN",
+	}
+	path, args := Unmarshal(n)
+	assert.Equal(t, "iptables -A Chaos_Chain -j Chaos_Target --protocol tcp -m multiport --source-ports 2021,2022 --tcp-flags SYN",
+		path+" "+strings.Join(args, " "))
+}


### PR DESCRIPTION
Signed-off-by: andrewmatilde <davis6813585853062@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Give a better way to Gen command instead of many  fmt.sprintf and empty judgments.
<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->


I am a contributor of chaos-mesh/chaosd and chaosd use chaosmesh/pkg/chaosdeamon/iptables_server as a lib to complete network attack.
I found it is hard to use , add extension, debug or read code of iptables_server ,because there are both many codes wrote to generate iptables and many logical codes to use iptables to complete to task like drop web packet ...
I think iptables_server may designed for just using it in chaos-mesh , but it is hard to get a further use , so I try to give a better way to generate iptables commands first .
### What is changed and how it works?


What's Changed:
Nothing changed except adding a cmmand generator package in utils.
If we use it to refactor iptables_server, it will reduce many code in generate codes and may make it easier to be understand.

Example (Before):
```
	protocolAndPort := ""
	if len(chain.Protocol) > 0 {
		protocolAndPort += fmt.Sprintf("--protocol %s", chain.Protocol)

		if len(chain.SourcePorts) > 0 {
			if strings.Contains(chain.SourcePorts, ",") {
				protocolAndPort += fmt.Sprintf(" -m multiport --source-ports %s", chain.SourcePorts)
			} else {
				protocolAndPort += fmt.Sprintf(" --source-port %s", chain.SourcePorts)
			}
		}

		if len(chain.DestinationPorts) > 0 {
			if strings.Contains(chain.DestinationPorts, ",") {
				protocolAndPort += fmt.Sprintf(" -m multiport --destination-ports %s", chain.DestinationPorts)
			} else {
				protocolAndPort += fmt.Sprintf(" --destination-port %s", chain.DestinationPorts)
			}
		}

		if len(chain.TcpFlags) > 0 {
			protocolAndPort += fmt.Sprintf(" --tcp-flags %s", chain.TcpFlags)
		}
	}

	rules := []string{}

	if len(chain.Ipsets) == 0 {
		rules = append(rules, strings.TrimSpace(fmt.Sprintf("-A %s -j %s -w 5 %s", chain.Name, chain.Target, protocolAndPort)))
	}

	for _, ipset := range chain.Ipsets {
		rules = append(rules, strings.TrimSpace(fmt.Sprintf("-A %s -m set --match-set %s %s -j %s -w 5 %s",
			chain.Name, ipset, matchPart, chain.Target, protocolAndPort)))
	}
	err := iptables.createNewChain(&iptablesChain{
		Name:  chain.Name,
		Rules: rules,
	})
	if err != nil {
		return err
	}
```
Example(After):
```
type Iptables struct {
	Exec           `exec:"iptables"`
	Tables         string `para:"-t"`
	Command        string `para:""`
	Chain          string `para:""`
	JumpTarget     string `para:"-j"`
	Protocol       string `para:"--protocol"`
	MatchExtension string `para:"-m"`
	SPorts         string `para:"--source-ports"`
	DPorts         string `para:"--destination-ports"`
	SPort          string `para:"--source-port"`
	DPort          string `para:"--destination-port"`
	TcpFlags       string `para:"--tcp-flags"`
}

func TestUnmarshalExample(t *testing.T) {
	n := Iptables{
		Exec:           NewExec(),
		Command:        "-A",
		Chain:          "Chaos_Chain",
		JumpTarget:     "Chaos_Target",
		Protocol:       "tcp",
		MatchExtension: "multiport",
		SPorts:         "2021,2022",
		TcpFlags:       "SYN",
	}
	path, args := Unmarshal(n)
	assert.Equal(t, "iptables -A Chaos_Chain -j Chaos_Target --protocol tcp -m multiport --source-ports 2021,2022 --tcp-flags SYN",
		path+" "+strings.Join(args, " "))
}
```
How it works:


### Related changes

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test

Side effects
