### PR TITLE
dashboard: initialize phase selector and pods

### DIFF
--- a/ui/src/components/NewExperiment/types.ts
+++ b/ui/src/components/NewExperiment/types.ts
@@ -25,7 +25,7 @@ interface Selector {
   namespaces: string[]
   labelSelectors?: string[]
   annotationSelectors?: string[]
-  phaseSelectors?: string[]
+  podPhaseSelectors?: string[]
   pods?: string[]
 }
 

--- a/ui/src/components/NewExperimentNext/data/basic.ts
+++ b/ui/src/components/NewExperimentNext/data/basic.ts
@@ -30,7 +30,7 @@ const data = {
       namespaces: [],
       labelSelectors: [],
       annotationSelectors: [],
-      phaseSelectors: ['all'],
+      podPhaseSelectors: ['all'],
       pods: [],
     },
     mode: 'one',

--- a/ui/src/components/NewExperimentNext/form/Scope.tsx
+++ b/ui/src/components/NewExperimentNext/form/Scope.tsx
@@ -182,8 +182,8 @@ const ScopeStep: React.FC<ScopeStepProps> = ({
         )}
 
         <SelectField
-          name={`${scope}.phaseSelectors`}
-          label={T('k8s.phaseSelectors')}
+          name={`${scope}.podPhaseSelectors`}
+          label={T('k8s.podPhaseSelectors')}
           helperText={T('common.multiOptions')}
           multiple
           onChange={handleChangeIncludeAll}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -347,6 +347,6 @@
     "namespaceSelectors": "Namespace Selectors",
     "labelSelectors": "Label Selectors",
     "annotationsSelectors": "Annotation Selectors",
-    "phaseSelectors": "Phase Selectors"
+    "podPhaseSelectors": "Phase Selectors"
   }
 }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -349,6 +349,6 @@
     "namespaceSelectors": "命名空间选择器",
     "labelSelectors": "标签选择器",
     "annotationsSelectors": "注解选择器",
-    "phaseSelectors": "阶段选择器"
+    "podPhaseSelectors": "阶段选择器"
   }
 }

--- a/ui/src/lib/formikhelpers.ts
+++ b/ui/src/lib/formikhelpers.ts
@@ -62,10 +62,10 @@ export function parseSubmit<K extends ExperimentKind>(
       delete scope.annotationSelectors
     }
 
-    // Parse phaseSelectors
-    const phaseSelectors = scope.phaseSelectors
-    if (phaseSelectors?.length === 1 && phaseSelectors[0] === 'all') {
-      delete scope.phaseSelectors
+    // Parse podPhaseSelectors
+    const podPhaseSelectors = scope.podPhaseSelectors
+    if (podPhaseSelectors?.length === 1 && podPhaseSelectors[0] === 'all') {
+      delete scope.podPhaseSelectors
     }
 
     // Parse pods
@@ -214,7 +214,7 @@ export function parseYAML(
       spec.target.selector.annotationSelectors = spec.target.selector.annotationSelectors
         ? selectorsToArr(spec.target.selector.annotationSelectors, ': ')
         : []
-      spec.target.selector.phaseSelectors = spec.target.selector.phaseSelectors || []
+      spec.target.selector.podPhaseSelectors = spec.target.selector.podPhaseSelectors || []
       spec.target.selector.pods = spec.target.selector.pods ? podSelectorsToArr(spec.target.selector.pods) : []
     }
   }


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #2376 

Problem Summary:

### What is changed and how it works?

Initialize phase selector and pods if they are `undefined`. The undefined phase selector will throw the error described in #2376 (the value of `Select` should be an array ...). The undefined `pods` will make the `formikPods` undefined and the following `formicPods.length` will give an error.