### PR TITLE
building images for realease-2.0 with GitHub Action

### DIFF
--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -1,18 +1,7 @@
 name: Upload Image
 on:
-  push:
-    branches:
-      # FIXME: only test on my branch
-      - building-images-for-realease-2.0
   release:
     types: [published]
-#on:
-#  workflow_dispatch: {}
-#  schedule:
-#    # cron only works on master, so no worry about it.
-#    - cron: "0 18 * * *"
-#  release:
-#    types: [published]
 
 jobs:
   build-specific-architecture:

--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -1,0 +1,68 @@
+name: Upload Image
+on:
+  push:
+    branches:
+      # FIXME: only test on my branch
+      - building-images-for-realease-2.0
+#on:
+#  workflow_dispatch: {}
+#  schedule:
+#    # cron only works on master, so no worry about it.
+#    - cron: "0 18 * * *"
+#  release:
+#    types: [published]
+
+jobs:
+  build-specific-architecture:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        image: [chaos-daemon, chaos-mesh, chaos-dashboard]
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.9'
+      - run: go version
+      - name: Extract Image Tag
+        shell: bash
+        run: |
+          IMAGE_TAG=${GITHUB_REF##*/}
+          if [ "${IMAGE_TAG}" = "master" ] ; then
+            IMAGE_TAG=latest;
+          fi
+
+          echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
+        id: image_tag
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Chaos Mesh
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+          ARCH: ${{ matrix.arch }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          if [ "${IMAGE}" = "chaos-dashboard" ]; then
+            UI=1
+          else
+            UI=0
+          fi
+          make -B IMAGE_TAG=$IMAGE_TAG IMAGE_PROJECT=strrl/chaos-mesh DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
+
+      - name: Upload Chaos Mesh
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+          ARCH: ${{ matrix.arch }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker push ghcr.io/strrl/chaos-mesh/$IMAGE:$IMAGE_TAG

--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -59,7 +59,8 @@ jobs:
           else
             UI=0
           fi
-          make -B IMAGE_TAG=$IMAGE_TAG IMAGE_PROJECT=strrl/chaos-mesh DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
+          # ${VAR,,} convertion to lower case
+          make -B IMAGE_TAG=$IMAGE_TAG IMAGE_PROJECT=${GITHUB_REPOSITORY,,} DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
 
       - name: Upload Chaos Mesh
         env:
@@ -67,4 +68,5 @@ jobs:
           ARCH: ${{ matrix.arch }}
           IMAGE: ${{ matrix.image }}
         run: |
-          docker push ghcr.io/strrl/chaos-mesh/$IMAGE:$IMAGE_TAG
+          # ${VAR,,} convertion to lower case
+          docker push ghcr.io/${GITHUB_REPOSITORY,,}/$IMAGE:$IMAGE_TAG

--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       # FIXME: only test on my branch
       - building-images-for-realease-2.0
+  release:
+    types: [published]
 #on:
 #  workflow_dispatch: {}
 #  schedule:


### PR DESCRIPTION
### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

> Problem Summary:

- We have migrated image build from public self-hosted Jenkins to  GitHub Action on `master` branch, but not cherry-pick  into `release-2.0` branch.


### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

- new GitHub Action Workflow for building images with release

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


I have tested it on my forked repo: 

see https://github.com/STRRL/chaos-mesh/actions
and https://github.com/STRRL/chaos-mesh/actions/runs/1424638417

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
