### PR TITLE
add github action to build on multiple arch

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron:  '0 18 * * *'
+  release:
+    types: [published]
 
 jobs:
   build-specific-architecture:

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -1,0 +1,90 @@
+name: Upload Image
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '0 18 * * *'
+
+jobs:
+  build-specific-architecture:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        image: [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-dlv]
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Extract Image Tag
+        shell: bash
+        run: |
+          IMAGE_TAG=${GITHUB_REF##*/}
+          if [ "${IMAGE_TAG}" = "master" ] ; then
+            IMAGE_TAG=latest; 
+          fi
+
+          echo "##[set-output name=image_tag;]$(echo $IMAGE_TAG)"
+        id: image_tag
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Chaos Mesh
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+          ARCH: ${{ matrix.arch }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+          make -B TARGET_PLATFORM=$ARCH IMAGE_TAG=$IMAGE_TAG-$ARCH IMAGE_PROJECT=chaos-mesh/chaos-mesh DOCKER_REGISTRY=ghcr.io image-$IMAGE
+      
+      - name: Upload Chaos Mesh
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+          ARCH: ${{ matrix.arch }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker push ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-$ARCH
+
+  upload-manifest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-dlv]
+    needs: build-specific-architecture
+    steps:
+      - name: Build Chaos Mesh manifest
+        env:
+          IMAGE: ${{ matrix.image }}
+          IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
+        run: |
+          docker manifest create ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
+            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-arm64
+          
+          docker manifest annotate ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
+            --os linux --arch amd64
+          docker manifest annotate ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-arm64 \
+            --os linux --arch arm64
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Chaos Mesh
+        env:
+          IMAGE: ${{ matrix.image }}
+          IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
+        run: |
+          docker manifest push ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,8 @@ DOCKER_REGISTRY ?= "localhost:5000"
 DOCKER_REGISTRY_PREFIX := $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY)/,)
 DOCKER_BUILD_ARGS := --build-arg HTTP_PROXY=${HTTP_PROXY} --build-arg HTTPS_PROXY=${HTTPS_PROXY} --build-arg UI=${UI} --build-arg LDFLAGS="${LDFLAGS}" --build-arg CRATES_MIRROR="${CRATES_MIRROR}"
 
-GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
-GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")
-GO111 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 11 ]; echo $$?)
-
 IMAGE_TAG := $(if $(IMAGE_TAG),$(IMAGE_TAG),latest)
+IMAGE_PROJECT := $(if $(IMAGE_PROJECT),$(IMAGE_PROJECT),pingcap)
 
 ROOT=$(shell pwd)
 OUTPUT_BIN=$(ROOT)/output/bin
@@ -23,10 +20,6 @@ IMAGE_BUILD_ENV_BUILD ?= 0
 IMAGE_DEV_ENV_PROJECT ?= chaos-mesh/chaos-mesh
 IMAGE_DEV_ENV_REGISTRY ?= ghcr.io
 IMAGE_DEV_ENV_BUILD ?= 0
-
-ifeq ($(GO111), 1)
-$(error Please upgrade your Go compiler to 1.11 or higher version)
-endif
 
 # Enable GO111MODULE=on explicitly, disable it with GO111MODULE=off when necessary.
 export GO111MODULE := on
@@ -43,13 +36,6 @@ PACKAGE_LIST := echo $$(go list ./... | grep -vE "chaos-mesh/test|pkg/ptrace|zz_
 
 # no version conversion
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,crdVersions=v1"
-
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
 
 GO_BUILD_CACHE ?= $(ROOT)/.cache/chaos-mesh
 
@@ -234,7 +220,7 @@ define IMAGE_TEMPLATE
 
 $(4)_PROJECT := ${IMAGE_$(4)_PROJECT}
 ifeq ($$($(4)_PROJECT),)
-$(4)_PROJECT := pingcap
+$(4)_PROJECT := $(IMAGE_PROJECT)
 endif
 
 $(4)_REGISTRY := $(IMAGE_$(4)_REGISTRY)

--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -10,11 +10,14 @@ ARG HTTP_PROXY
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
-RUN apt-get update && apt-get install build-essential curl git pkg-config libfuse-dev fuse -y
+RUN apt-get update && \ 
+    apt-get install build-essential curl git pkg-config libfuse-dev fuse -y && \
+    apt-get clean
 
 # require nodejs >= 12
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean
 RUN npm config set unsafe-perm true
 RUN npm install yarn -g
 

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -6,23 +6,20 @@ ARG HTTP_PROXY
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
-RUN apt-get update && apt-get install -y tzdata iptables ipset stress-ng iproute2 fuse util-linux procps curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \ 
+    apt-get install -y tzdata iptables ipset stress-ng iproute2 fuse util-linux procps curl && \
+    apt-get clean
 
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 ENV RUST_BACKTRACE 1
 
-RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.2.0/toda-linux-amd64.tar.gz -o /usr/local/bin/toda.tar.gz
-RUN curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.5/nsexec-linux-amd64.tar.gz -o /usr/local/bin/nsexec.tar.gz
-RUN curl -L https://github.com/chaos-mesh/rs-tproxy/releases/download/v0.2.3/tproxy-linux-amd64.tar.gz -o /usr/local/bin/tproxy.tar.gz
+# toda doesn't support arm64 yet
+RUN curl -L https://github.com/chaos-mesh/toda/releases/download/v0.2.0/toda-linux-amd64.tar.gz | tar -xz -C /usr/local/bin
 
-RUN tar xvf /usr/local/bin/toda.tar.gz -C /usr/local/bin
-RUN rm /usr/local/bin/toda.tar.gz
-RUN tar xvf /usr/local/bin/tproxy.tar.gz -C /usr/local/bin
-RUN rm /usr/local/bin/tproxy.tar.gz
-RUN tar xvf /usr/local/bin/nsexec.tar.gz -C /usr/local/bin
-RUN rm /usr/local/bin/nsexec.tar.gz
-RUN cp /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so
+RUN curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.6/nsexec-$(uname -m)-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin &&\
+    mv /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so
+RUN curl -L https://github.com/chaos-mesh/rs-tproxy/releases/download/v0.2.4/tproxy-$(uname -m)-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
 
 COPY bin/chaos-daemon /usr/local/bin/chaos-daemon
 COPY bin/pause /usr/local/bin/pause

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -9,7 +9,9 @@ ENV https_proxy $HTTPS_PROXY
 ARG UI
 ARG SWAGGER
 
-RUN apt-get update && apt-get install tzdata -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \ 
+    apt-get install tzdata -y && \
+    apt-get clean
 
 ENV http_proxy=
 ENV https_proxy=

--- a/images/chaos-dlv/Dockerfile
+++ b/images/chaos-dlv/Dockerfile
@@ -6,7 +6,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.6.1
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install procps -y
+RUN apt-get update && \
+    apt-get install procps -y && \
+    apt-get clean
 
 COPY --from=build-env /go/bin/dlv /
 CMD ["bash", "-c", "/dlv attach $(ps axf | grep $CMD_NAME | grep -v grep | awk '{print $1}') --listen=:8000 --headless=true --api-version=2 --accept-multiclient --continue"]

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -1,41 +1,9 @@
 # syntax=docker/dockerfile:experimental
 
-FROM debian:buster-slim
+FROM golang:1.16.7 AS go_install
 
-ENV DEBIAN_FRONTEND noninteractive
-
-ARG HTTPS_PROXY
-ARG HTTP_PROXY
-
-ENV http_proxy $HTTP_PROXY
-ENV https_proxy $HTTPS_PROXY
-
-RUN apt-get update && apt-get install unzip git build-essential curl python -y
-
-# The `TARGET_PLATFORM` would be `amd64` or `arm64`
-ARG TARGET_PLATFORM=amd64
-
-# The architecture part of the url is `aarch_64` or `x86_64`
-RUN case "$TARGET_PLATFORM" in \
-    'amd64') \
-    export PROTOC_ARCH='x86_64'; \
-    ;; \
-    'arm64') \
-    export PROTOC_ARCH='aarch_64'; \
-    ;; \
-    *) echo >&2 "error: unsupported architecture '$TARGET_PLATFORM'"; exit 1 ;; \
-    esac; \
-    curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-linux-$PROTOC_ARCH.zip > /protoc.zip; \
-    unzip /protoc.zip -d /usr/local; \
-    rm /protoc.zip;
-RUN chmod +xr -R /usr/local/include
-RUN chmod +x /usr/local/bin/protoc
-
-
-RUN curl https://dl.google.com/go/go1.16.7.linux-$TARGET_PLATFORM.tar.gz | tar -xz -C /usr/local
 ENV GO111MODULE=on
 ENV GOPATH /go
-ENV PATH "/usr/local/go/bin:${PATH}:/tmp/go/bin:/go/bin"
 ENV CGO_ENABLED 0
 
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
@@ -52,12 +20,52 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.6.7
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 RUN go install github.com/golang/mock/mockgen@v1.5.0
 
+FROM debian:buster-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG HTTPS_PROXY
+ARG HTTP_PROXY
+
+ENV http_proxy $HTTP_PROXY
+ENV https_proxy $HTTPS_PROXY
+
+RUN apt-get update && \ 
+    apt-get install unzip git build-essential curl python -y && \
+    apt-get clean
+
+# The `TARGET_PLATFORM` would be `amd64` or `arm64`
+ARG TARGET_PLATFORM=amd64
+
+# The architecture part of the url is `aarch_64` or `x86_64`
+RUN case "$TARGET_PLATFORM" in \
+    'amd64') \
+    export PROTOC_ARCH='x86_64'; \
+    ;; \
+    'arm64') \
+    export PROTOC_ARCH='aarch_64'; \
+    ;; \
+    *) echo >&2 "error: unsupported architecture '$TARGET_PLATFORM'"; exit 1 ;; \
+    esac; \
+    curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-linux-$PROTOC_ARCH.zip > /protoc.zip && \
+    unzip /protoc.zip -d /usr/local && \
+    rm /protoc.zip
+RUN chmod +xr -R /usr/local/include
+RUN chmod +x /usr/local/bin/protoc
+
+RUN mkdir -p /go/bin
+
+COPY --from=go_install /usr/local/go /usr/local/go
+COPY --from=go_install /go/bin /go/bin
+
+ENV PATH "/usr/local/go/bin:${PATH}:/tmp/go/bin:/go/bin"
+
 RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_$(go env GOOS)_$(go env GOARCH).tar.gz | tar -xz -C /usr/local/bin/
 
 RUN curl -L https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-1.19.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz -C /usr/local/
 
-RUN curl -L https://get.helm.sh/helm-v3.6.3-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz -C /usr/local/bin; \
-    mv /usr/local/bin/$(go env GOOS)-$(go env GOARCH)/helm /usr/local/bin/helm; \
+RUN curl -L https://get.helm.sh/helm-v3.6.3-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz -C /usr/local/bin && \
+    mv /usr/local/bin/$(go env GOOS)-$(go env GOARCH)/helm /usr/local/bin/helm && \
     rm -rf /usr/local/bin/$(go env GOOS)-$(go env GOARCH)
 
 RUN mkdir /.cache
@@ -65,5 +73,7 @@ RUN chmod -R 777 /.cache
 
 ENV GOCACHE /tmp/go-build
 ENV GOPATH /tmp/go
+ENV GO111MODULE=on
+ENV CGO_ENABLED 0
 
 LABEL org.opencontainers.image.source https://github.com/chaos-mesh/chaos-mesh


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #2317 close #1955

Problem Summary:

1. Shrink the image size of `dev-env` and `build-env`, but most of the image size is binary and go, so it's still very big.
2. Add github action to build image on multiple arch. `IOChaos` and `TimeChaos` is still not supported. It will cost a lot of time to build, so it will only trigger on every night, but not on every PR.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
1. nightly build image for amd64 and arm64.
2. publish image on `ghcr.io`
```
