### PR TITLE
chore: disable codecov/patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
   round: down
   range: "70...100"
   status:
+    patch: false
     project:
       default:
         target: auto


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Currently, we do not restrict the test coverage for each commit and PR, so I prefer to disable `codecov/patch` feature.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [x] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
