### PR TITLE
ci: fix image tag output in github action

### DIFF
--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -29,7 +29,7 @@ jobs:
             IMAGE_TAG=latest; 
           fi
 
-          echo "##[set-output name=image_tag::]$(echo $IMAGE_TAG)"
+          echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
         id: image_tag
 
       - name: Log in to GitHub Docker Registry

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -26,7 +26,7 @@ jobs:
             IMAGE_TAG=latest; 
           fi
 
-          echo "##[set-output name=image_tag::]$(echo $IMAGE_TAG)"
+          echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
         id: image_tag
 
       - name: Log in to GitHub Docker Registry


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Problem Summary:

The `image_tag` output in the github action definition is incorrect. In this PR, I will modify them according to the documents.

The original variable settings are copied from stackoverflow or somewhere, but it's out of date. The one submitted in the former PR is a mix of old and new one, which will obviously fail to work.