### PR TITLE
fix: add a resonable ulimit nofile for image-chaos-kernel

### DIFF
--- a/images/chaos-kernel/Dockerfile
+++ b/images/chaos-kernel/Dockerfile
@@ -14,7 +14,10 @@ RUN echo "deb https://apt.kitware.com/ubuntu/ bionic main" >> /etc/apt/sources.l
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 
-RUN apt-get update &&  apt-get install -y gcc-8 g++-8 bison build-essential \
+# buildkit would setup a extremlly high ulimit that waste much of time even to timeout.
+# so we would set a resonable value.
+# https://github.com/moby/moby/issues/40398
+RUN ulimit -n 1024 && apt-get update &&  apt-get install -y gcc-8 g++-8 bison build-essential \
     flex git libedit-dev libllvm6.0 llvm-6.0-dev libclang-6.0-dev python python-pip \
     zlib1g-dev libelf-dev libssl-dev && pip install cmake==3.13.3
 


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

close https://github.com/chaos-mesh/chaos-mesh/issues/2479

> Problem Summary: Can not build docker image chaos-kernel

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

refs to https://github.com/moby/moby/issues/40398, I set up a smaller ulimti nofile.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**: release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
