### PR TITLE
chore: update admissionregistration with v1

### DIFF
--- a/helm/chaos-mesh/templates/secrets-configuration.yaml
+++ b/helm/chaos-mesh/templates/secrets-configuration.yaml
@@ -6,6 +6,11 @@
 {{- $crtPEM := .Values.webhook.crtPEM }}
 {{- $keyPEM := .Values.webhook.keyPEM }}
 
+{{- $webhookApiVersion := "v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+  {{- $webhookApiVersion = "v1" }}
+{{- end }}
+
 {{- $supportTimeoutSeconds := false }}
 {{- if ge .Capabilities.KubeVersion.Minor "14" }}
 {{- $supportTimeoutSeconds = true }}
@@ -61,7 +66,11 @@ data:
 
 {{- end }}
 ---
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "chaos-mesh.mutation" . }}
@@ -77,6 +86,10 @@ webhooks:
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
     {{- end}}
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    {{- end }}
     clientConfig:
       {{- if $certManagerEnabled }}
       caBundle: Cg==
@@ -109,6 +122,10 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-{{ $crd }}
     failurePolicy: Fail
     name: m{{ $crd }}.kb.io
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    {{- end }}
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
     {{- end}}
@@ -124,8 +141,11 @@ webhooks:
           - {{ $crd }}
   {{- end }}
 ---
-
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ template "chaos-mesh.validation" . }}
@@ -151,6 +171,10 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-{{ $crd }}
     failurePolicy: Fail
     name: v{{ $crd }}.kb.io
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    {{- end }}
     {{- if $supportTimeoutSeconds }}
     timeoutSeconds: {{ $timeoutSeconds }}
     {{- end}}
@@ -174,8 +198,11 @@ webhooks:
   {{- end }}
 
 ---
-
+{{- if eq $webhookApiVersion "v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validate-auth
@@ -199,6 +226,10 @@ webhooks:
         path: /validate-auth
     failurePolicy: Fail
     name: vauth.kb.io
+    {{- if eq $webhookApiVersion "v1" }}
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    {{- end }}
     rules:
       - apiGroups:
           - chaos-mesh.org

--- a/install.sh
+++ b/install.sh
@@ -1426,7 +1426,7 @@ spec:
             secretName: chaos-mesh-webhook-certs
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: chaos-mesh-mutation
@@ -1439,6 +1439,8 @@ metadata:
 webhooks:
   - name: admission-webhook.chaos-mesh.org
     timeoutSeconds: 5
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     clientConfig:
       caBundle: "${CA_BUNDLE}"
       service:
@@ -1462,6 +1464,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-podchaos
     failurePolicy: Fail
     name: mpodchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1481,6 +1485,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-iochaos
     failurePolicy: Fail
     name: miochaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1500,6 +1506,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-timechaos
     failurePolicy: Fail
     name: mtimechaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1519,6 +1527,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-networkchaos
     failurePolicy: Fail
     name: mnetworkchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1538,6 +1548,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-kernelchaos
     failurePolicy: Fail
     name: mkernelchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1557,6 +1569,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-stresschaos
     failurePolicy: Fail
     name: mstresschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1576,6 +1590,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-awschaos
     failurePolicy: Fail
     name: mawschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1595,6 +1611,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-gcpchaos
     failurePolicy: Fail
     name: mgcpchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1614,6 +1632,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-dnschaos
     failurePolicy: Fail
     name: mdnschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1633,6 +1653,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-jvmchaos
     failurePolicy: Fail
     name: mjvmchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1652,6 +1674,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-schedule
     failurePolicy: Fail
     name: mschedule.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1671,6 +1695,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-workflow
     failurePolicy: Fail
     name: mworkflow.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1690,6 +1716,8 @@ webhooks:
         path: /mutate-chaos-mesh-org-v1alpha1-httpchaos
     failurePolicy: Fail
     name: mhttpchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1703,7 +1731,7 @@ webhooks:
           - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: chaos-mesh-validation
@@ -1722,6 +1750,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-podchaos
     failurePolicy: Fail
     name: vpodchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1741,6 +1771,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-iochaos
     failurePolicy: Fail
     name: viochaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1760,6 +1792,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-timechaos
     failurePolicy: Fail
     name: vtimechaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1779,6 +1813,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-networkchaos
     failurePolicy: Fail
     name: vnetworkchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1798,6 +1834,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-kernelchaos
     failurePolicy: Fail
     name: vkernelchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1817,6 +1855,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-stresschaos
     failurePolicy: Fail
     name: vstresschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1836,6 +1876,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-awschaos
     failurePolicy: Fail
     name: vawschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1855,6 +1897,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-gcpchaos
     failurePolicy: Fail
     name: vgcpchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1874,6 +1918,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-dnschaos
     failurePolicy: Fail
     name: vdnschaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1893,6 +1939,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-jvmchaos
     failurePolicy: Fail
     name: vjvmchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1912,6 +1960,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-schedule
     failurePolicy: Fail
     name: vschedule.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1931,6 +1981,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-workflow
     failurePolicy: Fail
     name: vworkflow.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1950,6 +2002,8 @@ webhooks:
         path: /validate-chaos-mesh-org-v1alpha1-httpchaos
     failurePolicy: Fail
     name: vhttpchaos.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 5
     rules:
       - apiGroups:
@@ -1963,7 +2017,7 @@ webhooks:
           - httpchaos
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validate-auth
@@ -1982,6 +2036,8 @@ webhooks:
         path: /validate-auth
     failurePolicy: Fail
     name: vauth.kb.io
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
     rules:
       - apiGroups:
           - chaos-mesh.org


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->
Issue Number: 
- close #2421, let next 2.0.x release support kuberentes 1.22+
- close https://github.com/chaos-mesh/website/issues/140

Problem Summary:
- helm charts on `release-2.0` still using admissionregistartion v1beat1, which has been removed from kubernetes 1.22, so 2.0.x could not play well with k8s 1.22+

### What is changed and how it works?

What's Changed:
- update helm charts

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No.
* Need to update Chaos Dashboard component, related issue: No.
* Need to cheery-pick to the release branch: No.

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
