### PR TITLE
e2e: Download build cache from file server (#2617, #2702)

### DIFF
--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -149,13 +149,6 @@ def build(String name, String code) {
 							docker version
 							"""
 						}
-						stage('Extract docker cache') {
-							ansiColor('xterm') {
-								sh """
-								tar xvf /cache.tar.gz
-								"""
-							}
-						}
 						stage('Copy binary tools') {
 							ansiColor('xterm') {
 								sh """
@@ -167,6 +160,8 @@ def build(String name, String code) {
 						stage('Build image') {
 							ansiColor('xterm') {
 								sh """
+								curl http://fileserver.pingcap.net/download/builds/pingcap/chaos-mesh/cache-master.tar.gz > cache-master.tar.gz
+								tar xvf cache-master.tar.gz
 								DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --use --name chaos-mesh-builder --config ./ci/builder.toml
 								make DOCKER_CACHE=1 DOCKER_CACHE_DIR=\$(pwd)/cache GO_BUILD_CACHE=\$(pwd)/cache image
 								make DOCKER_CACHE=1 DOCKER_CACHE_DIR=\$(pwd)/cache GO_BUILD_CACHE=\$(pwd)/cache image-e2e-helper

--- a/ci/pingcap_chaos_mesh_build_kind.groovy
+++ b/ci/pingcap_chaos_mesh_build_kind.groovy
@@ -160,8 +160,8 @@ def build(String name, String code) {
 						stage('Build image') {
 							ansiColor('xterm') {
 								sh """
-								curl http://fileserver.pingcap.net/download/builds/pingcap/chaos-mesh/cache-master.tar.gz > cache-master.tar.gz
-								tar xvf cache-master.tar.gz
+								curl http://fileserver.pingcap.net/download/builds/pingcap/chaos-mesh/cache-${ghprbTargetBranch}.tar.gz > cache-${ghprbTargetBranch}.tar.gz
+								tar xvf cache-${ghprbTargetBranch}.tar.gz
 								DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --use --name chaos-mesh-builder --config ./ci/builder.toml
 								make DOCKER_CACHE=1 DOCKER_CACHE_DIR=\$(pwd)/cache GO_BUILD_CACHE=\$(pwd)/cache image
 								make DOCKER_CACHE=1 DOCKER_CACHE_DIR=\$(pwd)/cache GO_BUILD_CACHE=\$(pwd)/cache image-e2e-helper
@@ -247,7 +247,7 @@ def call(BUILD_BRANCH, CREDENTIALS_ID) {
 						]
 					}
 
-					def modifiedFiles = sh(script: "git diff --name-only origin/master...", returnStdout: true).trim().split('\n')
+					def modifiedFiles = sh(script: "git diff --name-only origin/${ghprbTargetBranch}...", returnStdout: true).trim().split('\n')
 					List ignoredModifications = modifiedFiles.findAll {
 						// all files without extension and is not Makefile will be regarded as markdown file
 						it.endsWith('.md') ||


### PR DESCRIPTION
Download build cache from file server, and use `ghprbTargetBranch` to get the target branch.