### PR TITLE
fix: can't load schedule archives

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -110,6 +110,9 @@
     "ts-interface-builder": "^0.2.3",
     "ts-interface-checker": "^0.1.13"
   },
+  "jest": {
+    "resetMocks": false
+  },
   "lint-staged": {
     "*.(j|t)s?(x)": "prettier --write"
   },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,18 +14,17 @@
  * limitations under the License.
  *
  */
+
 import { Provider } from 'react-redux'
 import { BrowserRouter as Router } from 'react-router-dom'
 import ThemeProvider from './ThemeProvider'
 import TopContainer from 'components/TopContainer'
 import store from './store'
 
-const App = () => (
+const App: React.FC = ({ children }) => (
   <Provider store={store}>
     <Router>
-      <ThemeProvider>
-        <TopContainer />
-      </ThemeProvider>
+      <ThemeProvider>{children || <TopContainer />}</ThemeProvider>
     </Router>
   </Provider>
 )

--- a/ui/src/components/NewExperimentNext/LoadFrom/index.test.tsx
+++ b/ui/src/components/NewExperimentNext/LoadFrom/index.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 Chaos Mesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { act, fireEvent, render, screen } from 'test-utils'
+
+import LoadFrom from '.'
+
+const experiments = [
+  {
+    namespace: 'default',
+    name: 'random-pod-failure',
+    kind: 'PodChaos',
+    uid: 'e626701f-beaa-47de-91ce-767b856d8bec',
+    created_at: '2021-11-04T04:17:09Z',
+    status: 'finished',
+  },
+]
+
+const schedules = [
+  {
+    namespace: 'default',
+    name: 'sch-random-pod-failure',
+    kind: 'PodChaos',
+    uid: '63932612-978e-4aa8-81f5-98964ea82f9c',
+    created_at: '2021-11-12T03:44:15Z',
+    status: 'running',
+  },
+]
+
+const archives = [
+  {
+    namespace: 'default',
+    name: 'network-delay-90ms',
+    kind: 'NetworkChaos',
+    uid: '5ccdfb1e-5b12-4d3c-b065-7669552cc0f7',
+    created_at: '2021-11-11T08:11:15Z',
+  },
+]
+
+const scheduleArchives = [
+  {
+    namespace: 'default',
+    name: 'sch-network-delay-90ms',
+    kind: 'Schedule',
+    uid: 'af9daeb3-4cfc-48b6-a547-e1003810b628',
+    created_at: '2021-11-12T04:05:35Z',
+  },
+]
+
+jest.mock('api', () => {
+  return {
+    experiments: {
+      experiments: jest.fn().mockResolvedValue({ data: experiments }),
+      single: jest.fn().mockResolvedValue({ data: { kube_object: { spec: {} } } }),
+    },
+    schedules: {
+      schedules: jest.fn().mockResolvedValue({ data: schedules }),
+      archives: jest.fn().mockResolvedValue({ data: scheduleArchives }),
+    },
+    archives: {
+      archives: jest.fn().mockResolvedValue({ data: archives }),
+    },
+  }
+})
+
+jest.mock('lib/idb', () => {
+  return {
+    getDB: jest.fn().mockResolvedValue({
+      getAll: jest.fn().mockResolvedValue([]),
+    }),
+  }
+})
+
+describe('<LoadFrom />', () => {
+  test('loads and displays experiments and archives', async () => {
+    await act(async () => {
+      render(<LoadFrom />)
+    })
+
+    screen.getByText('random-pod-failure')
+  })
+
+  test('props inSchedule', async () => {
+    await act(async () => {
+      render(<LoadFrom inSchedule />)
+    })
+
+    screen.getByText('sch-random-pod-failure')
+    screen.getByText('sch-network-delay-90ms')
+  })
+
+  test('loads an experiment', async () => {
+    function callback(data: any) {
+      expect(data).not.toBeUndefined()
+    }
+
+    await act(async () => {
+      render(<LoadFrom callback={callback} />)
+    })
+
+    fireEvent.click(screen.getByText('random-pod-failure'))
+  })
+})

--- a/ui/src/components/NewExperimentNext/LoadFrom/index.tsx
+++ b/ui/src/components/NewExperimentNext/LoadFrom/index.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+
 import { Box, Divider, FormControlLabel, Radio, RadioGroup, Typography } from '@material-ui/core'
 import { PreDefinedValue, getDB } from 'lib/idb'
 import { useEffect, useState } from 'react'
@@ -56,24 +57,28 @@ const LoadFrom: React.FC<LoadFromProps> = ({ callback, inSchedule, inWorkflow })
   const [radio, setRadio] = useState('')
 
   useEffect(() => {
-    const fetchExperiments = api.experiments.experiments()
-    const fetchArchives = api.archives.archives()
-    const promises: Promise<any>[] = [fetchExperiments, fetchArchives]
+    const fetchExperiments = api.experiments.experiments
+    const fetchArchives = inSchedule ? api.schedules.archives : api.archives.archives
+    const promises: Promise<any>[] = [fetchExperiments(), fetchArchives()]
 
     if (inSchedule) {
       promises.push(api.schedules.schedules())
     }
 
     const fetchAll = async () => {
-      const data = await Promise.all(promises)
+      try {
+        const data = await Promise.all(promises)
 
-      setData({
-        experiments: data[0].data,
-        archives: data[1].data,
-        schedules: data[2] ? data[2].data : [],
-      })
+        setData({
+          experiments: data[0].data,
+          archives: data[1].data,
+          schedules: data[2] ? data[2].data : [],
+        })
+      } catch (error) {
+        console.error(error)
+      }
 
-      let _predefined = await (await getDB()).getAll('predefined' as never) // never?
+      let _predefined = await (await getDB()).getAll('predefined')
       if (!inSchedule) {
         _predefined = _predefined.filter((d) => d.kind !== 'Schedule')
       }
@@ -106,21 +111,20 @@ const LoadFrom: React.FC<LoadFromProps> = ({ callback, inSchedule, inWorkflow })
     let apiRequest
     switch (type) {
       case 's':
-        apiRequest = api.schedules
+        apiRequest = api.schedules.single
         break
       case 'e':
-        apiRequest = api.experiments
+        apiRequest = api.experiments.single
         break
       case 'a':
-        apiRequest = api.archives
+        apiRequest = inSchedule ? api.schedules.singleArchive : api.archives.single
         break
     }
 
     setRadio(e.target.value)
 
     if (apiRequest) {
-      apiRequest
-        .single(uuid)
+      apiRequest(uuid)
         .then(({ data }) => {
           callback && callback(data.kube_object)
 
@@ -158,7 +162,7 @@ const LoadFrom: React.FC<LoadFromProps> = ({ callback, inSchedule, inWorkflow })
                 </Box>
               ) : (
                 <Typography variant="body2" color="textSecondary">
-                  {T('experiments.notFound')}
+                  {T('schedules.notFound')}
                 </Typography>
               )}
 
@@ -166,28 +170,32 @@ const LoadFrom: React.FC<LoadFromProps> = ({ callback, inSchedule, inWorkflow })
             </>
           )}
 
-          <Typography>{T('experiments.title')}</Typography>
+          {!inSchedule && (
+            <>
+              <Typography>{T('experiments.title')}</Typography>
 
-          {loading ? (
-            <SkeletonN n={3} />
-          ) : data.experiments.length > 0 ? (
-            <Box display="flex" flexWrap="wrap">
-              {data.experiments.map((d) => (
-                <FormControlLabel
-                  key={d.uid}
-                  value={`e+${d.uid}`}
-                  control={<Radio color="primary" />}
-                  label={RadioLabel(d.name, d.uid)}
-                />
-              ))}
-            </Box>
-          ) : (
-            <Typography variant="body2" color="textSecondary">
-              {T('experiments.notFound')}
-            </Typography>
+              {loading ? (
+                <SkeletonN n={3} />
+              ) : data.experiments.length > 0 ? (
+                <Box display="flex" flexWrap="wrap">
+                  {data.experiments.map((d) => (
+                    <FormControlLabel
+                      key={d.uid}
+                      value={`e+${d.uid}`}
+                      control={<Radio color="primary" />}
+                      label={RadioLabel(d.name, d.uid)}
+                    />
+                  ))}
+                </Box>
+              ) : (
+                <Typography variant="body2" color="textSecondary">
+                  {T('experiments.notFound')}
+                </Typography>
+              )}
+
+              <Divider />
+            </>
           )}
-
-          <Divider />
 
           <Typography>{T('archives.title')}</Typography>
 

--- a/ui/src/lib/idb.ts
+++ b/ui/src/lib/idb.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  *
  */
+
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 
 import { ExperimentKind } from 'components/NewExperiment/types'
 
 export interface PreDefinedValue {
   name: string
-  kind: ExperimentKind
+  kind: ExperimentKind | 'Schedule'
   yaml: object
 }
 

--- a/ui/src/test-utils.tsx
+++ b/ui/src/test-utils.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Chaos Mesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { RenderOptions, render } from '@testing-library/react'
+
+import App from './App'
+import { IntlProvider } from 'react-intl'
+import { ReactElement } from 'react'
+import flat from 'flat'
+import messages from 'i18n/messages'
+
+const AllTheProviders: React.FC = ({ children }) => (
+  <App>
+    <IntlProvider messages={flat(messages['en'])} locale="en" defaultLocale="en">
+      {children}
+    </IntlProvider>
+  </App>
+)
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: AllTheProviders, ...options })
+
+export * from '@testing-library/react'
+export { customRender as render }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #2508, #1458.

> Problem Summary:

When creating a new schedule, the schedule archives can't be displayed.

#1458 is a legacy way to perform the components testing, I replace it with [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/).

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

Get the corresponding loadable objects according to the different creation methods.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
