### PR TITLE
feat(metrics): add gRPC client request duration histogram metric

### DIFF
--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -106,7 +106,8 @@ func newGRPCServer(containerRuntime string, reg prometheus.Registerer, tlsConf t
 
 	grpcMetrics := grpc_prometheus.NewServerMetrics()
 	grpcMetrics.EnableHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 10}),
+		grpc_prometheus.WithHistogramBuckets(metrics.ChaosDaemonGrpcServerBuckets),
+		metrics.WithHistogramName("chaos_daemon_grpc_server_handling_seconds"),
 	)
 	reg.MustRegister(
 		grpcMetrics,

--- a/pkg/dashboard/apiserver/server.go
+++ b/pkg/dashboard/apiserver/server.go
@@ -17,7 +17,6 @@ package apiserver
 
 import (
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"net"
 	"net/http"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 

--- a/pkg/dashboard/apiserver/server.go
+++ b/pkg/dashboard/apiserver/server.go
@@ -17,6 +17,7 @@ package apiserver
 
 import (
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"net"
 	"net/http"
 
@@ -42,7 +43,9 @@ var (
 			newAPIRouter,
 		),
 		handlerModule,
-		fx.Supply(controllermetrics.Registry),
+		fx.Provide(func() prometheus.Registerer {
+			return controllermetrics.Registry
+		}),
 		fx.Invoke(metrics.NewChaosDashboardMetricsCollector),
 		fx.Invoke(register),
 	)

--- a/pkg/dashboard/apiserver/server.go
+++ b/pkg/dashboard/apiserver/server.go
@@ -25,11 +25,13 @@ import (
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/fx"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	config "github.com/chaos-mesh/chaos-mesh/pkg/config/dashboard"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/apivalidator"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/swaggerserver"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/uiserver"
+	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
 )
 
 var (
@@ -40,6 +42,8 @@ var (
 			newAPIRouter,
 		),
 		handlerModule,
+		fx.Supply(controllermetrics.Registry),
+		fx.Invoke(metrics.NewChaosDashboardMetricsCollector),
 		fx.Invoke(register),
 	)
 )

--- a/pkg/dashboard/collector/collector.go
+++ b/pkg/dashboard/collector/collector.go
@@ -43,7 +43,6 @@ type ChaosCollector struct {
 
 // Reconcile reconciles a chaos collector.
 func (r *ChaosCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log.Info("chaos reconcile!")
 	var (
 		chaosMeta  metav1.Object
 		ok         bool

--- a/pkg/dashboard/collector/collector.go
+++ b/pkg/dashboard/collector/collector.go
@@ -43,6 +43,7 @@ type ChaosCollector struct {
 
 // Reconcile reconciles a chaos collector.
 func (r *ChaosCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Info("chaos reconcile!")
 	var (
 		chaosMeta  metav1.Object
 		ok         bool

--- a/pkg/metrics/chaos-daemon.go
+++ b/pkg/metrics/chaos-daemon.go
@@ -18,14 +18,20 @@ package metrics
 import (
 	"context"
 
+	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/metrics/utils"
 )
 
-// DefaultChaosDaemonMetricsCollector is the default metrics collector for chaos daemon
-var DefaultChaosDaemonMetricsCollector = NewChaosDaemonMetricsCollector()
+var (
+	// DefaultChaosDaemonMetricsCollector is the default metrics collector for chaos daemon
+	DefaultChaosDaemonMetricsCollector = NewChaosDaemonMetricsCollector()
+
+	// ChaosDaemonGrpcServerBuckets is the buckets for gRPC server handling histogram metrics
+	ChaosDaemonGrpcServerBuckets = []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 10}
+)
 
 const (
 	// kubernetesPodNameLabel, kubernetesPodNamespaceLabel and kubernetesContainerNameLabel are the label keys
@@ -35,6 +41,12 @@ const (
 	kubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
 	kubernetesContainerNameLabel = "io.kubernetes.container.name"
 )
+
+func WithHistogramName(name string) grpcprometheus.HistogramOption {
+	return func(opts *prometheus.HistogramOpts) {
+		opts.Name = name
+	}
+}
 
 type ChaosDaemonMetricsCollector struct {
 	crClient crclients.ContainerRuntimeInfoClient

--- a/pkg/metrics/chaos-dashboard.go
+++ b/pkg/metrics/chaos-dashboard.go
@@ -58,7 +58,6 @@ func (collector *ChaosDashboardMetricsCollector) Collect(ch chan<- prometheus.Me
 
 func (collector *ChaosDashboardMetricsCollector) ginMetricsCollector() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		log.Info("metrics collecting")
 		begin := time.Now()
 
 		ctx.Next()

--- a/pkg/metrics/chaos-dashboard.go
+++ b/pkg/metrics/chaos-dashboard.go
@@ -1,0 +1,69 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const chaosDashboardSubsystem = "chaos_dashboard"
+
+// ChaosDashboardMetricsCollector implements prometheus.Collector interface
+type ChaosDashboardMetricsCollector struct {
+	httpRequestDuration *prometheus.HistogramVec
+}
+
+// NewChaosDashboardMetricsCollector initializes metrics and collector
+func NewChaosDashboardMetricsCollector(engine *gin.Engine, registry *prometheus.Registry) *ChaosDashboardMetricsCollector {
+	collector := &ChaosDashboardMetricsCollector{
+		httpRequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Subsystem: chaosDashboardSubsystem,
+			Name:      "http_request_duration_seconds",
+			Help:      "Time histogram for each HTTP query",
+		}, []string{"path", "method", "status"}),
+	}
+
+	engine.Use(collector.ginMetricsCollector())
+	registry.MustRegister(collector)
+
+	return collector
+}
+
+// Describe implements the prometheus.Collector interface.
+func (collector *ChaosDashboardMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	collector.httpRequestDuration.Describe(ch)
+}
+
+// Collect implements the prometheus.Collector interface.
+func (collector *ChaosDashboardMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	collector.httpRequestDuration.Collect(ch)
+}
+
+func (collector *ChaosDashboardMetricsCollector) ginMetricsCollector() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		log.Info("metrics collecting")
+		begin := time.Now()
+
+		ctx.Next()
+
+		collector.httpRequestDuration.WithLabelValues(ctx.FullPath(), ctx.Request.Method, strconv.Itoa(ctx.Writer.Status())).
+			Observe(time.Since(begin).Seconds())
+	}
+}


### PR DESCRIPTION
Signed-off-by: TangliziGit <tanglizimail@foxmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you haven't already, please read Chaos Mesh's [CONTRIBUTING](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--
Automatically closes linked issue when PR is merged.
Usage: `close #<issue number>`
-->
Issue Number: a part of #2397

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

1. add new option `WithGrpcMetricsCollection` for `grpc.GrpcBuilder` to provide `grpc_prometheus.UnaryClientInterceptor` and `grpc_prometheus.StreamClientInterceptor`.
2. use the option `WithGrpcMetricsCollection` in `chaosdaemon.ChaosDaemonClientBuilder.Build()` to build gRPC client with prometheus gRPC metics collector, see more: https://github.com/grpc-ecosystem/go-grpc-prometheus#client-side.
3. register `grpc_prometheus.DefaultClientMetrics` and enable gRPC request duration histogram.

### Related changes

* PR to update `chaos-mesh/website`/`chaos-mesh/website-zh`: No
* Need to update Chaos Dashboard component, related issue: No
* Need to cheery-pick to the release branch: No

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

