### PR TITLE
docs: generate api reference

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -49,3 +49,5 @@ header:
     - '**/Dockerfile'
     # UI SVGs
     - 'ui/**/*.svg'
+    # api reference
+    - 'api-reference/**/*'

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ define generate-make
 	cd ./api/v1alpha1 ;\
 		controller-gen object:headerFile=../../hack/boilerplate/boilerplate.generatego.txt paths="./..." ;
 endef
-$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate,chaos-build generate-ctrl swagger_spec))
+$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate,chaos-build generate-ctrl swagger_spec api-reference/index.html))
 check: generate yaml vet boilerplate lint tidy install.sh fmt
 
 CLEAN_TARGETS+=e2e-test/image/e2e/bin/ginkgo
@@ -470,6 +470,23 @@ define generate-mock-make
 	$(GO) generate ./pkg/workflow
 endef
 $(eval $(call RUN_IN_DEV_ENV_TEMPLATE,generate-mock))
+
+define api-reference/index.asciidoc-make
+	cd /mnt; \
+	crd-ref-docs --source-path=./api/v1alpha1 \
+		--config=./api-reference/config.yaml \
+		--renderer=asciidoctor \
+		--templates-dir=./api-reference/asciidoctor \
+		--output-path=out.asciidoc \
+		--log-level debug --max-depth 1024 \
+		--output-path ./api-reference/index.asciidoc
+endef
+$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,api-reference/index.asciidoc,api/v1alpha1/*.go))
+
+define api-reference/index.html-make
+	asciidoctor -a toc2 -D api-reference -o ./index.html ./api-reference/index.asciidoc
+endef
+$(eval $(call RUN_IN_DEV_ENV_TEMPLATE,api-reference/index.html,api-reference/index.asciidoc))
 
 .PHONY: all clean test install manifests groupimports fmt vet tidy image \
 	docker-push lint generate config mockgen generate-mock \

--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ define api-reference/index.asciidoc-make
 		--renderer=asciidoctor \
 		--templates-dir=./api-reference/asciidoctor \
 		--output-path=out.asciidoc \
-		--log-level debug --max-depth 1024 \
+		--max-depth 1024 \
 		--output-path ./api-reference/index.asciidoc
 endef
 $(eval $(call RUN_IN_DEV_ENV_TEMPLATE,api-reference/index.asciidoc,api/v1alpha1/*.go))

--- a/api-reference/asciidoctor/gv_details.tpl
+++ b/api-reference/asciidoctor/gv_details.tpl
@@ -1,0 +1,19 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+[id="{{ asciidocGroupVersionID $gv | asciidocRenderAnchorID }}"]
+=== {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+.Resource Types
+{{- range $gv.SortedKinds }}
+- {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
+{{- end }}
+{{ end }}
+
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/api-reference/asciidoctor/gv_list.tpl
+++ b/api-reference/asciidoctor/gv_list.tpl
@@ -1,0 +1,19 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+== API Reference
+
+.Packages
+{{- range $groupVersions }}
+- {{ asciidocRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/api-reference/asciidoctor/gv_list.tpl
+++ b/api-reference/asciidoctor/gv_list.tpl
@@ -3,6 +3,7 @@
 
 // Generated documentation. Please do not edit.
 :anchor_prefix: k8s-api
+:nofooter:
 
 [id="{p}-api-reference"]
 == API Reference

--- a/api-reference/asciidoctor/type.tpl
+++ b/api-reference/asciidoctor/type.tpl
@@ -1,0 +1,35 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if asciidocShouldRenderType $type -}}
+
+[id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
+==== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.References -}}
+.Appears In:
+****
+{{- range $type.SortedReferences }}
+- {{ asciidocRenderTypeLink . }}
+{{- end }}
+****
+{{- end }}
+
+{{ if $type.Members -}}
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+{{ if $type.GVK -}}
+| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}`
+| *`kind`* __string__ | `{{ $type.GVK.Kind }}`
+{{ end -}}
+
+{{ range $type.Members -}}
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }}
+{{ end -}}
+|===
+{{ end -}}
+
+{{- end -}}
+{{- end -}}

--- a/api-reference/asciidoctor/type_members.tpl
+++ b/api-reference/asciidoctor/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{ else -}}
+{{ $field.Doc }}
+{{- end -}}
+{{- end -}}

--- a/api-reference/config.yaml
+++ b/api-reference/config.yaml
@@ -1,0 +1,8 @@
+processor:
+  # RE2 regular expressions describing types that should be excluded from the generated documentation.
+  ignoreTypes:
+    - ".*List$"
+
+render:
+  # Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.18

--- a/api-reference/index.asciidoc
+++ b/api-reference/index.asciidoc
@@ -1,0 +1,2983 @@
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+== API Reference
+
+.Packages
+- xref:{anchor_prefix}-chaos-mesh-org-v1alpha1[$$chaos-mesh.org/v1alpha1$$]
+
+
+[id="{anchor_prefix}-chaos-mesh-org-v1alpha1"]
+=== chaos-mesh.org/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the chaosmesh v1alpha1 API group
+
+.Resource Types
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos[$$AWSChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos[$$DNSChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos[$$GCPChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos[$$HTTPChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos[$$IOChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos[$$JVMChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos[$$KernelChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos[$$NetworkChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos[$$PhysicalMachineChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos[$$PodChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos[$$PodHttpChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos[$$PodIOChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos[$$PodNetworkChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule[$$Schedule$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos[$$StressChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos[$$TimeChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow[$$Workflow$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode[$$WorkflowNode$$]
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos"]
+==== AWSChaos 
+
+AWSChaos is the Schema for the awschaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `AWSChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec[$$AWSChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus[$$AWSChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosaction"]
+==== AWSChaosAction (string) 
+
+AWSChaosAction represents the chaos action about aws.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec[$$AWSChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec"]
+==== AWSChaosSpec 
+
+AWSChaosSpec is the content of the specification for an AWSChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos[$$AWSChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosaction[$$AWSChaosAction$$]__ | Action defines the specific aws chaos action. Supported action: ec2-stop / ec2-restart / detach-volume Default action: ec2-stop
+| *`duration`* __string__ | Duration represents the duration of the chaos action.
+| *`secretName`* __string__ | SecretName defines the name of kubernetes secret.
+| *`AWSSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awsselector[$$AWSSelector$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus"]
+==== AWSChaosStatus 
+
+AWSChaosStatus represents the status of an AWSChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos[$$AWSChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awsselector"]
+==== AWSSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec[$$AWSChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`endpoint`* __string__ | Endpoint indicates the endpoint of the aws server. Just used it in test now.
+| *`awsRegion`* __string__ | AWSRegion defines the region of aws.
+| *`ec2Instance`* __string__ | Ec2Instance indicates the ID of the ec2 instance.
+| *`volumeID`* __string__ | EbsVolume indicates the ID of the EBS volume. Needed in detach-volume.
+| *`deviceName`* __string__ | DeviceName indicates the name of the device. Needed in detach-volume.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec"]
+==== AttrOverrideSpec 
+
+AttrOverrideSpec represents an override of attribution
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ino`* __integer__ | 
+| *`size`* __integer__ | 
+| *`blocks`* __integer__ | 
+| *`atime`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec[$$Timespec$$]__ | 
+| *`mtime`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec[$$Timespec$$]__ | 
+| *`ctime`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec[$$Timespec$$]__ | 
+| *`kind`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filetype[$$FileType$$]__ | 
+| *`perm`* __integer__ | 
+| *`nlink`* __integer__ | 
+| *`uid`* __integer__ | 
+| *`gid`* __integer__ | 
+| *`rdev`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-bandwidthspec"]
+==== BandwidthSpec 
+
+BandwidthSpec defines detail of bandwidth limit.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`rate`* __string__ | Rate is the speed knob. Allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second.
+| *`limit`* __integer__ | Limit is the number of bytes that can be queued waiting for tokens to become available.
+| *`buffer`* __integer__ | Buffer is the maximum amount of bytes that tokens can be available for instantaneously.
+| *`peakrate`* __integer__ | Peakrate is the maximum depletion rate of the bucket. The peakrate does not need to be set, it is only necessary if perfect millisecond timescale shaping is required.
+| *`minburst`* __integer__ | Minburst specifies the size of the peakrate bucket. For perfect accuracy, should be set to the MTU of the interface.  If a peakrate is needed, but some burstiness is acceptable, this size can be raised. A 3000 byte minburst allows around 3mbit/s of peakrate, given 1000 byte packets.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor"]
+==== CPUStressor 
+
+CPUStressor defines how to stress CPU out
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors[$$Stressors$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`Stressor`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor[$$Stressor$$]__ | 
+| *`load`* __integer__ | Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100 is full loading.
+| *`options`* __string array__ | extend stress-ng options
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaindirection"]
+==== ChainDirection (string) 
+
+ChainDirection represents the direction of chain
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables[$$RawIptables$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition"]
+==== ChaosCondition 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosconditiontype[$$ChaosConditionType$$]__ | 
+| *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core[$$ConditionStatus$$]__ | 
+| *`reason`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosconditiontype"]
+==== ChaosConditionType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition[$$ChaosCondition$$]
+****
+
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec"]
+==== ChaosOnlyScheduleSpec 
+
+ChaosOnlyScheduleSpec is very similar with ScheduleSpec, but it could not schedule Workflow because we could not resolve nested CRD now
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`schedule`* __string__ | 
+| *`startingDeadlineSeconds`* __integer__ | 
+| *`concurrencyPolicy`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy[$$ConcurrencyPolicy$$]__ | 
+| *`historyLimit`* __integer__ | 
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype[$$ScheduleTemplateType$$]__ | TODO: use a custom type, as `TemplateType` contains other possible values
+| *`EmbedChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus"]
+==== ChaosStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus[$$AWSChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus[$$DNSChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus[$$GCPChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus[$$HTTPChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus[$$IOChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus[$$JVMChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus[$$KernelChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus[$$NetworkChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus[$$PhysicalMachineChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus[$$PodChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus[$$StressChaosStatus$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus[$$TimeChaosStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`conditions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition[$$ChaosCondition$$] array__ | Conditions represents the current global condition of the chaos
+| *`experiment`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus[$$ExperimentStatus$$]__ | Experiment records the last experiment state.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-clockspec"]
+==== ClockSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`pid`* __integer__ | 
+| *`time-offset`* __string__ | 
+| *`clock-ids-slice`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy"]
+==== ConcurrencyPolicy (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec[$$ChaosOnlyScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec[$$ScheduleSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch"]
+==== ConditionalBranch 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`target`* __string__ | Target is the name of other template, if expression is evaluated as true, this template will be spawned.
+| *`expression`* __string__ | Expression is the expression for this conditional branch, expected type of result is boolean. If expression is empty, this branch will always be selected/the template will be spawned.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchstatus"]
+==== ConditionalBranchStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus[$$ConditionalBranchesStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`target`* __string__ | 
+| *`evaluationResult`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core[$$ConditionStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus"]
+==== ConditionalBranchesStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus[$$WorkflowNodeStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`branches`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchstatus[$$ConditionalBranchStatus$$] array__ | 
+| *`context`* __string array__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector"]
+==== ContainerSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec[$$DNSChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec[$$PodChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec[$$StressChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec[$$TimeChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`PodSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]__ | 
+| *`containerNames`* __string array__ | ContainerNames indicates list of the name of affected container. If not set, all containers will be injected
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-corruptspec"]
+==== CorruptSpec 
+
+CorruptSpec defines detail of a corrupt action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`corrupt`* __string__ | 
+| *`correlation`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos"]
+==== DNSChaos 
+
+DNSChaos is the Schema for the networkchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `DNSChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec[$$DNSChaosSpec$$]__ | Spec defines the behavior of a pod chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus[$$DNSChaosStatus$$]__ | Most recently observed status of the chaos experiment about pods
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec"]
+==== DNSChaosSpec 
+
+DNSChaosSpec defines the desired state of DNSChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos[$$DNSChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`action`* __DNSChaosAction__ | Action defines the specific DNS chaos action. Supported action: error, random Default action: error
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+| *`patterns`* __string array__ | Choose which domain names to take effect, support the placeholder ? and wildcard *, or the Specified domain name. Note:      1. The wildcard * must be at the end of the string. For example, chaos-*.org is invalid.      2. if the patterns is empty, will take effect on all the domain names. For example: 		The value is ["google.com", "github.*", "chaos-mes?.org"], 		will take effect on "google.com", "github.com" and "chaos-mesh.org"
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus"]
+==== DNSChaosStatus 
+
+DNSChaosStatus defines the observed state of DNSChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos[$$DNSChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec"]
+==== DelaySpec 
+
+DelaySpec defines detail of a delay action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`latency`* __string__ | 
+| *`correlation`* __string__ | 
+| *`jitter`* __string__ | 
+| *`reorder`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-reorderspec[$$ReorderSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-desiredphase"]
+==== DesiredPhase (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus[$$ExperimentStatus$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-direction"]
+==== Direction (string) 
+
+Direction represents traffic direction from source to target, it could be netem, delay, loss, duplicate, corrupt or partition, check comments below for detail direction flow.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec"]
+==== DiskFileSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec[$$DiskFillSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec[$$DiskPayloadSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`size`* __string__ | 
+| *`path`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec"]
+==== DiskFillSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`DiskFileSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec[$$DiskFileSpec$$]__ | 
+| *`fill_by_fallocate`* __boolean__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec"]
+==== DiskPayloadSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`DiskFileSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec[$$DiskFileSpec$$]__ | 
+| *`payload_process_num`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-duplicatespec"]
+==== DuplicateSpec 
+
+DuplicateSpec defines detail of a duplicate action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`duplicate`* __string__ | 
+| *`correlation`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos"]
+==== EmbedChaos 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec[$$ChaosOnlyScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem[$$ScheduleItem$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`awsChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec[$$AWSChaosSpec$$]__ | 
+| *`dnsChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec[$$DNSChaosSpec$$]__ | 
+| *`gcpChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec[$$GCPChaosSpec$$]__ | 
+| *`httpChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec[$$HTTPChaosSpec$$]__ | 
+| *`ioChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]__ | 
+| *`jvmChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]__ | 
+| *`kernelChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec[$$KernelChaosSpec$$]__ | 
+| *`networkChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]__ | 
+| *`physicalmachineChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec[$$PhysicalMachineChaosSpec$$]__ | 
+| *`podChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec[$$PodChaosSpec$$]__ | 
+| *`stressChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec[$$StressChaosSpec$$]__ | 
+| *`timeChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec[$$TimeChaosSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo"]
+==== ExpInfo 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec[$$PhysicalMachineChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`uid`* __string__ | the experiment ID
+| *`action`* __string__ | the subAction, generate automatically
+| *`stress-cpu`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresscpuspec[$$StressCPUSpec$$]__ | 
+| *`stress-mem`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressmemoryspec[$$StressMemorySpec$$]__ | 
+| *`disk-read-payload`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec[$$DiskPayloadSpec$$]__ | 
+| *`disk-write-payload`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec[$$DiskPayloadSpec$$]__ | 
+| *`disk-fill`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec[$$DiskFillSpec$$]__ | 
+| *`network-corrupt`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec[$$NetworkCorruptSpec$$]__ | 
+| *`network-duplicate`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec[$$NetworkDuplicateSpec$$]__ | 
+| *`network-loss`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec[$$NetworkLossSpec$$]__ | 
+| *`network-delay`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec[$$NetworkDelaySpec$$]__ | 
+| *`network-partition`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkpartitionspec[$$NetworkPartitionSpec$$]__ | 
+| *`network-dns`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdnsspec[$$NetworkDNSSpec$$]__ | 
+| *`process`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-processspec[$$ProcessSpec$$]__ | 
+| *`jvm-exception`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec[$$JVMExceptionSpec$$]__ | 
+| *`jvm-gc`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec[$$JVMGCSpec$$]__ | 
+| *`jvm-latency`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec[$$JVMLatencySpec$$]__ | 
+| *`jvm-return`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec[$$JVMReturnSpec$$]__ | 
+| *`jvm-stress`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec[$$JVMStressSpec$$]__ | 
+| *`jvm-rule-data`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec[$$JVMRuleDataSpec$$]__ | 
+| *`clock`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-clockspec[$$ClockSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus"]
+==== ExperimentStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`desiredPhase`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-desiredphase[$$DesiredPhase$$]__ | 
+| *`containerRecords`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record[$$Record$$] array__ | Records are used to track the running status
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest"]
+==== FailKernRequest 
+
+FailKernRequest defines the injection conditions
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec[$$KernelChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`failtype`* __integer__ | FailType indicates what to fail, can be set to '0' / '1' / '2' If `0`, indicates slab to fail (should_failslab) If `1`, indicates alloc_page to fail (should_fail_alloc_page) If `2`, indicates bio to fail (should_fail_bio) You can read:   1. https://www.kernel.org/doc/html/latest/fault-injection/fault-injection.html   2. http://github.com/iovisor/bcc/blob/master/tools/inject_example.txt to learn more
+| *`headers`* __string array__ | Headers indicates the appropriate kernel headers you need. Eg: "linux/mmzone.h", "linux/blkdev.h" and so on
+| *`callchain`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-frame[$$Frame$$] array__ | Callchain indicate a special call chain, such as:     ext4_mount       -> mount_subtree          -> ...             -> should_failslab With an optional set of predicates and an optional set of parameters, which used with predicates. You can read call chan and predicate examples from https://github.com/chaos-mesh/bpfki/tree/develop/examples to learn more. If no special call chain, just keep Callchain empty, which means it will fail at any call chain with slab alloc (eg: kmalloc).
+| *`probability`* __integer__ | Probability indicates the fails with probability. If you want 1%, please set this field with 1.
+| *`times`* __integer__ | Times indicates the max times of fails.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filetype"]
+==== FileType (string) 
+
+FileType represents type of a file
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec[$$AttrOverrideSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-fillingtype"]
+==== FillingType (string) 
+
+FillingType represents type of data is filled for incorrectness
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec[$$MistakeSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter"]
+==== Filter 
+
+Filter represents a filter of IOChaos action, which will define the scope of an IOChaosAction
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`path`* __string__ | Path represents a glob of injecting path
+| *`methods`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod[$$IoMethod$$]__ | Methods represents the method that the action will inject in
+| *`percent`* __integer__ | Percent represents the percent probability of injecting this action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-frame"]
+==== Frame 
+
+Frame defines the function signature and predicate in function's body
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest[$$FailKernRequest$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`funcname`* __string__ | Funcname can be find from kernel source or `/proc/kallsyms`, such as `ext4_mount`
+| *`parameters`* __string__ | Parameters is used with predicate, for example, if you want to inject slab error in `d_alloc_parallel(struct dentry *parent, const struct qstr *name)` with a special name `bananas`, you need to set it to `struct dentry *parent, const struct qstr *name` otherwise omit it.
+| *`predicate`* __string__ | Predicate will access the arguments of this Frame, example with Parameters's, you can set it to `STRNCMP(name->name, "bananas", 8)` to make inject only with it, or omit it to inject for all d_alloc_parallel call chain.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos"]
+==== GCPChaos 
+
+GCPChaos is the Schema for the gcpchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `GCPChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec[$$GCPChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus[$$GCPChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosaction"]
+==== GCPChaosAction (string) 
+
+GCPChaosAction represents the chaos action about gcp.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec[$$GCPChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec"]
+==== GCPChaosSpec 
+
+GCPChaosSpec is the content of the specification for a GCPChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos[$$GCPChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosaction[$$GCPChaosAction$$]__ | Action defines the specific gcp chaos action. Supported action: node-stop / node-reset / disk-loss Default action: node-stop
+| *`duration`* __string__ | Duration represents the duration of the chaos action.
+| *`secretName`* __string__ | SecretName defines the name of kubernetes secret. It is used for GCP credentials.
+| *`GCPSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpselector[$$GCPSelector$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus"]
+==== GCPChaosStatus 
+
+GCPChaosStatus represents the status of a GCPChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos[$$GCPChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+| *`attachedDiskStrings`* __string array__ | The attached disk info strings. Needed in disk-loss.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpselector"]
+==== GCPSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec[$$GCPChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`project`* __string__ | Project defines the name of gcp project.
+| *`zone`* __string__ | Zone defines the zone of gcp project.
+| *`instance`* __string__ | Instance defines the name of the instance
+| *`deviceNames`* __string array__ | The device name of disks to detach. Needed in disk-loss.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-genericselectorspec"]
+==== GenericSelectorSpec 
+
+GenericSelectorSpec defines some selectors to select objects.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec[$$PodSelectorSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`namespaces`* __string array__ | Namespaces is a set of namespace to which objects belong.
+| *`fieldSelectors`* __object (keys:string, values:string)__ | Map of string keys and values that can be used to select objects. A selector based on fields.
+| *`labelSelectors`* __object (keys:string, values:string)__ | Map of string keys and values that can be used to select objects. A selector based on labels.
+| *`expressionSelectors`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselectorrequirement-v1-meta[$$LabelSelectorRequirement$$] array__ | a slice of label selector expressions that can be used to select objects. A list of selectors based on set-based label expressions.
+| *`annotationSelectors`* __object (keys:string, values:string)__ | Map of string keys and values that can be used to select objects. A selector based on annotations.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos"]
+==== HTTPChaos 
+
+HTTPChaos is the Schema for the HTTPchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `HTTPChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec[$$HTTPChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus[$$HTTPChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec"]
+==== HTTPChaosSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos[$$HTTPChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`PodSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]__ | 
+| *`target`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget[$$PodHttpChaosTarget$$]__ | Target is the object to be selected and injected.
+| *`PodHttpChaosActions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions[$$PodHttpChaosActions$$]__ | 
+| *`port`* __integer__ | Port represents the target port to be proxy of.
+| *`path`* __string__ | Path is a rule to select target by uri path in http request.
+| *`method`* __string__ | Method is a rule to select target by http method in request.
+| *`code`* __integer__ | Code is a rule to select target by http status code in response.
+| *`request_headers`* __object (keys:string, values:string)__ | RequestHeaders is a rule to select target by http headers in request. The key-value pairs represent header name and header value pairs.
+| *`response_headers`* __object (keys:string, values:string)__ | ResponseHeaders is a rule to select target by http headers in response. The key-value pairs represent header name and header value pairs.
+| *`duration`* __string__ | Duration represents the duration of the chaos action.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus"]
+==== HTTPChaosStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos[$$HTTPChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+| *`instances`* __object (keys:string, values:integer)__ | Instances always specifies podhttpchaos generation or empty
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos"]
+==== IOChaos 
+
+IOChaos is the Schema for the iochaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `IOChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus[$$IOChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction"]
+==== IOChaosAction 
+
+IOChaosAction defines an possible action of IOChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec[$$PodIOChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype[$$IOChaosType$$]__ | 
+| *`Filter`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter[$$Filter$$]__ | 
+| *`faults`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iofault[$$IoFault$$] array__ | Faults represents the fault to inject
+| *`latency`* __string__ | Latency represents the latency to inject
+| *`AttrOverrideSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec[$$AttrOverrideSpec$$]__ | AttrOverride represents the attribution to override
+| *`mistake`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec[$$MistakeSpec$$]__ | MistakeSpec represents the mistake to inject
+| *`source`* __string__ | Source represents the source of current rules
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec"]
+==== IOChaosSpec 
+
+IOChaosSpec defines the desired state of IOChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos[$$IOChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype[$$IOChaosType$$]__ | Action defines the specific pod chaos action. Supported action: latency / fault / attrOverride / mistake
+| *`delay`* __string__ | Delay defines the value of I/O chaos action delay. A delay string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+| *`errno`* __integer__ | Errno defines the error code that returned by I/O action. refer to: https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html
+| *`attr`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec[$$AttrOverrideSpec$$]__ | Attr defines the overrided attribution
+| *`mistake`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec[$$MistakeSpec$$]__ | Mistake defines what types of incorrectness are injected to IO operations
+| *`path`* __string__ | Path defines the path of files for injecting I/O chaos action.
+| *`methods`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod[$$IoMethod$$] array__ | Methods defines the I/O methods for injecting I/O chaos action. default: all I/O methods.
+| *`percent`* __integer__ | Percent defines the percentage of injection errors and provides a number from 0-100. default: 100.
+| *`volumePath`* __string__ | VolumePath represents the mount path of injected volume
+| *`duration`* __string__ | Duration represents the duration of the chaos action. It is required when the action is `PodFailureAction`. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus"]
+==== IOChaosStatus 
+
+IOChaosStatus defines the observed state of IOChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos[$$IOChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+| *`instances`* __object (keys:string, values:integer)__ | Instances always specifies podiochaos generation or empty
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype"]
+==== IOChaosType (string) 
+
+IOChaosType represents the type of an IOChaos Action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]
+****
+
+
+
+
+
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iofault"]
+==== IoFault 
+
+IoFault represents the fault to inject and their weight
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`errno`* __integer__ | 
+| *`weight`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod"]
+==== IoMethod (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter[$$Filter$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos"]
+==== JVMChaos 
+
+JVMChaos is the Schema for the jvmchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `JVMChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus[$$JVMChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosaction"]
+==== JVMChaosAction (string) 
+
+JVMChaosAction represents the chaos action about jvm
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec"]
+==== JVMChaosSpec 
+
+JVMChaosSpec defines the desired state of JVMChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos[$$JVMChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosaction[$$JVMChaosAction$$]__ | Action defines the specific jvm chaos action. Supported action: delay;return;script;cfl;oom;ccf;tce;cpf;tde;tpf
+| *`JVMParameter`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmparameter[$$JVMParameter$$]__ | JVMParameter represents the detail about jvm chaos action definition
+| *`target`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaostarget[$$JVMChaosTarget$$]__ | Target defines the specific jvm chaos target. Supported target: servlet;psql;jvm;jedis;http;dubbo;rocketmq;tars;mysql;druid;redisson;rabbitmq;mongodb
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus"]
+==== JVMChaosStatus 
+
+JVMChaosStatus defines the observed state of JVMChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos[$$JVMChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaostarget"]
+==== JVMChaosTarget (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec"]
+==== JVMClassMethodSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec[$$JVMExceptionSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec[$$JVMLatencySpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec[$$JVMReturnSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`class`* __string__ | Java class
+| *`method`* __string__ | the method in Java class
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec"]
+==== JVMCommonSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec[$$JVMExceptionSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec[$$JVMGCSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec[$$JVMLatencySpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec[$$JVMReturnSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec[$$JVMRuleDataSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec[$$JVMStressSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`port`* __integer__ | the port of agent server
+| *`pid`* __integer__ | the pid of Java process which need to attach
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec"]
+==== JVMExceptionSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+| *`JVMClassMethodSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec[$$JVMClassMethodSpec$$]__ | 
+| *`exception`* __string__ | the exception which needs to throw dor action `exception`
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec"]
+==== JVMGCSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec"]
+==== JVMLatencySpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+| *`JVMClassMethodSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec[$$JVMClassMethodSpec$$]__ | 
+| *`latency`* __integer__ | the latency duration for action 'latency', unit ms
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmparameter"]
+==== JVMParameter 
+
+JVMParameter represents the detail about jvm chaos action definition
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec[$$JVMChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`flags`* __object (keys:string, values:string)__ | Flags represents the flags of action
+| *`matchers`* __object (keys:string, values:string)__ | Matchers represents the matching rules for the target
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec"]
+==== JVMReturnSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+| *`JVMClassMethodSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec[$$JVMClassMethodSpec$$]__ | 
+| *`value`* __string__ | the return value for action 'return'
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec"]
+==== JVMRuleDataSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+| *`rule-data`* __string__ | RuleData used to save the rule file's data, will use it when recover
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec"]
+==== JVMStressSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`JVMCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec[$$JVMCommonSpec$$]__ | 
+| *`cpu-count`* __integer__ | the CPU core number need to use, only set it when action is stress
+| *`mem-type`* __integer__ | the memory type need to locate, only set it when action is stress, the value can be 'stack' or 'heap'
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos"]
+==== KernelChaos 
+
+KernelChaos is the Schema for the kernelchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `KernelChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec[$$KernelChaosSpec$$]__ | Spec defines the behavior of a kernel chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus[$$KernelChaosStatus$$]__ | Most recently observed status of the kernel chaos experiment
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec"]
+==== KernelChaosSpec 
+
+KernelChaosSpec defines the desired state of KernelChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos[$$KernelChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`PodSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]__ | 
+| *`failKernRequest`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest[$$FailKernRequest$$]__ | FailKernRequest defines the request of kernel injection
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus"]
+==== KernelChaosStatus 
+
+KernelChaosStatus defines the observed state of KernelChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos[$$KernelChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-lossspec"]
+==== LossSpec 
+
+LossSpec defines detail of a loss action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`loss`* __string__ | 
+| *`correlation`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor"]
+==== MemoryStressor 
+
+MemoryStressor defines how to stress memory out
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors[$$Stressors$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`Stressor`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor[$$Stressor$$]__ | 
+| *`size`* __string__ | Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.
+| *`options`* __string array__ | extend stress-ng options
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec"]
+==== MistakeSpec 
+
+MistakeSpec represents one type of mistake
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec[$$IOChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`filling`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-fillingtype[$$FillingType$$]__ | Filling determines what is filled in the miskate data.
+| *`maxOccurrences`* __integer__ | There will be [1, MaxOccurrences] segments of wrong data.
+| *`maxLength`* __integer__ | Max length of each wrong data segment in bytes
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos"]
+==== NetworkChaos 
+
+NetworkChaos is the Schema for the networkchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `NetworkChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]__ | Spec defines the behavior of a pod chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus[$$NetworkChaosStatus$$]__ | Most recently observed status of the chaos experiment about pods
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosaction"]
+==== NetworkChaosAction (string) 
+
+NetworkChaosAction represents the chaos action about network.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec"]
+==== NetworkChaosSpec 
+
+NetworkChaosSpec defines the desired state of NetworkChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos[$$NetworkChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`PodSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]__ | 
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosaction[$$NetworkChaosAction$$]__ | Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay
+| *`device`* __string__ | Device represents the network device to be affected.
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+| *`TcParameter`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]__ | TcParameter represents the traffic control definition
+| *`direction`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-direction[$$Direction$$]__ | Direction represents the direction, this applies on netem and network partition action
+| *`target`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]__ | Target represents network target, this applies on netem and network partition action
+| *`targetDevice`* __string__ | TargetDevice represents the network device to be affected in target scope.
+| *`externalTargets`* __string array__ | ExternalTargets represents network targets outside k8s
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus"]
+==== NetworkChaosStatus 
+
+NetworkChaosStatus defines the observed state of NetworkChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos[$$NetworkChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+| *`instances`* __object (keys:string, values:integer)__ | Instances always specifies podnetworkchaos generation or empty
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec"]
+==== NetworkCommonSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec[$$NetworkCorruptSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec[$$NetworkDelaySpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec[$$NetworkDuplicateSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec[$$NetworkLossSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`correlation`* __string__ | 
+| *`device`* __string__ | 
+| *`source-port`* __string__ | 
+| *`egress-port`* __string__ | 
+| *`ip-address`* __string__ | 
+| *`ip-protocol`* __string__ | 
+| *`hostname`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec"]
+==== NetworkCorruptSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`NetworkCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec[$$NetworkCommonSpec$$]__ | 
+| *`percent`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdnsspec"]
+==== NetworkDNSSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`dns-server`* __string__ | 
+| *`dns-ip`* __string__ | 
+| *`dns-domain-name`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec"]
+==== NetworkDelaySpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`NetworkCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec[$$NetworkCommonSpec$$]__ | 
+| *`jitter`* __string__ | 
+| *`latency`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec"]
+==== NetworkDuplicateSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`NetworkCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec[$$NetworkCommonSpec$$]__ | 
+| *`percent`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec"]
+==== NetworkLossSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`NetworkCommonSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec[$$NetworkCommonSpec$$]__ | 
+| *`percent`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkpartitionspec"]
+==== NetworkPartitionSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`device`* __string__ | 
+| *`hostname`* __string__ | 
+| *`ip-address`* __string__ | 
+| *`direction`* __string__ | 
+| *`ip-protocol`* __string__ | 
+| *`accept-tcp-flags`* __string__ | only the packet which match the tcp flag can be accepted, others will be dropped. only set when the IPProtocol is tcp, used for partition.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parameterrules"]
+==== ParameterRules 
+
+ParameterRules defines the parameter validation rules
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-actionparameterrules[$$ActionParameterRules$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`Name`* __string__ | Name represents the name of parameter
+| *`ParameterType`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parametertype[$$ParameterType$$]__ | ParameterType represents the parameter type
+| *`Required`* __boolean__ | Required defines whether it is a required parameter
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parametertype"]
+==== ParameterType (string) 
+
+ParameterType defines the parameter type
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parameterrules[$$ParameterRules$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-phase"]
+==== Phase (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record[$$Record$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos"]
+==== PhysicalMachineChaos 
+
+PhysicalMachineChaos is the Schema for the physical machine chaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `PhysicalMachineChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec[$$PhysicalMachineChaosSpec$$]__ | Spec defines the behavior of a physical machine chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus[$$PhysicalMachineChaosStatus$$]__ | Most recently observed status of the chaos experiment
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec"]
+==== PhysicalMachineChaosSpec 
+
+PhysicalMachineChaosSpec defines the desired state of PhysicalMachineChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos[$$PhysicalMachineChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`action`* __PhysicalMachineChaosAction__ | 
+| *`PhysicalMachineSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachineselector[$$PhysicalMachineSelector$$]__ | 
+| *`ExpInfo`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]__ | ExpInfo string `json:"expInfo"`
+| *`duration`* __string__ | Duration represents the duration of the chaos action Duration represents the duration of the chaos action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus"]
+==== PhysicalMachineChaosStatus 
+
+PhysicalMachineChaosStatus defines the observed state of PhysicalMachineChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos[$$PhysicalMachineChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachineselector"]
+==== PhysicalMachineSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec[$$PhysicalMachineChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`address`* __string array__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos"]
+==== PodChaos 
+
+PodChaos is the control script`s spec.
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `PodChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec[$$PodChaosSpec$$]__ | Spec defines the behavior of a pod chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus[$$PodChaosStatus$$]__ | Most recently observed status of the chaos experiment about pods
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosaction"]
+==== PodChaosAction (string) 
+
+PodChaosAction represents the chaos action about pods.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec[$$PodChaosSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec"]
+==== PodChaosSpec 
+
+PodChaosSpec defines the attributes that a user creates on a chaos experiment about pods.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos[$$PodChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`action`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosaction[$$PodChaosAction$$]__ | Action defines the specific pod chaos action. Supported action: pod-kill / pod-failure / container-kill Default action: pod-kill
+| *`duration`* __string__ | Duration represents the duration of the chaos action. It is required when the action is `PodFailureAction`. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+| *`gracePeriod`* __integer__ | GracePeriod is used in pod-kill action. It represents the duration in seconds before the pod should be deleted. Value must be non-negative integer. The default value is zero that indicates delete immediately.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus"]
+==== PodChaosStatus 
+
+PodChaosStatus represents the current status of the chaos experiment about pods.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos[$$PodChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos"]
+==== PodHttpChaos 
+
+PodHttpChaos is the Schema for the podhttpchaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `PodHttpChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec[$$PodHttpChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosstatus[$$PodHttpChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions"]
+==== PodHttpChaosActions 
+
+PodHttpChaosAction defines possible actions of HttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec[$$HTTPChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule[$$PodHttpChaosBaseRule$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`abort`* __boolean__ | Abort is a rule to abort a http session.
+| *`delay`* __string__ | Delay represents the delay of the target request/response. A duration string is a possibly unsigned sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+| *`replace`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosreplaceactions[$$PodHttpChaosReplaceActions$$]__ | Replace is a rule to replace some contents in target.
+| *`patch`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions[$$PodHttpChaosPatchActions$$]__ | Patch is a rule to patch some contents in target.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule"]
+==== PodHttpChaosBaseRule 
+
+PodHttpChaosBaseRule defines the injection rule without source and port.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule[$$PodHttpChaosRule$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`target`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget[$$PodHttpChaosTarget$$]__ | Target is the object to be selected and injected, <Request|Response>.
+| *`selector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosselector[$$PodHttpChaosSelector$$]__ | Selector contains the rules to select target.
+| *`actions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions[$$PodHttpChaosActions$$]__ | Actions contains rules to inject target.
+|===
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions"]
+==== PodHttpChaosPatchActions 
+
+PodHttpChaosPatchActions defines possible patch-actions of HttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions[$$PodHttpChaosActions$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`body`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchbodyaction[$$PodHttpChaosPatchBodyAction$$]__ | Body is a rule to patch message body of target.
+| *`queries`* __string array array__ | Queries is a rule to append uri queries of target(Request only). For example: `[["foo", "bar"], ["foo", "unknown"]]`.
+| *`headers`* __string array array__ | Headers is a rule to append http headers of target. For example: `[["Set-Cookie", "<one cookie>"], ["Set-Cookie", "<another cookie>"]]`.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchbodyaction"]
+==== PodHttpChaosPatchBodyAction 
+
+PodHttpChaosPatchBodyAction defines patch body action of HttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions[$$PodHttpChaosPatchActions$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __string__ | Type represents the patch type, only support `JSON` as [merge patch json](https://tools.ietf.org/html/rfc7396) currently.
+| *`value`* __string__ | Value is the patch contents.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosreplaceactions"]
+==== PodHttpChaosReplaceActions 
+
+PodHttpChaosReplaceActions defines possible replace-actions of HttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions[$$PodHttpChaosActions$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`path`* __string__ | Path is rule to to replace uri path in http request.
+| *`method`* __string__ | Method is a rule to replace http method in request.
+| *`code`* __integer__ | Code is a rule to replace http status code in response.
+| *`body`* __integer array__ | Body is a rule to replace http message body in target.
+| *`queries`* __object (keys:string, values:string)__ | Queries is a rule to replace uri queries in http request. For example, with value `{ "foo": "unknown" }`, the `/?foo=bar` will be altered to `/?foo=unknown`,
+| *`headers`* __object (keys:string, values:string)__ | Headers is a rule to replace http headers of target. The key-value pairs represent header name and header value pairs.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule"]
+==== PodHttpChaosRule 
+
+PodHttpChaosRule defines the injection rule for http.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec[$$PodHttpChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`PodHttpChaosBaseRule`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule[$$PodHttpChaosBaseRule$$]__ | 
+| *`source`* __string__ | Source represents the source of current rules
+| *`port`* __integer__ | Port represents the target port to be proxy of.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosselector"]
+==== PodHttpChaosSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule[$$PodHttpChaosBaseRule$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`port`* __integer__ | Port is a rule to select server listening on specific port.
+| *`path`* __string__ | Path is a rule to select target by uri path in http request.
+| *`method`* __string__ | Method is a rule to select target by http method in request.
+| *`code`* __integer__ | Code is a rule to select target by http status code in response.
+| *`request_headers`* __object (keys:string, values:string)__ | RequestHeaders is a rule to select target by http headers in request. The key-value pairs represent header name and header value pairs.
+| *`response_headers`* __object (keys:string, values:string)__ | ResponseHeaders is a rule to select target by http headers in response. The key-value pairs represent header name and header value pairs.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec"]
+==== PodHttpChaosSpec 
+
+PodHttpChaosSpec defines the desired state of PodHttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos[$$PodHttpChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`rules`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule[$$PodHttpChaosRule$$] array__ | Rules are a list of injection rule for http request.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosstatus"]
+==== PodHttpChaosStatus 
+
+PodHttpChaosStatus defines the actual state of PodHttpChaos.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos[$$PodHttpChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`pid`* __integer__ | Pid represents a running tproxy process id.
+| *`startTime`* __integer__ | StartTime represents the start time of a tproxy process.
+| *`failedMessage`* __string__ | 
+| *`observedGeneration`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget"]
+==== PodHttpChaosTarget (string) 
+
+PodHttpChaosTarget represents the type of an HttpChaos Action
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec[$$HTTPChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule[$$PodHttpChaosBaseRule$$]
+****
+
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos"]
+==== PodIOChaos 
+
+PodIOChaos is the Schema for the podiochaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `PodIOChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec[$$PodIOChaosSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosstatus[$$PodIOChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec"]
+==== PodIOChaosSpec 
+
+PodIOChaosSpec defines the desired state of IOChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos[$$PodIOChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`volumeMountPath`* __string__ | VolumeMountPath represents the target mount path It must be a root of mount path now. TODO: search the mount parent of any path automatically. TODO: support multiple different volume mount path in one pod
+| *`container`* __string__ | TODO: support multiple different container to inject in one pod
+| *`actions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction[$$IOChaosAction$$] array__ | Actions are a list of IOChaos actions
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosstatus"]
+==== PodIOChaosStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos[$$PodIOChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`pid`* __integer__ | Pid represents a running toda process id
+| *`startTime`* __integer__ | StartTime represents the start time of a toda process
+| *`failedMessage`* __string__ | 
+| *`observedGeneration`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos"]
+==== PodNetworkChaos 
+
+PodNetworkChaos is the Schema for the PodNetworkChaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `PodNetworkChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec[$$PodNetworkChaosSpec$$]__ | Spec defines the behavior of a pod chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosstatus[$$PodNetworkChaosStatus$$]__ | Most recently observed status of the chaos experiment about pods
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec"]
+==== PodNetworkChaosSpec 
+
+PodNetworkChaosSpec defines the desired state of PodNetworkChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos[$$PodNetworkChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ipsets`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset[$$RawIPSet$$] array__ | The ipset on the pod
+| *`iptables`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables[$$RawIptables$$] array__ | The iptables rules on the pod
+| *`tcs`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol[$$RawTrafficControl$$] array__ | The tc rules on the pod
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosstatus"]
+==== PodNetworkChaosStatus 
+
+PodNetworkChaosStatus defines the observed state of PodNetworkChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos[$$PodNetworkChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`failedMessage`* __string__ | 
+| *`observedGeneration`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector"]
+==== PodSelector 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec[$$HTTPChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec[$$KernelChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`selector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec[$$PodSelectorSpec$$]__ | Selector is used to select pods that are used to inject chaos action.
+| *`mode`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-selectormode[$$SelectorMode$$]__ | Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent
+| *`value`* __string__ | Value is required when the mode is set to `FixedMode` / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`, provide an integer of pods to do chaos action. If `FixedPercentMode`, provide a number from 0-100 to specify the percent of pods the server can do chaos action. IF `RandomMaxPercentMode`,  provide a number from 0-100 to specify the max percent of pods to do chaos action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec"]
+==== PodSelectorSpec 
+
+PodSelectorSpec defines the some selectors to select objects. If the all selectors are empty, all objects will be used in chaos experiment.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`GenericSelectorSpec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-genericselectorspec[$$GenericSelectorSpec$$]__ | 
+| *`nodes`* __string array__ | Nodes is a set of node name and objects must belong to these nodes.
+| *`pods`* __object (keys:string, values:string array)__ | Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.
+| *`nodeSelectors`* __object (keys:string, values:string)__ | Map of string keys and values that can be used to select nodes. Selector which must match a node's labels, and objects must belong to these selected nodes.
+| *`podPhaseSelectors`* __string array__ | PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-processspec"]
+==== ProcessSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`process`* __string__ | 
+| *`signal`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset"]
+==== RawIPSet 
+
+RawIPSet represents an ipset on specific pod
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec[$$PodNetworkChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | The name of ipset
+| *`cidrs`* __string array__ | The contents of ipset
+| *`RawRuleSource`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource[$$RawRuleSource$$]__ | The name and namespace of the source network chaos
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables"]
+==== RawIptables 
+
+RawIptables represents the iptables rules on specific pod
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec[$$PodNetworkChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | The name of iptables chain
+| *`ipsets`* __string array__ | The name of related ipset
+| *`direction`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaindirection[$$ChainDirection$$]__ | The block direction of this iptables rule
+| *`device`* __string__ | Device represents the network device to be affected.
+| *`RawRuleSource`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource[$$RawRuleSource$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource"]
+==== RawRuleSource 
+
+RawRuleSource represents the name and namespace of the source network chaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset[$$RawIPSet$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables[$$RawIptables$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`source`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol"]
+==== RawTrafficControl 
+
+RawTrafficControl represents the traffic control chaos on specific pod
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec[$$PodNetworkChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tctype[$$TcType$$]__ | The type of traffic control
+| *`TcParameter`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter[$$TcParameter$$]__ | 
+| *`ipset`* __string__ | The name of target ipset
+| *`source`* __string__ | The name and namespace of the source network chaos
+| *`device`* __string__ | Device represents the network device to be affected.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record"]
+==== Record 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus[$$ExperimentStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`id`* __string__ | 
+| *`selectorKey`* __string__ | 
+| *`phase`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-phase[$$Phase$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-reorderspec"]
+==== ReorderSpec 
+
+ReorderSpec defines details of packet reorder.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec[$$DelaySpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`reorder`* __string__ | 
+| *`correlation`* __string__ | 
+| *`gap`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule"]
+==== Schedule 
+
+Schedule is the cronly schedule object
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `Schedule`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec[$$ScheduleSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulestatus[$$ScheduleStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem"]
+==== ScheduleItem 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec[$$ScheduleSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`EmbedChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]__ | 
+| *`workflow`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec[$$WorkflowSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec"]
+==== ScheduleSpec 
+
+ScheduleSpec is the specification of a schedule object
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule[$$Schedule$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`schedule`* __string__ | 
+| *`startingDeadlineSeconds`* __integer__ | 
+| *`concurrencyPolicy`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy[$$ConcurrencyPolicy$$]__ | 
+| *`historyLimit`* __integer__ | 
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype[$$ScheduleTemplateType$$]__ | TODO: use a custom type, as `TemplateType` contains other possible values
+| *`ScheduleItem`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem[$$ScheduleItem$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulestatus"]
+==== ScheduleStatus 
+
+ScheduleStatus is the status of a schedule object
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule[$$Schedule$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`active`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core[$$ObjectReference$$] array__ | 
+| *`time`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype"]
+==== ScheduleTemplateType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec[$$ChaosOnlyScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec[$$ScheduleSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-selectormode"]
+==== SelectorMode (string) 
+
+SelectorMode represents the mode to run chaos action.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector[$$PodSelector$$]
+****
+
+
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresscpuspec"]
+==== StressCPUSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`load`* __integer__ | 
+| *`workers`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos"]
+==== StressChaos 
+
+StressChaos is the Schema for the stresschaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `StressChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec[$$StressChaosSpec$$]__ | Spec defines the behavior of a time chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus[$$StressChaosStatus$$]__ | Most recently observed status of the time chaos experiment
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec"]
+==== StressChaosSpec 
+
+StressChaosSpec defines the desired state of StressChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos[$$StressChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`stressors`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors[$$Stressors$$]__ | Stressors defines plenty of stressors supported to stress system components out. You can use one or more of them to make up various kinds of stresses. At least one of the stressors should be specified.
+| *`stressngStressors`* __string__ | StressngStressors defines plenty of stressors just like `Stressors` except that it's an experimental feature and more powerful. You can define stressors in `stress-ng` (see also `man stress-ng`) dialect, however not all of the supported stressors are well tested. It maybe retired in later releases. You should always use `Stressors` to define the stressors and use this only when you want more stressors unsupported by `Stressors`. When both `StressngStressors` and `Stressors` are defined, `StressngStressors` wins.
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus"]
+==== StressChaosStatus 
+
+StressChaosStatus defines the observed state of StressChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos[$$StressChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+| *`instances`* __object (keys:string, values:xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressinstance[$$StressInstance$$])__ | Instances always specifies stressing instances
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressinstance"]
+==== StressInstance 
+
+StressInstance is an instance generates stresses
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus[$$StressChaosStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`uid`* __string__ | UID is the instance identifier
+| *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | StartTime specifies when the instance starts
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressmemoryspec"]
+==== StressMemorySpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo[$$ExpInfo$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`size`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor"]
+==== Stressor 
+
+Stressor defines common configurations of a stressor
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor[$$CPUStressor$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor[$$MemoryStressor$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`workers`* __integer__ | Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors"]
+==== Stressors 
+
+Stressors defines plenty of stressors supported to stress system components out. You can use one or more of them to make up various kinds of stresses
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec[$$StressChaosSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`memory`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor[$$MemoryStressor$$]__ | MemoryStressor stresses virtual memory out
+| *`cpu`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor[$$CPUStressor$$]__ | CPUStressor stresses CPU out
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task"]
+==== Task 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`container`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core[$$Container$$]__ | Container is the main container image to run in the pod
+| *`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core[$$Volume$$] array__ | Volumes is a list of volumes that can be mounted by containers in a template.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter"]
+==== TcParameter 
+
+TcParameter represents the parameters for a traffic control chaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec[$$NetworkChaosSpec$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol[$$RawTrafficControl$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`delay`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec[$$DelaySpec$$]__ | Delay represents the detail about delay action
+| *`loss`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-lossspec[$$LossSpec$$]__ | Loss represents the detail about loss action
+| *`duplicate`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-duplicatespec[$$DuplicateSpec$$]__ | DuplicateSpec represents the detail about loss action
+| *`corrupt`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-corruptspec[$$CorruptSpec$$]__ | Corrupt represents the detail about corrupt action
+| *`bandwidth`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-bandwidthspec[$$BandwidthSpec$$]__ | Bandwidth represents the detail about bandwidth control action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tctype"]
+==== TcType (string) 
+
+TcType the type of traffic control
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol[$$RawTrafficControl$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template"]
+==== Template 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec[$$WorkflowSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | 
+| *`templateType`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype[$$TemplateType$$]__ | 
+| *`deadline`* __string__ | 
+| *`task`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task[$$Task$$]__ | Task describes the behavior of the custom task. Only used when Type is TypeTask.
+| *`children`* __string array__ | Children describes the children steps of serial or parallel node. Only used when Type is TypeSerial or TypeParallel.
+| *`conditionalBranches`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch[$$ConditionalBranch$$] array__ | ConditionalBranches describes the conditional branches of custom tasks. Only used when Type is TypeTask.
+| *`EmbedChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]__ | EmbedChaos describe the chaos to be injected with chaos nodes. Only used when Type is Type<Something>Chaos.
+| *`schedule`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec[$$ChaosOnlyScheduleSpec$$]__ | Schedule describe the Schedule(describing scheduled chaos) to be injected with chaos nodes. Only used when Type is TypeSchedule.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype"]
+==== TemplateType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos"]
+==== TimeChaos 
+
+TimeChaos is the Schema for the timechaos API
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `TimeChaos`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec[$$TimeChaosSpec$$]__ | Spec defines the behavior of a time chaos experiment
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus[$$TimeChaosStatus$$]__ | Most recently observed status of the time chaos experiment
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec"]
+==== TimeChaosSpec 
+
+TimeChaosSpec defines the desired state of TimeChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos[$$TimeChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ContainerSelector`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector[$$ContainerSelector$$]__ | 
+| *`timeOffset`* __string__ | TimeOffset defines the delta time of injected program. It's a possibly signed sequence of decimal numbers, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+| *`clockIds`* __string array__ | ClockIds defines all affected clock id All available options are ["CLOCK_REALTIME","CLOCK_MONOTONIC","CLOCK_PROCESS_CPUTIME_ID","CLOCK_THREAD_CPUTIME_ID", "CLOCK_MONOTONIC_RAW","CLOCK_REALTIME_COARSE","CLOCK_MONOTONIC_COARSE","CLOCK_BOOTTIME","CLOCK_REALTIME_ALARM", "CLOCK_BOOTTIME_ALARM"] Default value is ["CLOCK_REALTIME"]
+| *`duration`* __string__ | Duration represents the duration of the chaos action
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus"]
+==== TimeChaosStatus 
+
+TimeChaosStatus defines the observed state of TimeChaos
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos[$$TimeChaos$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ChaosStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus[$$ChaosStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec"]
+==== Timespec 
+
+Timespec represents a time
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec[$$AttrOverrideSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`sec`* __integer__ | 
+| *`nsec`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow"]
+==== Workflow 
+
+
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `Workflow`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec[$$WorkflowSpec$$]__ | Spec defines the behavior of a workflow
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus[$$WorkflowStatus$$]__ | Most recently observed status of the workflow
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition"]
+==== WorkflowCondition 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus[$$WorkflowStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowconditiontype[$$WorkflowConditionType$$]__ | 
+| *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core[$$ConditionStatus$$]__ | 
+| *`reason`* __string__ | 
+| *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowconditiontype"]
+==== WorkflowConditionType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition[$$WorkflowCondition$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode"]
+==== WorkflowNode 
+
+
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `chaos-mesh.org/v1alpha1`
+| *`kind`* __string__ | `WorkflowNode`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec[$$WorkflowNodeSpec$$]__ | Spec defines the behavior of a node of workflow
+| *`status`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus[$$WorkflowNodeStatus$$]__ | Most recently observed status of the workflow node
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition"]
+==== WorkflowNodeCondition 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus[$$WorkflowNodeStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodeconditiontype[$$WorkflowNodeConditionType$$]__ | 
+| *`status`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core[$$ConditionStatus$$]__ | 
+| *`reason`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodeconditiontype"]
+==== WorkflowNodeConditionType (string) 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition[$$WorkflowNodeCondition$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec"]
+==== WorkflowNodeSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode[$$WorkflowNode$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`templateName`* __string__ | 
+| *`workflowName`* __string__ | 
+| *`type`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype[$$TemplateType$$]__ | 
+| *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+| *`deadline`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+| *`task`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task[$$Task$$]__ | 
+| *`children`* __string array__ | 
+| *`conditionalBranches`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch[$$ConditionalBranch$$]__ | 
+| *`EmbedChaos`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos[$$EmbedChaos$$]__ | 
+| *`schedule`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec[$$ScheduleSpec$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus"]
+==== WorkflowNodeStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode[$$WorkflowNode$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`chaosResource`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typedlocalobjectreference-v1-core[$$TypedLocalObjectReference$$]__ | ChaosResource refs to the real chaos CR object.
+| *`conditionalBranchesStatus`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus[$$ConditionalBranchesStatus$$]__ | ConditionalBranchesStatus records the evaluation result of each ConditionalBranch
+| *`activeChildren`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | ActiveChildren means the created children node
+| *`finishedChildren`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | Children is necessary for representing the order when replicated child template references by parent template.
+| *`conditions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition[$$WorkflowNodeCondition$$] array__ | Represents the latest available observations of a workflow node's current state.
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec"]
+==== WorkflowSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem[$$ScheduleItem$$]
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow[$$Workflow$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`entry`* __string__ | 
+| *`templates`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template[$$Template$$] array__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus"]
+==== WorkflowStatus 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow[$$Workflow$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`entryNode`* __string__ | 
+| *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+| *`endTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta[$$Time$$]__ | 
+| *`conditions`* __xref:{anchor_prefix}-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition[$$WorkflowCondition$$] array__ | Represents the latest available observations of a workflow's current state.
+|===
+
+

--- a/api-reference/index.asciidoc
+++ b/api-reference/index.asciidoc
@@ -1,5 +1,6 @@
 // Generated documentation. Please do not edit.
 :anchor_prefix: k8s-api
+:nofooter:
 
 [id="{p}-api-reference"]
 == API Reference

--- a/api-reference/index.html
+++ b/api-reference/index.html
@@ -8551,10 +8551,5 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 </div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2021-11-11 09:48:08 UTC
-</div>
-</div>
 </body>
 </html>

--- a/api-reference/index.html
+++ b/api-reference/index.html
@@ -1,0 +1,8560 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
+<title>API Reference</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Uncomment @import statement below to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock pre.nowrap,.literalblock pre.nowrap pre,.listingblock pre.nowrap,.listingblock pre.nowrap pre{white-space:pre;word-wrap:normal}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #dddddf}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin:0 0 1.25em;padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd){background:#f8f8f7}
+table.stripes-none tr,table.stripes-odd tr:nth-of-type(even){background:none}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article toc2 toc-left">
+<div id="header">
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#{p}-api-reference">API Reference</a>
+<ul class="sectlevel2">
+<li><a href="#k8s-api-chaos-mesh-org-v1alpha1">chaos-mesh.org/v1alpha1</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="{p}-api-reference">API Reference</h2>
+<div class="sectionbody">
+<div class="ulist">
+<div class="title">Packages</div>
+<ul>
+<li>
+<p><a href="#k8s-api-chaos-mesh-org-v1alpha1">chaos-mesh.org/v1alpha1</a></p>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-chaos-mesh-org-v1alpha1">chaos-mesh.org/v1alpha1</h3>
+<div class="paragraph">
+<p>Package v1alpha1 contains API Schema definitions for the chaosmesh v1alpha1 API group</p>
+</div>
+<div class="ulist">
+<div class="title">Resource Types</div>
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos">AWSChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos">DNSChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos">GCPChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos">HTTPChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos">IOChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos">JVMChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos">KernelChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos">NetworkChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos">PhysicalMachineChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos">PodChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos">PodHttpChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos">PodIOChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos">PodNetworkChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule">Schedule</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos">StressChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos">TimeChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow">Workflow</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode">WorkflowNode</a></p>
+</li>
+</ul>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos">AWSChaos</h4>
+<div class="paragraph">
+<p>AWSChaos is the Schema for the awschaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>AWSChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec">AWSChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus">AWSChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosaction">AWSChaosAction (string)</h4>
+<div class="paragraph">
+<p>AWSChaosAction represents the chaos action about aws.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec">AWSChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec">AWSChaosSpec</h4>
+<div class="paragraph">
+<p>AWSChaosSpec is the content of the specification for an AWSChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos">AWSChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosaction">AWSChaosAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific aws chaos action. Supported action: ec2-stop / ec2-restart / detach-volume Default action: ec2-stop</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretName</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>SecretName defines the name of kubernetes secret.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>AWSSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awsselector">AWSSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus">AWSChaosStatus</h4>
+<div class="paragraph">
+<p>AWSChaosStatus represents the status of an AWSChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaos">AWSChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awsselector">AWSSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec">AWSChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>endpoint</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Endpoint indicates the endpoint of the aws server. Just used it in test now.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>awsRegion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>AWSRegion defines the region of aws.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ec2Instance</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Ec2Instance indicates the ID of the ec2 instance.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>volumeID</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>EbsVolume indicates the ID of the EBS volume. Needed in detach-volume.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>deviceName</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>DeviceName indicates the name of the device. Needed in detach-volume.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec">AttrOverrideSpec</h4>
+<div class="paragraph">
+<p>AttrOverrideSpec represents an override of attribution</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ino</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>size</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>blocks</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>atime</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec">Timespec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>mtime</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec">Timespec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ctime</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec">Timespec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filetype">FileType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>perm</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>nlink</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>uid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>gid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>rdev</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-bandwidthspec">BandwidthSpec</h4>
+<div class="paragraph">
+<p>BandwidthSpec defines detail of bandwidth limit.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>rate</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Rate is the speed knob. Allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>limit</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Limit is the number of bytes that can be queued waiting for tokens to become available.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>buffer</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Buffer is the maximum amount of bytes that tokens can be available for instantaneously.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>peakrate</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Peakrate is the maximum depletion rate of the bucket. The peakrate does not need to be set, it is only necessary if perfect millisecond timescale shaping is required.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>minburst</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Minburst specifies the size of the peakrate bucket. For perfect accuracy, should be set to the MTU of the interface.  If a peakrate is needed, but some burstiness is acceptable, this size can be raised. A 3000 byte minburst allows around 3mbit/s of peakrate, given 1000 byte packets.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor">CPUStressor</h4>
+<div class="paragraph">
+<p>CPUStressor defines how to stress CPU out</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors">Stressors</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>Stressor</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor">Stressor</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>load</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100 is full loading.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>options</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>extend stress-ng options</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaindirection">ChainDirection (string)</h4>
+<div class="paragraph">
+<p>ChainDirection represents the direction of chain</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables">RawIptables</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition">ChaosCondition</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosconditiontype">ChaosConditionType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">ConditionStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>reason</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosconditiontype">ChaosConditionType (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition">ChaosCondition</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec">ChaosOnlyScheduleSpec</h4>
+<div class="paragraph">
+<p>ChaosOnlyScheduleSpec is very similar with ScheduleSpec, but it could not schedule Workflow because we could not resolve nested CRD now</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>schedule</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startingDeadlineSeconds</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>concurrencyPolicy</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy">ConcurrencyPolicy</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>historyLimit</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype">ScheduleTemplateType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TODO: use a custom type, as <code>TemplateType</code> contains other possible values</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>EmbedChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosstatus">AWSChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus">DNSChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus">GCPChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus">HTTPChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus">IOChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus">JVMChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus">KernelChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus">NetworkChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus">PhysicalMachineChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus">PodChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus">StressChaosStatus</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus">TimeChaosStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaoscondition">ChaosCondition</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Conditions represents the current global condition of the chaos</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>experiment</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus">ExperimentStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Experiment records the last experiment state.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-clockspec">ClockSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>pid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>time-offset</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>clock-ids-slice</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy">ConcurrencyPolicy (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec">ChaosOnlyScheduleSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch">ConditionalBranch</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Target is the name of other template, if expression is evaluated as true, this template will be spawned.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>expression</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Expression is the expression for this conditional branch, expected type of result is boolean. If expression is empty, this branch will always be selected/the template will be spawned.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchstatus">ConditionalBranchStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus">ConditionalBranchesStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>evaluationResult</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">ConditionStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus">ConditionalBranchesStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus">WorkflowNodeStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>branches</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchstatus">ConditionalBranchStatus</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>context</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec">DNSChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec">PodChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec">StressChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec">TimeChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>containerNames</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ContainerNames indicates list of the name of affected container. If not set, all containers will be injected</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-corruptspec">CorruptSpec</h4>
+<div class="paragraph">
+<p>CorruptSpec defines detail of a corrupt action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>corrupt</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos">DNSChaos</h4>
+<div class="paragraph">
+<p>DNSChaos is the Schema for the networkchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>DNSChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec">DNSChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a pod chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus">DNSChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the chaos experiment about pods</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec">DNSChaosSpec</h4>
+<div class="paragraph">
+<p>DNSChaosSpec defines the desired state of DNSChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos">DNSChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em>DNSChaosAction</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific DNS chaos action. Supported action: error, random Default action: error</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>patterns</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Choose which domain names to take effect, support the placeholder ? and wildcard <strong>, or the Specified domain name. Note:      1. The wildcard * must be at the end of the string. For example, chaos-</strong>.org is invalid.      2. if the patterns is empty, will take effect on all the domain names. For example: 		The value is ["google.com", "github.*", "chaos-mes?.org"], 		will take effect on "google.com", "github.com" and "chaos-mesh.org"</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosstatus">DNSChaosStatus</h4>
+<div class="paragraph">
+<p>DNSChaosStatus defines the observed state of DNSChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaos">DNSChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec">DelaySpec</h4>
+<div class="paragraph">
+<p>DelaySpec defines detail of a delay action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>latency</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jitter</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>reorder</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-reorderspec">ReorderSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-desiredphase">DesiredPhase (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus">ExperimentStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-direction">Direction (string)</h4>
+<div class="paragraph">
+<p>Direction represents traffic direction from source to target, it could be netem, delay, loss, duplicate, corrupt or partition, check comments below for detail direction flow.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec">DiskFileSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec">DiskFillSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec">DiskPayloadSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>size</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec">DiskFillSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>DiskFileSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec">DiskFileSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>fill_by_fallocate</code></strong> <em>boolean</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec">DiskPayloadSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>DiskFileSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfilespec">DiskFileSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>payload_process_num</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-duplicatespec">DuplicateSpec</h4>
+<div class="paragraph">
+<p>DuplicateSpec defines detail of a duplicate action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duplicate</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec">ChaosOnlyScheduleSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem">ScheduleItem</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>awsChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-awschaosspec">AWSChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>dnsChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-dnschaosspec">DNSChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>gcpChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec">GCPChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>httpChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ioChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvmChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kernelChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec">KernelChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>networkChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>physicalmachineChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec">PhysicalMachineChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>podChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec">PodChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>stressChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec">StressChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>timeChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec">TimeChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec">PhysicalMachineChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>uid</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the experiment ID</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the subAction, generate automatically</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>stress-cpu</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresscpuspec">StressCPUSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>stress-mem</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressmemoryspec">StressMemorySpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>disk-read-payload</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec">DiskPayloadSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>disk-write-payload</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskpayloadspec">DiskPayloadSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>disk-fill</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-diskfillspec">DiskFillSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-corrupt</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec">NetworkCorruptSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-duplicate</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec">NetworkDuplicateSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-loss</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec">NetworkLossSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-delay</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec">NetworkDelaySpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-partition</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkpartitionspec">NetworkPartitionSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>network-dns</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdnsspec">NetworkDNSSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>process</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-processspec">ProcessSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-exception</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec">JVMExceptionSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-gc</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec">JVMGCSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-latency</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec">JVMLatencySpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-return</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec">JVMReturnSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-stress</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec">JVMStressSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jvm-rule-data</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec">JVMRuleDataSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>clock</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-clockspec">ClockSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus">ExperimentStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>desiredPhase</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-desiredphase">DesiredPhase</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>containerRecords</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record">Record</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Records are used to track the running status</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest">FailKernRequest</h4>
+<div class="paragraph">
+<p>FailKernRequest defines the injection conditions</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec">KernelChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>failtype</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>FailType indicates what to fail, can be set to '0' / '1' / '2' If <code>0</code>, indicates slab to fail (should_failslab) If <code>1</code>, indicates alloc_page to fail (should_fail_alloc_page) If <code>2</code>, indicates bio to fail (should_fail_bio) You can read:   1. <a href="https://www.kernel.org/doc/html/latest/fault-injection/fault-injection.html" class="bare">https://www.kernel.org/doc/html/latest/fault-injection/fault-injection.html</a>   2. <a href="http://github.com/iovisor/bcc/blob/master/tools/inject_example.txt" class="bare">http://github.com/iovisor/bcc/blob/master/tools/inject_example.txt</a> to learn more</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>headers</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Headers indicates the appropriate kernel headers you need. Eg: "linux/mmzone.h", "linux/blkdev.h" and so on</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>callchain</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-frame">Frame</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Callchain indicate a special call chain, such as:     ext4_mount       &#8594; mount_subtree          &#8594; &#8230;&#8203;             &#8594; should_failslab With an optional set of predicates and an optional set of parameters, which used with predicates. You can read call chan and predicate examples from <a href="https://github.com/chaos-mesh/bpfki/tree/develop/examples" class="bare">https://github.com/chaos-mesh/bpfki/tree/develop/examples</a> to learn more. If no special call chain, just keep Callchain empty, which means it will fail at any call chain with slab alloc (eg: kmalloc).</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>probability</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Probability indicates the fails with probability. If you want 1%, please set this field with 1.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>times</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Times indicates the max times of fails.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filetype">FileType (string)</h4>
+<div class="paragraph">
+<p>FileType represents type of a file</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec">AttrOverrideSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-fillingtype">FillingType (string)</h4>
+<div class="paragraph">
+<p>FillingType represents type of data is filled for incorrectness</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec">MistakeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter">Filter</h4>
+<div class="paragraph">
+<p>Filter represents a filter of IOChaos action, which will define the scope of an IOChaosAction</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Path represents a glob of injecting path</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>methods</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod">IoMethod</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Methods represents the method that the action will inject in</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>percent</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Percent represents the percent probability of injecting this action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-frame">Frame</h4>
+<div class="paragraph">
+<p>Frame defines the function signature and predicate in function&#8217;s body</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest">FailKernRequest</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>funcname</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Funcname can be find from kernel source or <code>/proc/kallsyms</code>, such as <code>ext4_mount</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>parameters</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Parameters is used with predicate, for example, if you want to inject slab error in <code>d_alloc_parallel(struct dentry *parent, const struct qstr *name)</code> with a special name <code>bananas</code>, you need to set it to <code>struct dentry *parent, const struct qstr *name</code> otherwise omit it.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>predicate</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Predicate will access the arguments of this Frame, example with Parameters&#8217;s, you can set it to <code>STRNCMP(name&#8594;name, "bananas", 8)</code> to make inject only with it, or omit it to inject for all d_alloc_parallel call chain.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos">GCPChaos</h4>
+<div class="paragraph">
+<p>GCPChaos is the Schema for the gcpchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>GCPChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec">GCPChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus">GCPChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosaction">GCPChaosAction (string)</h4>
+<div class="paragraph">
+<p>GCPChaosAction represents the chaos action about gcp.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec">GCPChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec">GCPChaosSpec</h4>
+<div class="paragraph">
+<p>GCPChaosSpec is the content of the specification for a GCPChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos">GCPChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosaction">GCPChaosAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific gcp chaos action. Supported action: node-stop / node-reset / disk-loss Default action: node-stop</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretName</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>SecretName defines the name of kubernetes secret. It is used for GCP credentials.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>GCPSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpselector">GCPSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosstatus">GCPChaosStatus</h4>
+<div class="paragraph">
+<p>GCPChaosStatus represents the status of a GCPChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaos">GCPChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>attachedDiskStrings</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The attached disk info strings. Needed in disk-loss.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpselector">GCPSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-gcpchaosspec">GCPChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>project</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Project defines the name of gcp project.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>zone</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Zone defines the zone of gcp project.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>instance</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Instance defines the name of the instance</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>deviceNames</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The device name of disks to detach. Needed in disk-loss.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-genericselectorspec">GenericSelectorSpec</h4>
+<div class="paragraph">
+<p>GenericSelectorSpec defines some selectors to select objects.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec">PodSelectorSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>namespaces</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Namespaces is a set of namespace to which objects belong.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>fieldSelectors</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Map of string keys and values that can be used to select objects. A selector based on fields.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>labelSelectors</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Map of string keys and values that can be used to select objects. A selector based on labels.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>expressionSelectors</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselectorrequirement-v1-meta">LabelSelectorRequirement</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>a slice of label selector expressions that can be used to select objects. A list of selectors based on set-based label expressions.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>annotationSelectors</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Map of string keys and values that can be used to select objects. A selector based on annotations.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos">HTTPChaos</h4>
+<div class="paragraph">
+<p>HTTPChaos is the Schema for the HTTPchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>HTTPChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus">HTTPChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos">HTTPChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget">PodHttpChaosTarget</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Target is the object to be selected and injected.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodHttpChaosActions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions">PodHttpChaosActions</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>port</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Port represents the target port to be proxy of.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Path is a rule to select target by uri path in http request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>method</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Method is a rule to select target by http method in request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>code</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Code is a rule to select target by http status code in response.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>request_headers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>RequestHeaders is a rule to select target by http headers in request. The key-value pairs represent header name and header value pairs.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>response_headers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ResponseHeaders is a rule to select target by http headers in response. The key-value pairs represent header name and header value pairs.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosstatus">HTTPChaosStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaos">HTTPChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>instances</code></strong> <em>object (keys:string, values:integer)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Instances always specifies podhttpchaos generation or empty</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos">IOChaos</h4>
+<div class="paragraph">
+<p>IOChaos is the Schema for the iochaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>IOChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus">IOChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</h4>
+<div class="paragraph">
+<p>IOChaosAction defines an possible action of IOChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec">PodIOChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype">IOChaosType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>Filter</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter">Filter</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>faults</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iofault">IoFault</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Faults represents the fault to inject</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>latency</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Latency represents the latency to inject</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>AttrOverrideSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec">AttrOverrideSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>AttrOverride represents the attribution to override</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>mistake</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec">MistakeSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>MistakeSpec represents the mistake to inject</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>source</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Source represents the source of current rules</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</h4>
+<div class="paragraph">
+<p>IOChaosSpec defines the desired state of IOChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos">IOChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype">IOChaosType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific pod chaos action. Supported action: latency / fault / attrOverride / mistake</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>delay</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Delay defines the value of I/O chaos action delay. A delay string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>errno</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Errno defines the error code that returned by I/O action. refer to: <a href="https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html" class="bare">https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html</a></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>attr</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec">AttrOverrideSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Attr defines the overrided attribution</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>mistake</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec">MistakeSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Mistake defines what types of incorrectness are injected to IO operations</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Path defines the path of files for injecting I/O chaos action.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>methods</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod">IoMethod</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Methods defines the I/O methods for injecting I/O chaos action. default: all I/O methods.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>percent</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Percent defines the percentage of injection errors and provides a number from 0-100. default: 100.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>volumePath</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>VolumePath represents the mount path of injected volume</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action. It is required when the action is <code>PodFailureAction</code>. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosstatus">IOChaosStatus</h4>
+<div class="paragraph">
+<p>IOChaosStatus defines the observed state of IOChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaos">IOChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>instances</code></strong> <em>object (keys:string, values:integer)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Instances always specifies podiochaos generation or empty</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaostype">IOChaosType (string)</h4>
+<div class="paragraph">
+<p>IOChaosType represents the type of an IOChaos Action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iofault">IoFault</h4>
+<div class="paragraph">
+<p>IoFault represents the fault to inject and their weight</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>errno</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>weight</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iomethod">IoMethod (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-filter">Filter</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos">JVMChaos</h4>
+<div class="paragraph">
+<p>JVMChaos is the Schema for the jvmchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>JVMChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus">JVMChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosaction">JVMChaosAction (string)</h4>
+<div class="paragraph">
+<p>JVMChaosAction represents the chaos action about jvm</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</h4>
+<div class="paragraph">
+<p>JVMChaosSpec defines the desired state of JVMChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos">JVMChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosaction">JVMChaosAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific jvm chaos action. Supported action: delay;return;script;cfl;oom;ccf;tce;cpf;tde;tpf</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMParameter</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmparameter">JVMParameter</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>JVMParameter represents the detail about jvm chaos action definition</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaostarget">JVMChaosTarget</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Target defines the specific jvm chaos target. Supported target: servlet;psql;jvm;jedis;http;dubbo;rocketmq;tars;mysql;druid;redisson;rabbitmq;mongodb</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosstatus">JVMChaosStatus</h4>
+<div class="paragraph">
+<p>JVMChaosStatus defines the observed state of JVMChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaos">JVMChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaostarget">JVMChaosTarget (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec">JVMClassMethodSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec">JVMExceptionSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec">JVMLatencySpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec">JVMReturnSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>class</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Java class</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>method</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the method in Java class</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec">JVMExceptionSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec">JVMGCSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec">JVMLatencySpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec">JVMReturnSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec">JVMRuleDataSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec">JVMStressSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>port</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the port of agent server</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>pid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the pid of Java process which need to attach</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmexceptionspec">JVMExceptionSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMClassMethodSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec">JVMClassMethodSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>exception</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the exception which needs to throw dor action <code>exception</code></p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmgcspec">JVMGCSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmlatencyspec">JVMLatencySpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMClassMethodSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec">JVMClassMethodSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>latency</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the latency duration for action 'latency', unit ms</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmparameter">JVMParameter</h4>
+<div class="paragraph">
+<p>JVMParameter represents the detail about jvm chaos action definition</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmchaosspec">JVMChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>flags</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Flags represents the flags of action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>matchers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Matchers represents the matching rules for the target</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmreturnspec">JVMReturnSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMClassMethodSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmclassmethodspec">JVMClassMethodSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>value</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the return value for action 'return'</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmruledataspec">JVMRuleDataSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>rule-data</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>RuleData used to save the rule file&#8217;s data, will use it when recover</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmstressspec">JVMStressSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>JVMCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-jvmcommonspec">JVMCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>cpu-count</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the CPU core number need to use, only set it when action is stress</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>mem-type</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>the memory type need to locate, only set it when action is stress, the value can be 'stack' or 'heap'</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos">KernelChaos</h4>
+<div class="paragraph">
+<p>KernelChaos is the Schema for the kernelchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>KernelChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec">KernelChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a kernel chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus">KernelChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the kernel chaos experiment</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec">KernelChaosSpec</h4>
+<div class="paragraph">
+<p>KernelChaosSpec defines the desired state of KernelChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos">KernelChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>failKernRequest</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-failkernrequest">FailKernRequest</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>FailKernRequest defines the request of kernel injection</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosstatus">KernelChaosStatus</h4>
+<div class="paragraph">
+<p>KernelChaosStatus defines the observed state of KernelChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaos">KernelChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-lossspec">LossSpec</h4>
+<div class="paragraph">
+<p>LossSpec defines detail of a loss action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>loss</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor">MemoryStressor</h4>
+<div class="paragraph">
+<p>MemoryStressor defines how to stress memory out</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors">Stressors</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>Stressor</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor">Stressor</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>size</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Size specifies N bytes consumed per vm worker, default is the total available memory. One can specify the size as % of total available memory or in units of B, KB/KiB, MB/MiB, GB/GiB, TB/TiB.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>options</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>extend stress-ng options</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-mistakespec">MistakeSpec</h4>
+<div class="paragraph">
+<p>MistakeSpec represents one type of mistake</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosspec">IOChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>filling</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-fillingtype">FillingType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Filling determines what is filled in the miskate data.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>maxOccurrences</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>There will be [1, MaxOccurrences] segments of wrong data.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>maxLength</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Max length of each wrong data segment in bytes</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos">NetworkChaos</h4>
+<div class="paragraph">
+<p>NetworkChaos is the Schema for the networkchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>NetworkChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a pod chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus">NetworkChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the chaos experiment about pods</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosaction">NetworkChaosAction (string)</h4>
+<div class="paragraph">
+<p>NetworkChaosAction represents the chaos action about network.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</h4>
+<div class="paragraph">
+<p>NetworkChaosSpec defines the desired state of NetworkChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos">NetworkChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosaction">NetworkChaosAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>device</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Device represents the network device to be affected.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TcParameter</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TcParameter represents the traffic control definition</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>direction</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-direction">Direction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Direction represents the direction, this applies on netem and network partition action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Target represents network target, this applies on netem and network partition action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>targetDevice</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TargetDevice represents the network device to be affected in target scope.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>externalTargets</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ExternalTargets represents network targets outside k8s</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosstatus">NetworkChaosStatus</h4>
+<div class="paragraph">
+<p>NetworkChaosStatus defines the observed state of NetworkChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaos">NetworkChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>instances</code></strong> <em>object (keys:string, values:integer)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Instances always specifies podnetworkchaos generation or empty</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec">NetworkCommonSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec">NetworkCorruptSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec">NetworkDelaySpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec">NetworkDuplicateSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec">NetworkLossSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>device</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>source-port</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>egress-port</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ip-address</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ip-protocol</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>hostname</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcorruptspec">NetworkCorruptSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>NetworkCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec">NetworkCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>percent</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdnsspec">NetworkDNSSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>dns-server</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>dns-ip</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>dns-domain-name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkdelayspec">NetworkDelaySpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>NetworkCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec">NetworkCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>jitter</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>latency</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkduplicatespec">NetworkDuplicateSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>NetworkCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec">NetworkCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>percent</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networklossspec">NetworkLossSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>NetworkCommonSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkcommonspec">NetworkCommonSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>percent</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkpartitionspec">NetworkPartitionSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>device</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>hostname</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ip-address</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>direction</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ip-protocol</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>accept-tcp-flags</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>only the packet which match the tcp flag can be accepted, others will be dropped. only set when the IPProtocol is tcp, used for partition.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parameterrules">ParameterRules</h4>
+<div class="paragraph">
+<p>ParameterRules defines the parameter validation rules</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-actionparameterrules">ActionParameterRules</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>Name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Name represents the name of parameter</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ParameterType</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parametertype">ParameterType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ParameterType represents the parameter type</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>Required</code></strong> <em>boolean</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Required defines whether it is a required parameter</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parametertype">ParameterType (string)</h4>
+<div class="paragraph">
+<p>ParameterType defines the parameter type</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-parameterrules">ParameterRules</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-phase">Phase (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record">Record</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos">PhysicalMachineChaos</h4>
+<div class="paragraph">
+<p>PhysicalMachineChaos is the Schema for the physical machine chaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>PhysicalMachineChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec">PhysicalMachineChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a physical machine chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus">PhysicalMachineChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the chaos experiment</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec">PhysicalMachineChaosSpec</h4>
+<div class="paragraph">
+<p>PhysicalMachineChaosSpec defines the desired state of PhysicalMachineChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos">PhysicalMachineChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em>PhysicalMachineChaosAction</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PhysicalMachineSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachineselector">PhysicalMachineSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ExpInfo</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ExpInfo string <code>json:"expInfo"</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosstatus">PhysicalMachineChaosStatus</h4>
+<div class="paragraph">
+<p>PhysicalMachineChaosStatus defines the observed state of PhysicalMachineChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaos">PhysicalMachineChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachineselector">PhysicalMachineSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-physicalmachinechaosspec">PhysicalMachineChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>address</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos">PodChaos</h4>
+<div class="paragraph">
+<p>PodChaos is the control script`s spec.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>PodChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec">PodChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a pod chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus">PodChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the chaos experiment about pods</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosaction">PodChaosAction (string)</h4>
+<div class="paragraph">
+<p>PodChaosAction represents the chaos action about pods.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec">PodChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosspec">PodChaosSpec</h4>
+<div class="paragraph">
+<p>PodChaosSpec defines the attributes that a user creates on a chaos experiment about pods.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos">PodChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>action</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosaction">PodChaosAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Action defines the specific pod chaos action. Supported action: pod-kill / pod-failure / container-kill Default action: pod-kill</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action. It is required when the action is <code>PodFailureAction</code>. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>gracePeriod</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>GracePeriod is used in pod-kill action. It represents the duration in seconds before the pod should be deleted. Value must be non-negative integer. The default value is zero that indicates delete immediately.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaosstatus">PodChaosStatus</h4>
+<div class="paragraph">
+<p>PodChaosStatus represents the current status of the chaos experiment about pods.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podchaos">PodChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos">PodHttpChaos</h4>
+<div class="paragraph">
+<p>PodHttpChaos is the Schema for the podhttpchaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>PodHttpChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec">PodHttpChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosstatus">PodHttpChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions">PodHttpChaosActions</h4>
+<div class="paragraph">
+<p>PodHttpChaosAction defines possible actions of HttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule">PodHttpChaosBaseRule</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>abort</code></strong> <em>boolean</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Abort is a rule to abort a http session.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>delay</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Delay represents the delay of the target request/response. A duration string is a possibly unsigned sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>replace</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosreplaceactions">PodHttpChaosReplaceActions</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Replace is a rule to replace some contents in target.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>patch</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions">PodHttpChaosPatchActions</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Patch is a rule to patch some contents in target.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule">PodHttpChaosBaseRule</h4>
+<div class="paragraph">
+<p>PodHttpChaosBaseRule defines the injection rule without source and port.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule">PodHttpChaosRule</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>target</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget">PodHttpChaosTarget</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Target is the object to be selected and injected, &lt;Request</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Response&gt;.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>selector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosselector">PodHttpChaosSelector</a></em></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Selector contains the rules to select target.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>actions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions">PodHttpChaosActions</a></em></p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions">PodHttpChaosPatchActions</h4>
+<div class="paragraph">
+<p>PodHttpChaosPatchActions defines possible patch-actions of HttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions">PodHttpChaosActions</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>body</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchbodyaction">PodHttpChaosPatchBodyAction</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Body is a rule to patch message body of target.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>queries</code></strong> <em>string array array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Queries is a rule to append uri queries of target(Request only). For example: <code>[["foo", "bar"], ["foo", "unknown"]]</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>headers</code></strong> <em>string array array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Headers is a rule to append http headers of target. For example: <code>[["Set-Cookie", "&lt;one cookie&gt;"], ["Set-Cookie", "&lt;another cookie&gt;"]]</code>.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchbodyaction">PodHttpChaosPatchBodyAction</h4>
+<div class="paragraph">
+<p>PodHttpChaosPatchBodyAction defines patch body action of HttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaospatchactions">PodHttpChaosPatchActions</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Type represents the patch type, only support <code>JSON</code> as [merge patch json](<a href="https://tools.ietf.org/html/rfc7396" class="bare">https://tools.ietf.org/html/rfc7396</a>) currently.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>value</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Value is the patch contents.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosreplaceactions">PodHttpChaosReplaceActions</h4>
+<div class="paragraph">
+<p>PodHttpChaosReplaceActions defines possible replace-actions of HttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosactions">PodHttpChaosActions</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Path is rule to to replace uri path in http request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>method</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Method is a rule to replace http method in request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>code</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Code is a rule to replace http status code in response.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>body</code></strong> <em>integer array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Body is a rule to replace http message body in target.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>queries</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Queries is a rule to replace uri queries in http request. For example, with value <code>{ "foo": "unknown" }</code>, the <code>/?foo=bar</code> will be altered to <code>/?foo=unknown</code>,</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>headers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Headers is a rule to replace http headers of target. The key-value pairs represent header name and header value pairs.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule">PodHttpChaosRule</h4>
+<div class="paragraph">
+<p>PodHttpChaosRule defines the injection rule for http.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec">PodHttpChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>PodHttpChaosBaseRule</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule">PodHttpChaosBaseRule</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>source</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Source represents the source of current rules</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>port</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Port represents the target port to be proxy of.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosselector">PodHttpChaosSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule">PodHttpChaosBaseRule</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>port</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Port is a rule to select server listening on specific port.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>path</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Path is a rule to select target by uri path in http request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>method</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Method is a rule to select target by http method in request.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>code</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Code is a rule to select target by http status code in response.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>request_headers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>RequestHeaders is a rule to select target by http headers in request. The key-value pairs represent header name and header value pairs.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>response_headers</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ResponseHeaders is a rule to select target by http headers in response. The key-value pairs represent header name and header value pairs.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosspec">PodHttpChaosSpec</h4>
+<div class="paragraph">
+<p>PodHttpChaosSpec defines the desired state of PodHttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos">PodHttpChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>rules</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosrule">PodHttpChaosRule</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Rules are a list of injection rule for http request.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosstatus">PodHttpChaosStatus</h4>
+<div class="paragraph">
+<p>PodHttpChaosStatus defines the actual state of PodHttpChaos.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaos">PodHttpChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>pid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Pid represents a running tproxy process id.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>StartTime represents the start time of a tproxy process.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>failedMessage</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>observedGeneration</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaostarget">PodHttpChaosTarget (string)</h4>
+<div class="paragraph">
+<p>PodHttpChaosTarget represents the type of an HttpChaos Action</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podhttpchaosbaserule">PodHttpChaosBaseRule</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos">PodIOChaos</h4>
+<div class="paragraph">
+<p>PodIOChaos is the Schema for the podiochaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>PodIOChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec">PodIOChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosstatus">PodIOChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosspec">PodIOChaosSpec</h4>
+<div class="paragraph">
+<p>PodIOChaosSpec defines the desired state of IOChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos">PodIOChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>volumeMountPath</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>VolumeMountPath represents the target mount path It must be a root of mount path now. TODO: search the mount parent of any path automatically. TODO: support multiple different volume mount path in one pod</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>container</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TODO: support multiple different container to inject in one pod</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>actions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-iochaosaction">IOChaosAction</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Actions are a list of IOChaos actions</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaosstatus">PodIOChaosStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podiochaos">PodIOChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>pid</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Pid represents a running toda process id</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>StartTime represents the start time of a toda process</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>failedMessage</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>observedGeneration</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos">PodNetworkChaos</h4>
+<div class="paragraph">
+<p>PodNetworkChaos is the Schema for the PodNetworkChaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>PodNetworkChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec">PodNetworkChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a pod chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosstatus">PodNetworkChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the chaos experiment about pods</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec">PodNetworkChaosSpec</h4>
+<div class="paragraph">
+<p>PodNetworkChaosSpec defines the desired state of PodNetworkChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos">PodNetworkChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ipsets</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset">RawIPSet</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The ipset on the pod</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>iptables</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables">RawIptables</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The iptables rules on the pod</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>tcs</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol">RawTrafficControl</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The tc rules on the pod</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosstatus">PodNetworkChaosStatus</h4>
+<div class="paragraph">
+<p>PodNetworkChaosStatus defines the observed state of PodNetworkChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaos">PodNetworkChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>failedMessage</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>observedGeneration</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-httpchaosspec">HTTPChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-kernelchaosspec">KernelChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>selector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec">PodSelectorSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Selector is used to select pods that are used to inject chaos action.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>mode</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-selectormode">SelectorMode</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>value</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Value is required when the mode is set to <code>FixedMode</code> / <code>FixedPercentMode</code> / <code>RandomMaxPercentMode</code>. If <code>FixedMode</code>, provide an integer of pods to do chaos action. If <code>FixedPercentMode</code>, provide a number from 0-100 to specify the percent of pods the server can do chaos action. IF <code>RandomMaxPercentMode</code>,  provide a number from 0-100 to specify the max percent of pods to do chaos action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselectorspec">PodSelectorSpec</h4>
+<div class="paragraph">
+<p>PodSelectorSpec defines the some selectors to select objects. If the all selectors are empty, all objects will be used in chaos experiment.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>GenericSelectorSpec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-genericselectorspec">GenericSelectorSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>nodes</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Nodes is a set of node name and objects must belong to these nodes.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>pods</code></strong> <em>object (keys:string, values:string array)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>nodeSelectors</code></strong> <em>object (keys:string, values:string)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Map of string keys and values that can be used to select nodes. Selector which must match a node&#8217;s labels, and objects must belong to these selected nodes.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>podPhaseSelectors</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>PodPhaseSelectors is a set of condition of a pod at the current time. supported value: Pending / Running / Succeeded / Failed / Unknown</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-processspec">ProcessSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>process</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>signal</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset">RawIPSet</h4>
+<div class="paragraph">
+<p>RawIPSet represents an ipset on specific pod</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec">PodNetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name of ipset</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>cidrs</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The contents of ipset</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>RawRuleSource</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource">RawRuleSource</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name and namespace of the source network chaos</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables">RawIptables</h4>
+<div class="paragraph">
+<p>RawIptables represents the iptables rules on specific pod</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec">PodNetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name of iptables chain</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ipsets</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name of related ipset</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>direction</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaindirection">ChainDirection</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The block direction of this iptables rule</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>device</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Device represents the network device to be affected.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>RawRuleSource</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource">RawRuleSource</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawrulesource">RawRuleSource</h4>
+<div class="paragraph">
+<p>RawRuleSource represents the name and namespace of the source network chaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawipset">RawIPSet</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawiptables">RawIptables</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>source</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol">RawTrafficControl</h4>
+<div class="paragraph">
+<p>RawTrafficControl represents the traffic control chaos on specific pod</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podnetworkchaosspec">PodNetworkChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tctype">TcType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The type of traffic control</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TcParameter</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ipset</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name of target ipset</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>source</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>The name and namespace of the source network chaos</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>device</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Device represents the network device to be affected.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-record">Record</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-experimentstatus">ExperimentStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>id</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>selectorKey</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>phase</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-phase">Phase</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-reorderspec">ReorderSpec</h4>
+<div class="paragraph">
+<p>ReorderSpec defines details of packet reorder.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec">DelaySpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>reorder</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>correlation</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>gap</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule">Schedule</h4>
+<div class="paragraph">
+<p>Schedule is the cronly schedule object</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>Schedule</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulestatus">ScheduleStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem">ScheduleItem</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>EmbedChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>workflow</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec">WorkflowSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</h4>
+<div class="paragraph">
+<p>ScheduleSpec is the specification of a schedule object</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule">Schedule</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>schedule</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startingDeadlineSeconds</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>concurrencyPolicy</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-concurrencypolicy">ConcurrencyPolicy</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>historyLimit</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype">ScheduleTemplateType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TODO: use a custom type, as <code>TemplateType</code> contains other possible values</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ScheduleItem</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem">ScheduleItem</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulestatus">ScheduleStatus</h4>
+<div class="paragraph">
+<p>ScheduleStatus is the status of a schedule object</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedule">Schedule</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>active</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">ObjectReference</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>time</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduletemplatetype">ScheduleTemplateType (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec">ChaosOnlyScheduleSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-selectormode">SelectorMode (string)</h4>
+<div class="paragraph">
+<p>SelectorMode represents the mode to run chaos action.</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-podselector">PodSelector</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresscpuspec">StressCPUSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>load</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>workers</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos">StressChaos</h4>
+<div class="paragraph">
+<p>StressChaos is the Schema for the stresschaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>StressChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec">StressChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a time chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus">StressChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the time chaos experiment</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec">StressChaosSpec</h4>
+<div class="paragraph">
+<p>StressChaosSpec defines the desired state of StressChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos">StressChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>stressors</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors">Stressors</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Stressors defines plenty of stressors supported to stress system components out. You can use one or more of them to make up various kinds of stresses. At least one of the stressors should be specified.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>stressngStressors</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>StressngStressors defines plenty of stressors just like <code>Stressors</code> except that it&#8217;s an experimental feature and more powerful. You can define stressors in <code>stress-ng</code> (see also <code>man stress-ng</code>) dialect, however not all of the supported stressors are well tested. It maybe retired in later releases. You should always use <code>Stressors</code> to define the stressors and use this only when you want more stressors unsupported by <code>Stressors</code>. When both <code>StressngStressors</code> and <code>Stressors</code> are defined, <code>StressngStressors</code> wins.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus">StressChaosStatus</h4>
+<div class="paragraph">
+<p>StressChaosStatus defines the observed state of StressChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaos">StressChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>instances</code></strong> <em>object (keys:string, values:<a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressinstance">StressInstance</a>)</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Instances always specifies stressing instances</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressinstance">StressInstance</h4>
+<div class="paragraph">
+<p>StressInstance is an instance generates stresses</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosstatus">StressChaosStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>uid</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>UID is the instance identifier</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>StartTime specifies when the instance starts</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressmemoryspec">StressMemorySpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-expinfo">ExpInfo</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>size</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressor">Stressor</h4>
+<div class="paragraph">
+<p>Stressor defines common configurations of a stressor</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor">CPUStressor</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor">MemoryStressor</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>workers</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Workers specifies N workers to apply the stressor. Maximum 8192 workers can run by stress-ng</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stressors">Stressors</h4>
+<div class="paragraph">
+<p>Stressors defines plenty of stressors supported to stress system components out. You can use one or more of them to make up various kinds of stresses</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-stresschaosspec">StressChaosSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>memory</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-memorystressor">MemoryStressor</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>MemoryStressor stresses virtual memory out</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>cpu</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-cpustressor">CPUStressor</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>CPUStressor stresses CPU out</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task">Task</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>container</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core">Container</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Container is the main container image to run in the pod</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>volumes</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core">Volume</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Volumes is a list of volumes that can be mounted by containers in a template.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tcparameter">TcParameter</h4>
+<div class="paragraph">
+<p>TcParameter represents the parameters for a traffic control chaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-networkchaosspec">NetworkChaosSpec</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol">RawTrafficControl</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>delay</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-delayspec">DelaySpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Delay represents the detail about delay action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>loss</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-lossspec">LossSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Loss represents the detail about loss action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duplicate</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-duplicatespec">DuplicateSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>DuplicateSpec represents the detail about loss action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>corrupt</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-corruptspec">CorruptSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Corrupt represents the detail about corrupt action</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>bandwidth</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-bandwidthspec">BandwidthSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Bandwidth represents the detail about bandwidth control action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-tctype">TcType (string)</h4>
+<div class="paragraph">
+<p>TcType the type of traffic control</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-rawtrafficcontrol">RawTrafficControl</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec">WorkflowSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>templateType</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype">TemplateType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>deadline</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>task</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task">Task</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Task describes the behavior of the custom task. Only used when Type is TypeTask.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>children</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Children describes the children steps of serial or parallel node. Only used when Type is TypeSerial or TypeParallel.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditionalBranches</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch">ConditionalBranch</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ConditionalBranches describes the conditional branches of custom tasks. Only used when Type is TypeTask.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>EmbedChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>EmbedChaos describe the chaos to be injected with chaos nodes. Only used when Type is Type&lt;Something&gt;Chaos.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>schedule</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosonlyschedulespec">ChaosOnlyScheduleSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Schedule describe the Schedule(describing scheduled chaos) to be injected with chaos nodes. Only used when Type is TypeSchedule.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype">TemplateType (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos">TimeChaos</h4>
+<div class="paragraph">
+<p>TimeChaos is the Schema for the timechaos API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>TimeChaos</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec">TimeChaosSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a time chaos experiment</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus">TimeChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the time chaos experiment</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosspec">TimeChaosSpec</h4>
+<div class="paragraph">
+<p>TimeChaosSpec defines the desired state of TimeChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos">TimeChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ContainerSelector</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-containerselector">ContainerSelector</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>timeOffset</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>TimeOffset defines the delta time of injected program. It&#8217;s a possibly signed sequence of decimal numbers, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>clockIds</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ClockIds defines all affected clock id All available options are ["CLOCK_REALTIME","CLOCK_MONOTONIC","CLOCK_PROCESS_CPUTIME_ID","CLOCK_THREAD_CPUTIME_ID", "CLOCK_MONOTONIC_RAW","CLOCK_REALTIME_COARSE","CLOCK_MONOTONIC_COARSE","CLOCK_BOOTTIME","CLOCK_REALTIME_ALARM", "CLOCK_BOOTTIME_ALARM"] Default value is ["CLOCK_REALTIME"]</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>duration</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Duration represents the duration of the chaos action</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaosstatus">TimeChaosStatus</h4>
+<div class="paragraph">
+<p>TimeChaosStatus defines the observed state of TimeChaos</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timechaos">TimeChaos</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>ChaosStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-chaosstatus">ChaosStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-timespec">Timespec</h4>
+<div class="paragraph">
+<p>Timespec represents a time</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-attroverridespec">AttrOverrideSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>sec</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>nsec</code></strong> <em>integer</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow">Workflow</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>Workflow</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec">WorkflowSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a workflow</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus">WorkflowStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the workflow</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition">WorkflowCondition</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus">WorkflowStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowconditiontype">WorkflowConditionType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">ConditionStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>reason</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowconditiontype">WorkflowConditionType (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition">WorkflowCondition</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode">WorkflowNode</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>chaos-mesh.org/v1alpha1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>WorkflowNode</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>TypeMeta</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typemeta-v1-meta">TypeMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Spec defines the behavior of a node of workflow</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus">WorkflowNodeStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Most recently observed status of the workflow node</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition">WorkflowNodeCondition</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus">WorkflowNodeStatus</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodeconditiontype">WorkflowNodeConditionType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>status</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">ConditionStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>reason</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodeconditiontype">WorkflowNodeConditionType (string)</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition">WorkflowNodeCondition</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodespec">WorkflowNodeSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode">WorkflowNode</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>templateName</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>workflowName</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>type</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-templatetype">TemplateType</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>deadline</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>task</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-task">Task</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>children</code></strong> <em>string array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditionalBranches</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranch">ConditionalBranch</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>EmbedChaos</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-embedchaos">EmbedChaos</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>schedule</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-schedulespec">ScheduleSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodestatus">WorkflowNodeStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownode">WorkflowNode</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>chaosResource</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#typedlocalobjectreference-v1-core">TypedLocalObjectReference</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ChaosResource refs to the real chaos CR object.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditionalBranchesStatus</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-conditionalbranchesstatus">ConditionalBranchesStatus</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ConditionalBranchesStatus records the evaluation result of each ConditionalBranch</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>activeChildren</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">LocalObjectReference</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ActiveChildren means the created children node</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>finishedChildren</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#localobjectreference-v1-core">LocalObjectReference</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Children is necessary for representing the order when replicated child template references by parent template.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflownodecondition">WorkflowNodeCondition</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Represents the latest available observations of a workflow node&#8217;s current state.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowspec">WorkflowSpec</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-scheduleitem">ScheduleItem</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow">Workflow</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>entry</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>templates</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-template">Template</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowstatus">WorkflowStatus</h4>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflow">Workflow</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>entryNode</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>startTime</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>endTime</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">Time</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>conditions</code></strong> <em><a href="#k8s-api-github-com-chaos-mesh-chaos-mesh-api-v1alpha1-workflowcondition">WorkflowCondition</a> array</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Represents the latest available observations of a workflow&#8217;s current state.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-11-11 09:48:08 UTC
+</div>
+</div>
+</body>
+</html>

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -19,6 +19,7 @@ RUN go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
 RUN go install github.com/swaggo/swag/cmd/swag@v1.6.7
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 RUN go install github.com/golang/mock/mockgen@v1.5.0
+RUN go install github.com/elastic/crd-ref-docs@v0.0.7
 
 FROM debian:buster-slim
 
@@ -31,7 +32,7 @@ ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
 RUN apt-get update && \ 
-    apt-get install unzip git build-essential curl python -y && \
+    apt-get install unzip git build-essential curl python asciidoctor -y && \
     rm -rf /var/lib/apt/lists/*
 
 # The `TARGET_PLATFORM` would be `amd64` or `arm64`


### PR DESCRIPTION
### What problem does this PR solve?

close #2513

![image](https://user-images.githubusercontent.com/5244316/141278694-618a33d7-5f39-42d1-8369-88dc20524624.png)

Generate an api reference.

It uses the [crd-ref-docs](https://github.com/elastic/crd-ref-docs) and `asciidoctor` to generate the web page. The kubernetes api reference generator seems cannot be used in CRD.

I haven't decided whether it's a good place to write the api reference html page.