### PR TITLE
fix: specify branch name as env image tag

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -16,9 +16,12 @@ jobs:
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          # it is required for fetching branches which contains certain tag
+          fetch-depth: 0
 
-      - name: Extract Image Tag
+      - name: Extract Image Tags
         shell: bash
         run: |
           IMAGE_TAG=${GITHUB_REF##*/}
@@ -26,7 +29,18 @@ jobs:
             IMAGE_TAG=latest;
           fi
 
+          ENV_IMAGE_TAG=${IMAGE_TAG}
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] ; then
+              BRANCHES=$(git branch -r --contains ${{ github.ref }})
+              ENV_IMAGE_TAG_RAW=$(git branch -r --contains ${{ github.ref }} | head -n 1)
+              ENV_IMAGE_TAG=${ENV_IMAGE_TAG_RAW/origin\/}
+              echo -e "available branches for this tag:\n${BRANCHES}\n"
+              echo "use dev-env and build-env for branch: ${ENV_IMAGE_TAG}"
+          fi
+
           echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
+          echo "::set-output name=env_image_tag::$(echo $ENV_IMAGE_TAG)"
         id: image_tag
 
       - name: Log in to GitHub Docker Registry
@@ -39,6 +53,8 @@ jobs:
       - name: Build Chaos Mesh
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.image_tag }}
+          IMAGE_DEV_ENV_TAG: ${{ steps.image_tag.outputs.env_image_tag }}
+          IMAGE_BUILD_ENV_TAG: ${{ steps.image_tag.outputs.env_image_tag }}
           ARCH: ${{ matrix.arch }}
           IMAGE: ${{ matrix.image }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
@@ -51,7 +67,15 @@ jobs:
             UI=0
           fi
           # ${VAR,,} convert VAR to lower case
-          make -B TARGET_PLATFORM=$ARCH IMAGE_TAG=$IMAGE_TAG-$ARCH IMAGE_PROJECT=${GITHUB_REPOSITORY_OWNER,,} DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
+          make -B \
+            TARGET_PLATFORM=$ARCH \
+            IMAGE_DEV_ENV_TAG=$IMAGE_DEV_ENV_TAG \
+            IMAGE_BUILD_ENV_TAG=$IMAGE_BUILD_ENV_TAG \
+            IMAGE_TAG=$IMAGE_TAG-$ARCH \
+            IMAGE_PROJECT=${GITHUB_REPOSITORY_OWNER,,} \
+            DOCKER_REGISTRY=ghcr.io \
+            UI=$UI \
+            image-$IMAGE
 
       - name: Upload Chaos Mesh
         env:

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Extract Image Tags
         shell: bash
         run: |
-          IMAGE_TAG=${GITHUB_REF##*/}
+          IMAGE_TAG=${{ github.ref_name }}
           if [ "${IMAGE_TAG}" = "master" ] ; then
             IMAGE_TAG=latest;
           fi


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

GitHub Action failed to build images for release: https://github.com/chaos-mesh/chaos-mesh/actions/runs/1633015443

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Use the dev-env and build-env with the branch `release-2.1`

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
