### PR TITLE
fix: remove hardcoded ports and expose them on helm level

### DIFF
--- a/cmd/chaos-controller-manager/provider/controller.go
+++ b/cmd/chaos-controller-manager/provider/controller.go
@@ -18,6 +18,8 @@ package provider
 import (
 	"context"
 	"math"
+	"net"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru"
@@ -62,7 +64,7 @@ func NewOption(logger logr.Logger) *ctrl.Options {
 	}
 	options := ctrl.Options{
 		Scheme:                     scheme,
-		MetricsBindAddress:         config.ControllerCfg.MetricsAddr,
+		MetricsBindAddress:         net.JoinHostPort(config.ControllerCfg.MetricsHost, strconv.Itoa(config.ControllerCfg.MetricsPort)),
 		LeaderElection:             config.ControllerCfg.EnableLeaderElection,
 		LeaderElectionNamespace:    leaderElectionNamespace,
 		LeaderElectionResourceLock: "configmaps",
@@ -70,7 +72,8 @@ func NewOption(logger logr.Logger) *ctrl.Options {
 		LeaseDuration:              &config.ControllerCfg.LeaderElectLeaseDuration,
 		RetryPeriod:                &config.ControllerCfg.LeaderElectRetryPeriod,
 		RenewDeadline:              &config.ControllerCfg.LeaderElectRenewDeadline,
-		Port:                       9443,
+		Port:                       config.ControllerCfg.WebhookPort,
+		Host:                       config.ControllerCfg.WebhookHost,
 		// Don't aggregate events
 		EventBroadcaster: record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
 			MaxEvents:            math.MaxInt32,

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -59,6 +59,10 @@ spec:
         command:
           - /usr/local/bin/chaos-controller-manager
         env:
+          {{- range $envKey, $envVal := .Values.controllerManager.env }}
+          - name: {{ $envKey | upper }}
+            value: {{ $envVal | quote }}
+          {{- end }}
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -138,9 +142,9 @@ spec:
           {{- end }}
         ports:
           - name: webhook
-            containerPort: 9443 # Customize containerPort
+            containerPort: {{ .Values.controllerManager.env.WEBHOOK_PORT }}
           - name: http
-            containerPort: 10080
+            containerPort: {{ .Values.controllerManager.env.METRICS_PORT }}
         {{- if .Values.enableProfiling }}
           - name: pprof
             containerPort: 10081

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -45,7 +45,7 @@ spec:
       protocol: TCP
       name: dlv
   {{- end }}
-    - port: 10080
+    - port: {{ .Values.controllerManager.env.METRICS_PORT }}
       targetPort: http
       protocol: TCP
       name: http

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -70,6 +70,11 @@ controllerManager:
     tag: ""
   imagePullPolicy: IfNotPresent
 
+  # The keys within the "env" map are mounted as environment variables on the pod.
+  env:
+    WEBHOOK_PORT: 9443
+    METRICS_PORT: 10080
+
   enableFilterNamespace: false
 
   # targetNamespace only works with clusterScoped is false(namespace scoped mode).

--- a/install.sh
+++ b/install.sh
@@ -1486,6 +1486,10 @@ spec:
         command:
           - /usr/local/bin/chaos-controller-manager
         env:
+          - name: METRICS_PORT
+            value: "10080"
+          - name: WEBHOOK_PORT
+            value: "9443"
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -1542,7 +1546,7 @@ spec:
             readOnly: true
         ports:
           - name: webhook
-            containerPort: 9443 # Customize containerPort
+            containerPort: 9443
           - name: http
             containerPort: 10080
           - name: pprof

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -47,8 +47,12 @@ type ChaosControllerConfig struct {
 
 	// BPFKIPort is the port which BFFKI grpc server listens on
 	BPFKIPort int `envconfig:"BPFKI_PORT" default:"50051"`
-	// MetricsAddr is the address the metric endpoint binds to
-	MetricsAddr string `envconfig:"METRICS_ADDR" default:":10080"`
+	// WebhookHost and WebhookPort are combined into an address the webhook server bind to
+	WebhookHost string `envconfig:"WEBHOOK_HOST" default:"0.0.0.0"`
+	WebhookPort int    `envconfig:"WEBHOOK_PORT" default:"9443"`
+	// MetricsHost and MetricsPort are combined into an address the metric endpoint binds to
+	MetricsHost string `envconfig:"METRICS_HOST" default:"0.0.0.0"`
+	MetricsPort int    `envconfig:"METRICS_PORT" default:"10080"`
 	// PprofAddr is the address the pprof endpoint binds to.
 	PprofAddr string `envconfig:"PPROF_ADDR" default:"0"`
 


### PR DESCRIPTION
Signed-off-by: TangliziGit <tanglizimail@foxmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #2569

> Problem Summary: #2569

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:
1. expose webhook and metrics ports in helm `values.yaml`.
2.  add `WebhookHost` and `WebhookPort` in `ChaosControllerConfig`.
3. disassemble `MetricsAddr` in `ChaosControllerConfig` into `MetricsHost` and `MetricsPort`.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility
