### PR TITLE
Makefile: remove buildx and load argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ else
 endif
 
 else
-	DOCKER_BUILDKIT=1 docker buildx build --load -t $$($(4)_IMAGE)  ${DOCKER_BUILD_ARGS} $(2)
+	DOCKER_BUILDKIT=1 docker build -t $$($(4)_IMAGE) ${DOCKER_BUILD_ARGS} $(2)
 endif
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,13 @@ else
 endif
 
 else
+
+ifneq ($(TARGET_PLATFORM),)
+	DOCKER_BUILDKIT=1 docker buildx build --load -t $$($(4)_IMAGE) ${DOCKER_BUILD_ARGS} $(2)
+else
 	DOCKER_BUILDKIT=1 docker build -t $$($(4)_IMAGE) ${DOCKER_BUILD_ARGS} $(2)
+endif
+
 endif
 
 endif


### PR DESCRIPTION
### What problem does this PR solve?

The nightly build failed because `--load` is not supported.