### PR TITLE
feat(metrics): add archived objects metrics for chaos-dashboard

### DIFF
--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -92,6 +92,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.dashboard.env.LISTEN_PORT }}
+            - name: metric
+              containerPort: {{ .Values.dashboard.env.METRIC_PORT }}
         {{- if .Values.chaosDlv.enable }}
         - name: chaos-mesh-dlv
           image: {{template "chaos-dlv.image" . }}
@@ -166,4 +168,8 @@ spec:
       protocol: TCP
       name: dlv
   {{- end }}
+    - protocol: TCP
+      port: {{ .Values.dashboard.env.METRIC_PORT }}
+      targetPort: {{ .Values.dashboard.env.METRIC_PORT }}
+      name: metric
 {{- end }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -45,7 +45,7 @@ enableCtrlServer: true
 
 images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
-  registry: "localhost:5000"
+  registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
   tag: "latest"
 

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -45,7 +45,7 @@ enableCtrlServer: true
 
 images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
-  registry: "ghcr.io"
+  registry: "localhost:5000"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
   tag: "latest"
 
@@ -276,6 +276,8 @@ dashboard:
   env:
     LISTEN_HOST: "0.0.0.0"
     LISTEN_PORT: 2333
+    METRIC_HOST: "0.0.0.0"
+    METRIC_PORT: 8080
 
     # If you'd like to use a DB other than SQLite (the default), set a driver + DSN here.
     DATABASE_DRIVER: sqlite3

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -277,7 +277,7 @@ dashboard:
     LISTEN_HOST: "0.0.0.0"
     LISTEN_PORT: 2333
     METRIC_HOST: "0.0.0.0"
-    METRIC_PORT: 8080
+    METRIC_PORT: 2334
 
     # If you'd like to use a DB other than SQLite (the default), set a driver + DSN here.
     DATABASE_DRIVER: sqlite3

--- a/install.sh
+++ b/install.sh
@@ -1193,6 +1193,10 @@ spec:
       port: 2333
       targetPort: 2333
       name: http
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: metric
 ---
 # Source: chaos-mesh/templates/controller-manager-service.yaml
 # Copyright 2021 Chaos Mesh Authors.
@@ -1396,6 +1400,10 @@ spec:
               value: "0.0.0.0"
             - name: LISTEN_PORT
               value: "2333"
+            - name: METRIC_HOST
+              value: "0.0.0.0"
+            - name: METRIC_PORT
+              value: "8080"
             - name: TZ
               value: ${timezone}
             - name: CLUSTER_SCOPED
@@ -1423,6 +1431,8 @@ spec:
           ports:
             - name: http
               containerPort: 2333
+            - name: metric
+              containerPort: 8080
       volumes:
       - name: storage-volume
         emptyDir: {}

--- a/install.sh
+++ b/install.sh
@@ -1194,8 +1194,8 @@ spec:
       targetPort: 2333
       name: http
     - protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: 2334
+      targetPort: 2334
       name: metric
 ---
 # Source: chaos-mesh/templates/controller-manager-service.yaml
@@ -1403,7 +1403,7 @@ spec:
             - name: METRIC_HOST
               value: "0.0.0.0"
             - name: METRIC_PORT
-              value: "8080"
+              value: "2334"
             - name: TZ
               value: ${timezone}
             - name: CLUSTER_SCOPED
@@ -1432,7 +1432,7 @@ spec:
             - name: http
               containerPort: 2333
             - name: metric
-              containerPort: 8080
+              containerPort: 2334
       volumes:
       - name: storage-volume
         emptyDir: {}

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -27,7 +27,8 @@ import (
 type ChaosDashboardConfig struct {
 	ListenHost           string            `envconfig:"LISTEN_HOST" default:"0.0.0.0" json:"listen_host"`
 	ListenPort           int               `envconfig:"LISTEN_PORT" default:"2333" json:"listen_port"`
-	MetricAddress        string            `envconfig:"METRIC_ADDRESS" json:"-"`
+	MetricHost           string            `envconfig:"METRIC_HOST" default:"0.0.0.0" json:"-"`
+	MetricPort           int               `envconfig:"METRIC_PORT" default:"8080" json:"-"`
 	EnableLeaderElection bool              `envconfig:"ENABLE_LEADER_ELECTION" json:"-"`
 	Database             *DatabaseConfig   `json:"-"`
 	PersistTTL           *PersistTTLConfig `json:"-"`

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -28,7 +28,7 @@ type ChaosDashboardConfig struct {
 	ListenHost           string            `envconfig:"LISTEN_HOST" default:"0.0.0.0" json:"listen_host"`
 	ListenPort           int               `envconfig:"LISTEN_PORT" default:"2333" json:"listen_port"`
 	MetricHost           string            `envconfig:"METRIC_HOST" default:"0.0.0.0" json:"-"`
-	MetricPort           int               `envconfig:"METRIC_PORT" default:"8080" json:"-"`
+	MetricPort           int               `envconfig:"METRIC_PORT" default:"2334" json:"-"`
 	EnableLeaderElection bool              `envconfig:"ENABLE_LEADER_ELECTION" json:"-"`
 	Database             *DatabaseConfig   `json:"-"`
 	PersistTTL           *PersistTTLConfig `json:"-"`

--- a/pkg/dashboard/collector/server.go
+++ b/pkg/dashboard/collector/server.go
@@ -17,7 +17,9 @@ package collector
 
 import (
 	"context"
+	"net"
 	"os"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +62,7 @@ func NewServer(
 	// namespace scoped
 	options := ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: conf.MetricAddress,
+		MetricsBindAddress: net.JoinHostPort(conf.MetricHost, strconv.Itoa(conf.MetricPort)),
 		LeaderElection:     conf.EnableLeaderElection,
 		Port:               9443,
 	}

--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -20,11 +20,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
 
 const chaosDashboardSubsystem = "chaos_dashboard"
+
+var log = ctrl.Log.WithName("metrics-collector")
 
 // Collector implements prometheus.Collector interface
 type Collector struct {
@@ -83,6 +86,7 @@ func (collector *Collector) collectArchivedExperiments() {
 
 	metas, err := collector.experimentStore.ListMeta(context.TODO(), "", "", "", true)
 	if err != nil {
+		log.Error(err, "fail to list all archived chaos experiments")
 		return
 	}
 
@@ -107,6 +111,7 @@ func (collector *Collector) collectArchivedSchedules() {
 
 	metas, err := collector.scheduleStore.ListMeta(context.TODO(), "", "", true)
 	if err != nil {
+		log.Error(err, "fail to list all archived schedules")
 		return
 	}
 
@@ -125,6 +130,7 @@ func (collector *Collector) collectArchivedWorkflows() {
 
 	metas, err := collector.workflowStore.ListMeta(context.TODO(), "", "", true)
 	if err != nil {
+		log.Error(err, "fail to list all archived workflows")
 		return
 	}
 

--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -52,15 +52,11 @@ func NewCollector(experimentStore core.ExperimentStore, scheduleStore core.Sched
 			Subsystem: chaosDashboardSubsystem,
 			Name:      "archived_schedules",
 			Help:      "Total number of archived chaos schedules",
-
-			// TODO: labels
 		}, []string{"namespace"}),
 		archivedWorkflows: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Subsystem: chaosDashboardSubsystem,
 			Name:      "archived_workflows",
 			Help:      "Total number of archived chaos workflows",
-
-			// TODO: labels
 		}, []string{"namespace"}),
 	}
 }

--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -1,0 +1,160 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/fx"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
+)
+
+const chaosDashboardSubsystem = "chaos_dashboard"
+
+var log = ctrl.Log.WithName("metrics-collector")
+
+// Collector implements prometheus.Collector interface
+type Collector struct {
+	experimentStore core.ExperimentStore
+	scheduleStore   core.ScheduleStore
+	workflowStore   core.WorkflowStore
+
+	archivedExperiments *prometheus.GaugeVec
+	archivedSchedules   *prometheus.GaugeVec
+	archivedWorkflows   *prometheus.GaugeVec
+}
+
+// NewCollector initializes metrics and collector
+func NewCollector(experimentStore core.ExperimentStore, scheduleStore core.ScheduleStore, workflowStore core.WorkflowStore) *Collector {
+	return &Collector{
+		experimentStore: experimentStore,
+		scheduleStore:   scheduleStore,
+		workflowStore:   workflowStore,
+		archivedExperiments: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: chaosDashboardSubsystem,
+			Name:      "archived_experiments",
+			Help:      "Total number of archived chaos experiments",
+		}, []string{"namespace", "type"}),
+		archivedSchedules: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: chaosDashboardSubsystem,
+			Name:      "archived_schedules",
+			Help:      "Total number of archived chaos schedules",
+
+			// TODO: labels
+		}, []string{"namespace"}),
+		archivedWorkflows: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: chaosDashboardSubsystem,
+			Name:      "archived_workflows",
+			Help:      "Total number of archived chaos workflows",
+
+			// TODO: labels
+		}, []string{"namespace"}),
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
+	collector.archivedExperiments.Describe(ch)
+	collector.archivedSchedules.Describe(ch)
+	collector.archivedWorkflows.Describe(ch)
+}
+
+// Collect implements the prometheus.Collector interface.
+func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
+	collector.collectArchivedExperiments()
+	collector.collectArchivedSchedules()
+	collector.collectArchivedWorkflows()
+	collector.archivedExperiments.Collect(ch)
+	collector.archivedSchedules.Collect(ch)
+	collector.archivedWorkflows.Collect(ch)
+}
+
+func (collector *Collector) collectArchivedExperiments() {
+	collector.archivedExperiments.Reset()
+
+	metas, err := collector.experimentStore.ListMeta(context.TODO(), "", "", "", true)
+	if err != nil {
+		return
+	}
+
+	countByNamespaceAndKind := map[string]map[string]int{}
+	for _, meta := range metas {
+		if _, ok := countByNamespaceAndKind[meta.Namespace]; !ok {
+			countByNamespaceAndKind[meta.Namespace] = map[string]int{}
+		}
+
+		countByNamespaceAndKind[meta.Namespace][meta.Kind]++
+	}
+
+	for namespace, countByKind := range countByNamespaceAndKind {
+		for kind, count := range countByKind {
+			collector.archivedExperiments.WithLabelValues(namespace, kind).Set(float64(count))
+		}
+	}
+}
+
+func (collector *Collector) collectArchivedSchedules() {
+	collector.archivedSchedules.Reset()
+
+	metas, err := collector.scheduleStore.ListMeta(context.TODO(), "", "", true)
+	if err != nil {
+		return
+	}
+
+	countByNamespace := map[string]int{}
+	for _, meta := range metas {
+		countByNamespace[meta.Namespace]++
+	}
+
+	for namespace, count := range countByNamespace {
+		collector.archivedSchedules.WithLabelValues(namespace).Set(float64(count))
+	}
+}
+
+func (collector *Collector) collectArchivedWorkflows() {
+	collector.archivedWorkflows.Reset()
+
+	metas, err := collector.workflowStore.ListMeta(context.TODO(), "", "", true)
+	if err != nil {
+		return
+	}
+
+	countByNamespace := map[string]int{}
+	for _, meta := range metas {
+		countByNamespace[meta.Namespace]++
+	}
+
+	for namespace, count := range countByNamespace {
+		collector.archivedWorkflows.WithLabelValues(namespace).Set(float64(count))
+	}
+}
+
+type Params struct {
+	fx.In
+
+	Registry        *prometheus.Registry
+	ExperimentStore core.ExperimentStore
+	ScheduleStore   core.ScheduleStore
+	WorkflowStore   core.WorkflowStore
+}
+
+func Register(params Params) {
+	collector := NewCollector(params.ExperimentStore, params.ScheduleStore, params.WorkflowStore)
+	params.Registry.MustRegister(collector)
+}

--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -18,16 +18,12 @@ package metrics
 import (
 	"context"
 
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
 
 const chaosDashboardSubsystem = "chaos_dashboard"
-
-var log = ctrl.Log.WithName("metrics-collector")
 
 // Collector implements prometheus.Collector interface
 type Collector struct {

--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -18,9 +18,10 @@ package metrics
 import (
 	"context"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
 
 const chaosDashboardSubsystem = "chaos_dashboard"

--- a/pkg/dashboard/store/store.go
+++ b/pkg/dashboard/store/store.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/jinzhu/gorm"
 	ctrl "sigs.k8s.io/controller-runtime"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	config "github.com/chaos-mesh/chaos-mesh/pkg/config/dashboard"
-	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/workflow"
-
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/event"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/experiment"
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/metrics"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/schedule"
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store/workflow"
 )
 
 var (
@@ -40,6 +41,8 @@ var (
 			schedule.NewStore,
 			workflow.NewStore,
 		),
+		fx.Supply(controllermetrics.Registry),
+		fx.Invoke(metrics.Register),
 		fx.Invoke(experiment.DeleteIncompleteExperiments),
 		fx.Invoke(schedule.DeleteIncompleteSchedules),
 	)


### PR DESCRIPTION
Signed-off-by: TangliziGit <tanglizimail@foxmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

> Problem Summary: a part of #2397

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:
1. add archived objects metrics for `/pkg/dashboard/store`.
2. expose metric host and port for `chaos-dashboard` in `/helm/chaos-mesh/values.yaml`.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [x] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Breaking backward compatibility

In previous versions, the metric endpoint was exposed by manually adding the environment variable `METRIC_ADDRESS: "0.0.0.0:8080"` to the deployment configuration of 'chaos-dashboard'. But the port can not be exposed in the helm template, because `spec.template.spec.containers.ports.containerPort` in deployment configurations and service configurations should be an integer.

In order to expose metric port from the helm template, `ChaosDashboardConfig.MetricAdress` in `/pkg/config/dashboard/dashboard.go` is modified for `ChaosDashboardConfig.MetricHost` and `ChaosDashboardConfig.MetricPort`.

As a result, if the chaos-dashboard is installed by helm, there is no change required. However, if it is installed manually, you need to change the environment variable `METRIC_ADDRESS: "0.0.0.0:8080"` to `METRIC_HOST: "0.0.0.0"` and `METRIC_PORT: 8080`.