### PR TITLE
fix: always use latest for build-env and dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ HELM_BIN=$(OUTPUT_BIN)/helm
 IMAGE_BUILD_ENV_PROJECT ?= chaos-mesh
 IMAGE_BUILD_ENV_REGISTRY ?= ghcr.io
 IMAGE_BUILD_ENV_BUILD ?= 0
+IMAGE_BUILD_ENV_TAG ?= latest
 IMAGE_DEV_ENV_PROJECT ?= chaos-mesh
 IMAGE_DEV_ENV_REGISTRY ?= ghcr.io
 IMAGE_DEV_ENV_BUILD ?= 0
+IMAGE_DEV_ENV_TAG ?= latest
 
 # Enable GO111MODULE=on explicitly, disable it with GO111MODULE=off when necessary.
 export GO111MODULE := on


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

> Problem Summary:

It should always use the latest version for `build-env` and `dev-env`.


### What's changed and how it works?

Specify the certain image tag for `build-env` and `dev-env`

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [ ] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
