### PR TITLE
physicalmachinechaos: remove key before set kv

### DIFF
--- a/controllers/chaosimpl/physicalmachinechaos/impl.go
+++ b/controllers/chaosimpl/physicalmachinechaos/impl.go
@@ -85,10 +85,10 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		impl.Log.Error(err, "")
 		return v1alpha1.NotInjected, err
 	}
+	delete(expInfoMap, string(physicalMachinechaos.Spec.Action))
 	for k, v := range configKV {
 		expInfoMap[k] = v
 	}
-	delete(expInfoMap, string(physicalMachinechaos.Spec.Action))
 
 	expInfoBytes, err = json.Marshal(expInfoMap)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

The `process` field has a `process` key :full_moon_with_face: . The original logic will remove `process` key from the request.