### PR TITLE
refactor pkg/time

### DIFF
--- a/pkg/time/asset.go
+++ b/pkg/time/asset.go
@@ -36,32 +36,6 @@ type FakeImage struct {
 	offset map[string]int
 }
 
-// fakeImages would be initialized in init.
-// Key presents the filename(compiled .o file, for example fake_clock_gettime.o), Value presents the corresponded FakeImage struct.
-// Deprecated: use LoadFakeImageFromEmbedFs
-var fakeImages = map[string]FakeImage{}
-
-func init() {
-	// in this function, we will load fake image from `fakeclock/*.o`
-	entries, err := fakeclock.ReadDir("fakeclock")
-	if err != nil {
-		log.Error(err, "readdir from embedded fs")
-		os.Exit(1)
-	}
-
-	for _, entry := range entries {
-		if entry.Name() == ".embed.o" {
-			// skip the .embed.o file, as it's used to remove the error of `go fmt`
-			continue
-		}
-		fakeImage, err := LoadFakeImageFromEmbedFs(entry.Name())
-		if err != nil {
-			log.Error(err, "failed to load fakeimage")
-		}
-		fakeImages[entry.Name()] = *fakeImage
-	}
-}
-
 func LoadFakeImageFromEmbedFs(filename string) (*FakeImage, error) {
 	path := "fakeclock/" + filename
 	object, err := fakeclock.ReadFile(path)

--- a/pkg/time/asset.go
+++ b/pkg/time/asset.go
@@ -27,7 +27,7 @@ import (
 var fakeclock embed.FS
 
 // FakeImage introduce the replacement of VDSO ELF entry and customizable variables.
-// FakeImage could be constructed with
+// FakeImage could be constructed by LoadFakeImageFromEmbedFs(), and then used by FakeClockInjector.
 type FakeImage struct {
 	// content presents .text section which has been "manually relocation", the address of extern variables have been calculated manually
 	content []byte
@@ -36,6 +36,7 @@ type FakeImage struct {
 	offset map[string]int
 }
 
+// LoadFakeImageFromEmbedFs builds FakeImage from the embed filesystem. It parses the ELF file and extract the variables from the relocation section, reserves the space for them at the end of content, then calculates and saves offsets as "manually relocation"
 func LoadFakeImageFromEmbedFs(filename string) (*FakeImage, error) {
 	path := "fakeclock/" + filename
 	object, err := fakeclock.ReadFile(path)

--- a/pkg/time/asset.go
+++ b/pkg/time/asset.go
@@ -1,0 +1,140 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"bytes"
+	"debug/elf"
+	"embed"
+	"encoding/binary"
+	"os"
+)
+
+//go:embed fakeclock/*.o
+var fakeclock embed.FS
+
+// FakeImage introduce the replacement of VDSO ELF entry and customizable variables.
+// FakeImage could be constructed with
+type FakeImage struct {
+	// content presents .text section which has been "manually relocation", the address of extern variables have been calculated manually
+	content []byte
+	// offset stores the table with variable name, and it's address in content.
+	// the key presents extern variable name, ths value is the address/offset within the content.
+	offset map[string]int
+}
+
+// fakeImages would be initialized in init.
+// Key presents the filename(compiled .o file, for example fake_clock_gettime.o), Value presents the corresponded FakeImage struct.
+// Deprecated: use LoadFakeImageFromEmbedFs
+var fakeImages = map[string]FakeImage{}
+
+func init() {
+	// in this function, we will load fake image from `fakeclock/*.o`
+	entries, err := fakeclock.ReadDir("fakeclock")
+	if err != nil {
+		log.Error(err, "readdir from embedded fs")
+		os.Exit(1)
+	}
+
+	for _, entry := range entries {
+		if entry.Name() == ".embed.o" {
+			// skip the .embed.o file, as it's used to remove the error of `go fmt`
+			continue
+		}
+		fakeImage, err := LoadFakeImageFromEmbedFs(entry.Name())
+		if err != nil {
+			log.Error(err, "failed to load fakeimage")
+		}
+		fakeImages[entry.Name()] = *fakeImage
+	}
+}
+
+func LoadFakeImageFromEmbedFs(filename string) (*FakeImage, error) {
+	path := "fakeclock/" + filename
+	object, err := fakeclock.ReadFile(path)
+	if err != nil {
+		log.Error(err, "read file from embedded fs", "path", path)
+		os.Exit(1)
+	}
+
+	elfFile, err := elf.NewFile(bytes.NewReader(object))
+	if err != nil {
+		log.Error(err, "parse elf", "path", path)
+		os.Exit(1)
+	}
+
+	syms, err := elfFile.Symbols()
+	if err != nil {
+		log.Error(err, "get symbols")
+		os.Exit(1)
+	}
+
+	fakeImage := FakeImage{
+		offset: make(map[string]int),
+	}
+	for _, r := range elfFile.Sections {
+		if r.Type == elf.SHT_PROGBITS && r.Name == ".text" {
+			fakeImage.content, err = r.Data()
+			if err != nil {
+				log.Error(err, "read text section")
+				os.Exit(1)
+			}
+
+			break
+		}
+	}
+
+	for _, r := range elfFile.Sections {
+		if r.Type == elf.SHT_RELA && r.Name == ".rela.text" {
+			rela_section, err := r.Data()
+			if err != nil {
+				log.Error(err, "read rela section")
+				os.Exit(1)
+			}
+			rela_section_reader := bytes.NewReader(rela_section)
+
+			var rela elf.Rela64
+			for rela_section_reader.Len() > 0 {
+				binary.Read(rela_section_reader, elfFile.ByteOrder, &rela)
+
+				symNo := rela.Info >> 32
+				if symNo == 0 || symNo > uint64(len(syms)) {
+					continue
+				}
+
+				// The relocation of a X86 image is like:
+				// Relocation section '.rela.text' at offset 0x288 contains 3 entries:
+				// Offset          Info           Type           Sym. Value    Sym. Name + Addend
+				// 000000000016  000900000002 R_X86_64_PC32     0000000000000000 CLOCK_IDS_MASK - 4
+				// 00000000001f  000a00000002 R_X86_64_PC32     0000000000000008 TV_NSEC_DELTA - 4
+				// 00000000002a  000b00000002 R_X86_64_PC32     0000000000000010 TV_SEC_DELTA - 4
+				//
+				// For example, we need to write the offset of `CLOCK_IDS_MASK` - 4 in 0x16 of the section
+				// If we want to put the `CLOCK_IDS_MASK` at the end of the section, it will be
+				// len(fakeImage.content) - 4 - 0x16
+
+				sym := &syms[symNo-1]
+				fakeImage.offset[sym.Name] = len(fakeImage.content)
+				targetOffset := uint32(len(fakeImage.content)) - uint32(rela.Off) + uint32(rela.Addend)
+				elfFile.ByteOrder.PutUint32(fakeImage.content[rela.Off:rela.Off+4], targetOffset)
+
+				// TODO: support other length besides uint64 (which is 8 bytes)
+				fakeImage.content = append(fakeImage.content, make([]byte, 8)...)
+			}
+
+			break
+		}
+	}
+	return &fakeImage, nil
+}

--- a/pkg/time/asset.go
+++ b/pkg/time/asset.go
@@ -8,8 +8,10 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package time
 

--- a/pkg/time/fakeclock.go
+++ b/pkg/time/fakeclock.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+// FakeClock could modify the time of certain process.
+// TODO: rename this interface, it brings confusing with .c files under pkg/time/fakeclock.
+type FakeClock interface {
+	Inject(pid int) error
+	Recover(pid int) error
+}

--- a/pkg/time/fakeclock.go
+++ b/pkg/time/fakeclock.go
@@ -15,9 +15,9 @@
 
 package time
 
-// FakeClock could modify the time of certain process.
+// FakeClockInjector could modify the time of certain process.
 // TODO: rename this interface, it brings confusing with .c files under pkg/time/fakeclock.
-type FakeClock interface {
+type FakeClockInjector interface {
 	Inject(pid int) error
 	Recover(pid int) error
 }

--- a/pkg/time/time_linux_amd64.go
+++ b/pkg/time/time_linux_amd64.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ModifyTime modifies time of target process
-// Deprecated:  Please use FakeClock.Inject and FakeClock.Recover instead.
+// Deprecated:  Please use FakeClockInjector.Inject and FakeClockInjector.Recover instead.
 func ModifyTime(pid int, deltaSec int64, deltaNsec int64, clockIdsMask uint64) error {
 	// Mock point to return error in unit test
 	if err := mock.On("ModifyTimeError"); err != nil {

--- a/pkg/time/time_linux_amd64.go
+++ b/pkg/time/time_linux_amd64.go
@@ -16,120 +16,11 @@
 package time
 
 import (
-	"bytes"
-	"debug/elf"
-	"embed"
-	"encoding/binary"
-	"os"
-	"strings"
-
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
 
-//go:embed fakeclock/*.o
-var fakeclock embed.FS
-
-type FakeImage struct {
-	content []byte
-	offset  map[string]int
-}
-
-var fakeImages = map[string]FakeImage{}
-
-func init() {
-	// in this function, we will load fake image from `fakeclock/*.o`
-	entries, err := fakeclock.ReadDir("fakeclock")
-	if err != nil {
-		log.Error(err, "readdir from embedded fs")
-		os.Exit(1)
-	}
-
-	for _, entry := range entries {
-		if entry.Name() == ".embed.o" {
-			// skip the .embed.o file, as it's used to remove the error of `go fmt`
-			continue
-		}
-		path := "fakeclock/" + entry.Name()
-		object, err := fakeclock.ReadFile(path)
-		if err != nil {
-			log.Error(err, "read file from embedded fs", "path", path)
-			os.Exit(1)
-		}
-
-		elfFile, err := elf.NewFile(bytes.NewReader(object))
-		if err != nil {
-			log.Error(err, "parse elf", "path", path)
-			os.Exit(1)
-		}
-
-		syms, err := elfFile.Symbols()
-		if err != nil {
-			log.Error(err, "get symbols")
-			os.Exit(1)
-		}
-
-		fakeImage := FakeImage{
-			offset: make(map[string]int),
-		}
-		for _, r := range elfFile.Sections {
-			if r.Type == elf.SHT_PROGBITS && r.Name == ".text" {
-				fakeImage.content, err = r.Data()
-				if err != nil {
-					log.Error(err, "read text section")
-					os.Exit(1)
-				}
-
-				break
-			}
-		}
-
-		for _, r := range elfFile.Sections {
-			if r.Type == elf.SHT_RELA && r.Name == ".rela.text" {
-				rela_section, err := r.Data()
-				if err != nil {
-					log.Error(err, "read rela section")
-					os.Exit(1)
-				}
-				rela_section_reader := bytes.NewReader(rela_section)
-
-				var rela elf.Rela64
-				for rela_section_reader.Len() > 0 {
-					binary.Read(rela_section_reader, elfFile.ByteOrder, &rela)
-
-					symNo := rela.Info >> 32
-					if symNo == 0 || symNo > uint64(len(syms)) {
-						continue
-					}
-
-					// The relocation of a X86 image is like:
-					// Relocation section '.rela.text' at offset 0x288 contains 3 entries:
-					// Offset          Info           Type           Sym. Value    Sym. Name + Addend
-					// 000000000016  000900000002 R_X86_64_PC32     0000000000000000 CLOCK_IDS_MASK - 4
-					// 00000000001f  000a00000002 R_X86_64_PC32     0000000000000008 TV_NSEC_DELTA - 4
-					// 00000000002a  000b00000002 R_X86_64_PC32     0000000000000010 TV_SEC_DELTA - 4
-					//
-					// For example, we need to write the offset of `CLOCK_IDS_MASK` - 4 in 0x16 of the section
-					// If we want to put the `CLOCK_IDS_MASK` at the end of the section, it will be
-					// len(fakeImage.content) - 4 - 0x16
-
-					sym := &syms[symNo-1]
-					fakeImage.offset[sym.Name] = len(fakeImage.content)
-					targetOffset := uint32(len(fakeImage.content)) - uint32(rela.Off) + uint32(rela.Addend)
-					elfFile.ByteOrder.PutUint32(fakeImage.content[rela.Off:rela.Off+4], targetOffset)
-
-					// TODO: support other length besides uint64 (which is 8 bytes)
-					fakeImage.content = append(fakeImage.content, make([]byte, 8)...)
-				}
-
-				break
-			}
-		}
-
-		fakeImages[strings.TrimSuffix(entry.Name(), ".o")] = fakeImage
-	}
-}
-
 // ModifyTime modifies time of target process
+// Deprecated:  Please use FakeClock.Inject and FakeClock.Recover instead.
 func ModifyTime(pid int, deltaSec int64, deltaNsec int64, clockIdsMask uint64) error {
 	// Mock point to return error in unit test
 	if err := mock.On("ModifyTimeError"); err != nil {
@@ -140,5 +31,9 @@ func ModifyTime(pid int, deltaSec int64, deltaNsec int64, clockIdsMask uint64) e
 			return nil
 		}
 	}
-	return NewTimeSkew(deltaSec, deltaNsec, clockIdsMask).Inject(pid)
+	timeSkew, err := NewTimeSkew(deltaSec, deltaNsec, clockIdsMask)
+	if err != nil {
+		return err
+	}
+	return timeSkew.Inject(pid)
 }

--- a/pkg/time/time_linux_amd64_test.go
+++ b/pkg/time/time_linux_amd64_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/test/pkg/timer"
 )
 
+// These test cases required bin/test/timer as its workload.
+// You could use make test-utils to build it.
+
 func TestModifyTime(t *testing.T) {
 	RegisterFailHandler(Fail)
 

--- a/pkg/time/time_skew_amd64.go
+++ b/pkg/time/time_skew_amd64.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+import (
+	"bytes"
+	"runtime"
+
+	"github.com/pkg/errors"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/mapreader"
+	"github.com/chaos-mesh/chaos-mesh/pkg/ptrace"
+)
+
+type TimeSkew struct {
+	deltaSeconds     int64
+	deltaNanoSeconds int64
+	clockIDsMask     uint64
+}
+
+func NewTimeSkew(deltaSeconds int64, deltaNanoSeconds int64, clockIDsMask uint64) *TimeSkew {
+	return &TimeSkew{deltaSeconds: deltaSeconds, deltaNanoSeconds: deltaNanoSeconds, clockIDsMask: clockIDsMask}
+}
+
+func (it *TimeSkew) Inject(pid int) error {
+
+	runtime.LockOSThread()
+	defer func() {
+		runtime.UnlockOSThread()
+	}()
+
+	program, err := ptrace.Trace(pid)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = program.Detach()
+		if err != nil {
+			log.Error(err, "fail to detach program", "pid", program.Pid())
+		}
+	}()
+
+	var vdsoEntry *mapreader.Entry
+	for index := range program.Entries {
+		// reverse loop is faster
+		e := program.Entries[len(program.Entries)-index-1]
+		if e.Path == "[vdso]" {
+			vdsoEntry = &e
+			break
+		}
+	}
+	if vdsoEntry == nil {
+		return errors.New("cannot find [vdso] entry")
+	}
+
+	for name, fakeImage := range fakeImages {
+		switch name {
+		case "fake_clock_gettime":
+			// minus tailing variable part
+			// every variable has 8 bytes
+			constImageLen := len(fakeImage.content) - 8*len(fakeImage.offset)
+			var fakeEntry *mapreader.Entry
+
+			// find injected image to avoid redundant inject (which will lead to memory leak)
+			for _, e := range program.Entries {
+				e := e
+
+				image, err := program.ReadSlice(e.StartAddress, uint64(constImageLen))
+				if err != nil {
+					continue
+				}
+
+				if bytes.Equal(*image, fakeImage.content[0:constImageLen]) {
+					fakeEntry = &e
+					log.Info("found injected image", "addr", fakeEntry.StartAddress)
+					break
+				}
+			}
+			if fakeEntry == nil {
+				fakeEntry, err = program.MmapSlice(fakeImage.content)
+				if err != nil {
+					return err
+				}
+
+				originAddr, err := program.FindSymbolInEntry("clock_gettime", vdsoEntry)
+				if err != nil {
+					return err
+				}
+
+				err = program.JumpToFakeFunc(originAddr, fakeEntry.StartAddress)
+				if err != nil {
+					return err
+				}
+			}
+
+			err = program.WriteUint64ToAddr(fakeEntry.StartAddress+uint64(fakeImage.offset["CLOCK_IDS_MASK"]), it.clockIDsMask)
+			if err != nil {
+				return err
+			}
+
+			err = program.WriteUint64ToAddr(fakeEntry.StartAddress+uint64(fakeImage.offset["TV_SEC_DELTA"]), uint64(it.deltaSeconds))
+			if err != nil {
+				return err
+			}
+
+			err = program.WriteUint64ToAddr(fakeEntry.StartAddress+uint64(fakeImage.offset["TV_NSEC_DELTA"]), uint64(it.deltaNanoSeconds))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+func (it *TimeSkew) Recover(pid int) error {
+	zeroSkew := NewTimeSkew(0, 0, it.clockIDsMask)
+	return zeroSkew.Inject(pid)
+}

--- a/pkg/time/time_skew_amd64.go
+++ b/pkg/time/time_skew_amd64.go
@@ -35,12 +35,14 @@ type TimeSkew struct {
 }
 
 func NewTimeSkew(deltaSeconds int64, deltaNanoSeconds int64, clockIDsMask uint64) (*TimeSkew, error) {
-	if _, ok := fakeImages[timeSkewFakeImage]; !ok {
-		return nil, errors.Errorf("construct TimeSkew: no such fake image called %s", timeSkewFakeImage)
+	var image *FakeImage
+	var err error
+
+	if image, err = LoadFakeImageFromEmbedFs(timeSkewFakeImage); err != nil {
+		return nil, err
 	}
 
-	image := fakeImages[timeSkewFakeImage]
-	return NewTimeSkewWithCustomFakeImage(deltaSeconds, deltaNanoSeconds, clockIDsMask, &image), nil
+	return NewTimeSkewWithCustomFakeImage(deltaSeconds, deltaNanoSeconds, clockIDsMask, image), nil
 }
 
 func NewTimeSkewWithCustomFakeImage(deltaSeconds int64, deltaNanoSeconds int64, clockIDsMask uint64, fakeImage *FakeImage) *TimeSkew {


### PR DESCRIPTION
### What problem does this PR solve?

No. It does not relate to any problem. 

### What's changed and how it works?

This PR aims to make it easier to extend TimeChaos Injection.

This PR introducer new interface called `FakeClockInjector` to present a component that could modify the time of the target process. 

```go
type FakeClockInjector interface {
	Inject(pid int) error
	Recover(pid int) error
}
```

Currently, one implementation of `FakeClockInjector` has its corresponding "fake image" as the data which would be poked into the target process. 

For each different `FakeImage`, I suggest building different `FakeClockInjector` based on it. And use the composite pattern if we need to inject more than one fake image into the target process.

We have only one implementation `TimeSkew` for `FakeClockInjector` now.

And it uses full filename(not trim `.o`) as the name of FakeImage, that's a change.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [x] Need to **cheery-pick to release branches**
	- [x] release-2.1 

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
