### PR TITLE
fix: support aws/gcp chaos in dashboard archive

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -155,6 +155,10 @@ func (r *ChaosCollector) setUnarchivedExperiment(req ctrl.Request, obj v1alpha1.
 		archive.Action = ""
 	case *v1alpha1.DNSChaos:
 		archive.Action = string(chaos.Spec.Action)
+	case *v1alpha1.AWSChaos:
+		archive.Action = string(chaos.Spec.Action)
+	case *v1alpha1.GCPChaos:
+		archive.Action = string(chaos.Spec.Action)
 	default:
 		return errors.New("unsupported chaos type " + archive.Kind)
 	}


### PR DESCRIPTION
Signed-off-by: “fewdan” <fewdan@hotmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
support aws/gcp chaos in dashboard archive

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->
Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:
* Need to update Chaos Dashboard component, related issue:
* Need to cheery-pick to the release branch

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
