### PR TITLE
use chaosd v1.1.0 in integration test

### DIFF
--- a/test/integration_test/physical_machine/run.sh
+++ b/test/integration_test/physical_machine/run.sh
@@ -19,9 +19,10 @@ cd $cur
 
 echo "download and deploy chaosd"
 
-curl -fsSL -o chaosd-v1.1.0-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-v1.1.0-linux-amd64.tar.gz
-tar zxvf chaosd-v1.1.0-linux-amd64.tar.gz
-./chaosd-v1.1.0-linux-amd64/chaosd server --port 31768 > chaosd.log 2>&1 &
+CHAOSD_VERSION=v1.1.0
+curl -fsSL -o chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz
+tar zxvf chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz
+./chaosd-${CHAOSD_VERSION}-linux-amd64/chaosd server --port 31768 > chaosd.log 2>&1 &
 
 function judge_stress() {
     hava_stress=$1
@@ -84,8 +85,8 @@ judge_stress false
 
 echo "****** finish physical machine chaos test ******"
 # clean
-rm chaosd-v1.1.0-linux-amd64.tar.gz
-rm -rf chaosd-v1.1.0-linux-amd64
+rm chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz
+rm -rf chaosd-${CHAOSD_VERSION}-linux-amd64
 rm *_tmp.yaml
 rm chaosd.log
 killall chaosd

--- a/test/integration_test/physical_machine/run.sh
+++ b/test/integration_test/physical_machine/run.sh
@@ -19,10 +19,9 @@ cd $cur
 
 echo "download and deploy chaosd"
 
-# TODO: use a released version
-curl -fsSL -o chaosd-platform-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-platform-linux-amd64.tar.gz
-tar zxvf chaosd-platform-linux-amd64.tar.gz
-./chaosd-platform-linux-amd64/chaosd server --port 31768 > chaosd.log 2>&1 &
+curl -fsSL -o chaosd-v1.1.0-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-v1.1.0-linux-amd64.tar.gz
+tar zxvf chaosd-v1.1.0-linux-amd64.tar.gz
+./chaosd-v1.1.0-linux-amd64/chaosd server --port 31768 > chaosd.log 2>&1 &
 
 function judge_stress() {
     hava_stress=$1
@@ -85,8 +84,8 @@ judge_stress false
 
 echo "****** finish physical machine chaos test ******"
 # clean
-rm chaosd-platform-linux-amd64.tar.gz
-rm -rf chaosd-platform-linux-amd64
+rm chaosd-v1.1.0-linux-amd64.tar.gz
+rm -rf chaosd-v1.1.0-linux-amd64
 rm *_tmp.yaml
 rm chaosd.log
 killall chaosd


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

### What problem does this PR solve?

Chaosd [v1.1.0](https://github.com/chaos-mesh/chaosd/releases/tag/v1.1.0) is released, so use it in the integration test.


### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
