### PR TITLE
update default socket path for containerd

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -109,7 +109,7 @@ spec:
               {{- if eq .Values.chaosDaemon.runtime "docker" }}
               mountPath: /var/run/docker.sock
               {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
-              mountPath: /run/containerd/containerd.sock
+              mountPath: /var/run/containerd/containerd.sock
               {{- else if eq .Values.chaosDaemon.runtime "crio" }}
               mountPath: /var/run/crio/crio.sock
               {{- end }}

--- a/pkg/chaosdaemon/crclients/client.go
+++ b/pkg/chaosdaemon/crclients/client.go
@@ -31,7 +31,7 @@ const (
 
 	// TODO(yeya24): make socket and ns configurable
 	defaultDockerSocket     = "unix:///var/run/docker.sock"
-	defaultContainerdSocket = "/run/containerd/containerd.sock"
+	defaultContainerdSocket = "/var/run/containerd/containerd.sock"
 	defaultCrioSocket       = "/var/run/crio/crio.sock"
 	containerdDefaultNS     = "k8s.io"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The newer default socket path of containerd is `/var/run/containerd/containerd.sock`.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [x] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
