### PR TITLE
chore: short the project name for image

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -50,7 +50,7 @@ jobs:
             UI=0
           fi
 
-          make -B TARGET_PLATFORM=$ARCH IMAGE_TAG=$IMAGE_TAG-$ARCH IMAGE_PROJECT=chaos-mesh/chaos-mesh DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
+          make -B TARGET_PLATFORM=$ARCH IMAGE_TAG=$IMAGE_TAG-$ARCH IMAGE_PROJECT=chaos-mesh DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
 
       - name: Upload Chaos Mesh
         env:
@@ -58,7 +58,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           IMAGE: ${{ matrix.image }}
         run: |
-          docker push ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-$ARCH
+          docker push ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG-$ARCH
 
   upload-manifest:
     runs-on: ubuntu-latest
@@ -72,15 +72,15 @@ jobs:
           IMAGE: ${{ matrix.image }}
           IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
         run: |
-          docker manifest create ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
-            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
-            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-arm64
+          docker manifest create ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
+            ghcr.io/chaos-mesh$IMAGE:$IMAGE_TAG-arm64
 
-          docker manifest annotate ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
-            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
+          docker manifest annotate ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG-amd64 \
             --os linux --arch amd64
-          docker manifest annotate ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG \
-            ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG-arm64 \
+          docker manifest annotate ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG \
+            ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG-arm64 \
             --os linux --arch arm64
 
       - name: Log in to GitHub Docker Registry
@@ -95,4 +95,4 @@ jobs:
           IMAGE: ${{ matrix.image }}
           IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
         run: |
-          docker manifest push ghcr.io/chaos-mesh/chaos-mesh/$IMAGE:$IMAGE_TAG
+          docker manifest push ghcr.io/chaos-mesh/$IMAGE:$IMAGE_TAG


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
It's a part of https://github.com/chaos-mesh/chaos-mesh/issues/2475;

> Problem Summary:

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

change artifact image name, from `ghcr.io/chaos-mesh/chaos-mesh/<component>` to  `ghcr.io/chaos-mesh/<component>`

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [x] Need to **cheery-pick to release branches**, should manually cherry-picked to release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
