### PR TITLE
fix(ui): unable to load from objects

### DIFF
--- a/ui/src/components/NewExperimentNext/Step2.tsx
+++ b/ui/src/components/NewExperimentNext/Step2.tsx
@@ -35,6 +35,7 @@ import SkeletonN from 'components-mui/SkeletonN'
 import Space from 'components-mui/Space'
 import T from 'components/T'
 import UndoIcon from '@material-ui/icons/Undo'
+import _isEmpty from 'lodash.isempty'
 
 interface Step2Props {
   inWorkflow?: boolean
@@ -64,10 +65,22 @@ const Step2: React.FC<Step2Props> = ({ inWorkflow = false, inSchedule = false })
   const [init, setInit] = useState(originalInit)
 
   useEffect(() => {
-    setInit({
-      ...originalInit,
-      ...basic,
-    })
+    if (!_isEmpty(basic)) {
+      setInit({
+        metadata: {
+          ...originalInit.metadata,
+          ...basic.metadata,
+        },
+        spec: {
+          ...originalInit.spec,
+          ...basic.spec,
+          selector: {
+            ...originalInit.spec.selector,
+            ...basic.spec.selector,
+          },
+        },
+      })
+    }
   }, [originalInit, basic])
 
   const handleOnSubmitStep2 = (_values: Record<string, any>) => {

--- a/ui/src/components/NewExperimentNext/index.tsx
+++ b/ui/src/components/NewExperimentNext/index.tsx
@@ -64,9 +64,8 @@ const NewExperiment: React.ForwardRefRenderFunction<NewExperimentHandles, NewExp
 
   const fillExperiment = (original: any) => {
     const { kind, basic, spec } = parseYAML(original)
-    const env = basic.spec.address.length ? 'physic' : 'k8s'
-    const action =
-      env === 'k8s' ? spec.action ?? '' : (kind as any) !== 'ProcessChaos' && kind !== 'TimeChaos' ? spec.action : ''
+    const env = kind === 'PhysicalMachineChaos' ? 'physic' : 'k8s'
+    const action = spec.action ?? ''
 
     dispatch(setEnv(env))
     dispatch(


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

> Problem Summary:

This PR fixes two problems:

- Use `kind` to detect `PhysicalMachineChaos` or others
- Due to we sanitize the object before creating, we also need to add default fields before we load them

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

> What's Changed:

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Chaos Dashboard`
- [x] Need to **cheery-pick to release branches**

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```
