### PR TITLE
auth: add rooturl configuration in gcp authentication

### DIFF
--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -83,6 +83,8 @@ spec:
               value: "{{ .Values.dashboard.gcpClientSecret }}"
             - name: DNS_SERVER_CREATE
               value: "{{ .Values.dnsServer.create }}"
+            - name: ROOT_URL
+              value: "{{ .Values.dashboard.rootUrl }}"
           volumeMounts:
             - name: storage-volume
               mountPath: {{ .Values.dashboard.persistentVolume.mountPath }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -195,6 +195,7 @@ chaosDaemon:
   affinity: {}
 
 dashboard:
+  rootUrl: http://localhost:2333
   create: true
   hostNetwork: false
 

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -10,7 +10,7 @@ ARG UI
 ARG SWAGGER
 
 RUN apt-get update && \ 
-    apt-get install tzdata -y && \
+    apt-get install tzdata ca-certificates -y && \
     rm -rf /var/lib/apt/lists/*
 
 ENV http_proxy=

--- a/install.sh
+++ b/install.sh
@@ -1414,6 +1414,8 @@ spec:
               value: ""
             - name: DNS_SERVER_CREATE
               value: "false"
+            - name: ROOT_URL
+              value: "http://localhost:2333"
           volumeMounts:
             - name: storage-volume
               mountPath: /data

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -46,6 +46,8 @@ type ChaosDashboardConfig struct {
 	GcpClientId     string `envconfig:"GCP_CLIENT_ID" default:"" json:"-"`
 	GcpClientSecret string `envconfig:"GCP_CLIENT_SECRET" default:"" json:"-"`
 
+	RootUrl string `envconfig:"ROOT_URL" default:"http://localhost:2333" json:"root_path"`
+
 	DNSServerCreate bool   `envconfig:"DNS_SERVER_CREATE" default:"false" json:"dns_server_create"`
 	Version         string `json:"version"`
 }

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -1945,6 +1945,10 @@ var doc = `{
                     "type": "integer",
                     "default": 2333
                 },
+                "root_path": {
+                    "type": "string",
+                    "default": "http://localhost:2333"
+                },
                 "security_mode": {
                     "description": "SecurityMode will use the token login by the user if set to true",
                     "type": "boolean",

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -1929,6 +1929,10 @@
                     "type": "integer",
                     "default": 2333
                 },
+                "root_path": {
+                    "type": "string",
+                    "default": "http://localhost:2333"
+                },
                 "security_mode": {
                     "description": "SecurityMode will use the token login by the user if set to true",
                     "type": "boolean",

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -52,6 +52,9 @@ definitions:
       listen_port:
         default: 2333
         type: integer
+      root_path:
+        default: http://localhost:2333
+        type: string
       security_mode:
         default: true
         description: SecurityMode will use the token login by the user if set to true


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Try to get the scheme and host from the request is not realistic. If the dashboard is deployed behind a load balancer, it will have no way to guess the scheme. In this PR, I added a config field, so that the users can set the root url manually. The dashboard will append `/api/auth/gcp/callback` to the path.

BTW, it also installs the `ca-certificates` to the `chaos-dashboard` container, which is required to avoid x509 error.