### PR TITLE
Fix dashboard mysql bug

### DIFF
--- a/pkg/dashboard/core/workflow.go
+++ b/pkg/dashboard/core/workflow.go
@@ -439,7 +439,7 @@ type WorkflowStore interface {
 // WorkflowEntity is the gorm entity, refers to a row of data
 type WorkflowEntity struct {
 	WorkflowMeta
-	Workflow string `gorm:"size:32768"`
+	Workflow string `gorm:"type:text;size:32768"`
 }
 
 func WorkflowCR2WorkflowEntity(workflow *v1alpha1.Workflow) (*WorkflowEntity, error) {


### PR DESCRIPTION
### What problem does this PR solve?
Close #2464

> Problem Summary:

### What's changed and how it works?

Added gorm argument in dashboard core workflow for the WorkflowEntity struct. This will define the type as a TEXT, allowing the column length to be bigger than MySQL allows via defaults.

Related error shown when starting dashboard with brand new / blank database:
```
[2021-11-03 17:06:15]  Error 1074: Column length too big for column 'workflow' (max = 16383); use BLOB or TEXT instead 
panic: Error 1146: Table 'chaos-mesh.workflow_entities' doesn't exist
```

> What's Changed:

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard` (Leaving unchecked, I believe this is for NPM changes?)
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests
- [X] Manual test (add detailed scripts or steps below)

I have not had time to get local complete e2e testing environment working to run unit tests, however have tried basic test of starting the dashboard and running an experiment.

Manually tested with sqlite and mysql 8.0 ( Complete MySQL usage still blocked by bug outlined in #1659 )

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Fixed issue within workflows causing initial dashboard startup to fail when using mysql 8.x
```
