### PR TITLE
client: use updatedClient to fix cache problem

### DIFF
--- a/pkg/router/reconciler.go
+++ b/pkg/router/reconciler.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -118,7 +119,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error)
 }
 
 // NewReconciler creates a new reconciler
-func NewReconciler(name string, object runtime.Object, mgr ctrl.Manager, endpoints []routeEndpoint, clusterScoped bool, targetNamespace string) *Reconciler {
+func NewReconciler(name string, object runtime.Object, c client.Client, mgr ctrl.Manager, endpoints []routeEndpoint, clusterScoped bool, targetNamespace string) *Reconciler {
 	return &Reconciler{
 		Name:            name,
 		Object:          object,
@@ -127,7 +128,7 @@ func NewReconciler(name string, object runtime.Object, mgr ctrl.Manager, endpoin
 		TargetNamespace: targetNamespace,
 
 		Context: ctx.Context{
-			Client:        mgr.GetClient(),
+			Client:        c,
 			Reader:        mgr.GetAPIReader(),
 			EventRecorder: mgr.GetEventRecorderFor(name + "-controller"),
 			Log:           ctrl.Log.WithName("controllers").WithName(name),

--- a/pkg/router/route_table.go
+++ b/pkg/router/route_table.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/router/endpoint"
@@ -69,10 +70,10 @@ func Register(name string, obj runtime.Object, routeFunc func(runtime.Object) bo
 }
 
 // SetupWithManagerAndConfigs setups reconciler with manager and controller configs
-func SetupWithManagerAndConfigs(mgr ctrl.Manager, cfg *config.ChaosControllerConfig) error {
+func SetupWithManagerAndConfigs(c client.Client, mgr ctrl.Manager, cfg *config.ChaosControllerConfig) error {
 	for typ, end := range routeTable {
 		log.Info("setup reconciler with manager", "type", typ, "endpoint", end.Name)
-		reconciler := NewReconciler(end.Name, end.Object, mgr, end.Endpoints, cfg.ClusterScoped, cfg.TargetNamespace)
+		reconciler := NewReconciler(end.Name, end.Object, c, mgr, end.Endpoints, cfg.ClusterScoped, cfg.TargetNamespace)
 		err := reconciler.SetupWithManager(mgr)
 		if err != nil {
 			log.Error(err, "fail to setup reconciler with manager")

--- a/pkg/updatedclient/updated_client.go
+++ b/pkg/updatedclient/updated_client.go
@@ -4,14 +4,12 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package updatedclient
 

--- a/pkg/updatedclient/updated_client.go
+++ b/pkg/updatedclient/updated_client.go
@@ -1,0 +1,185 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package updatedclient
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+
+	lru "github.com/hashicorp/golang-lru"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var _ client.Client = &UpdatedClient{}
+
+type UpdatedClient struct {
+	client client.Client
+	scheme *runtime.Scheme
+
+	cache *lru.Cache
+}
+
+func New(mgr ctrl.Manager, scheme *runtime.Scheme) (*UpdatedClient, error) {
+	// TODO: make this size configurable
+	cache, err := lru.New(100)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdatedClient{
+		client: mgr.GetClient(),
+		scheme: scheme,
+		cache:  cache,
+	}, nil
+}
+
+func (c *UpdatedClient) objectKey(key client.ObjectKey, obj runtime.Object) (string, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return "", err
+	}
+
+	return gvk.String() + "/" + key.String(), nil
+}
+
+func (c *UpdatedClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	err := c.client.Get(ctx, key, obj)
+	if err != nil {
+		return err
+	}
+
+	objectKey, err := c.objectKey(key, obj)
+	if err != nil {
+		return err
+	}
+
+	cachedObject, ok := c.cache.Get(objectKey)
+	if ok {
+		cachedMeta, err := meta.Accessor(cachedObject)
+		if err != nil {
+			return nil
+		}
+
+		objMeta, err := meta.Accessor(obj)
+		if err != nil {
+			return nil
+		}
+
+		cachedResourceVersion, err := strconv.Atoi(cachedMeta.GetResourceVersion())
+		if err != nil {
+			return nil
+		}
+		newResourceVersion, err := strconv.Atoi(objMeta.GetResourceVersion())
+		if err != nil {
+			return nil
+		}
+		if cachedResourceVersion >= newResourceVersion {
+			cachedObject := cachedObject.(runtime.Object).DeepCopyObject()
+
+			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(cachedObject).Elem())
+		}
+	}
+
+	return nil
+}
+
+func (c *UpdatedClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c *UpdatedClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	err := c.client.Update(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+
+	err = c.writeCache(obj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UpdatedClient) writeCache(obj runtime.Object) error {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil
+	}
+
+	objectKey, err := c.objectKey(types.NamespacedName{
+		Namespace: objMeta.GetNamespace(),
+		Name:      objMeta.GetName(),
+	}, obj)
+	if err != nil {
+		return err
+	}
+
+	c.cache.Add(objectKey, obj.DeepCopyObject())
+
+	return nil
+}
+
+func (c *UpdatedClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *UpdatedClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *UpdatedClient) Status() client.StatusWriter {
+	return &UpdatedStatusWriter{
+		statusWriter: c.client.Status(),
+		client:       c,
+	}
+}
+
+type UpdatedStatusWriter struct {
+	statusWriter client.StatusWriter
+	client       *UpdatedClient
+}
+
+func (c *UpdatedStatusWriter) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	err := c.statusWriter.Update(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+
+	err = c.client.writeCache(obj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UpdatedStatusWriter) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.statusWriter.Patch(ctx, obj, patch, opts...)
+}


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

After #2509 , the cache in client breaks the twophase controller:

1. The controller updates the chaos into Running.
2. The controller reconciles the chaos, gets a cache and think it's waiting
3. Step into the finished state, merge the conflict, remove the finalizer and step out.

In this PR, I backported the `UpdatedClient` in `release-2.0` to make the cache at least updated to the latest successfully `Update`d object.