### PR TITLE
BugBash : fixed issue in setupProxy.js

### DIFF
--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -9,4 +9,4 @@ module.exports = function (app) {
       target: API_URL,
     })
   );
-}
+};


### PR DESCRIPTION
### What problem does this PR solve?
fixed bug given by the Sonatype lift scanner. 
Problem Summary:

### What is changed and how it works?
A semicolon was missing in setupProxy.js file under the ui/src directory .

What's Changed:

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`:

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
