### PR TITLE
chore: rebuild dev-env and build-env when releasing

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -51,7 +51,15 @@ jobs:
             UI=0
           fi
           # ${VAR,,} convert VAR to lower case
-          make -B TARGET_PLATFORM=$ARCH IMAGE_TAG=$IMAGE_TAG-$ARCH IMAGE_PROJECT=${GITHUB_REPOSITORY_OWNER,,} DOCKER_REGISTRY=ghcr.io UI=$UI image-$IMAGE
+          make -B \
+            TARGET_PLATFORM=$ARCH \
+            IMAGE_TAG=$IMAGE_TAG-$ARCH \
+            IMAGE_DEV_ENV_BUILD=1 \
+            IMAGE_BUILD_ENV_BUILD=1 \
+            IMAGE_PROJECT=${GITHUB_REPOSITORY_OWNER,,} \
+            DOCKER_REGISTRY=ghcr.io \
+            UI=$UI \
+            image-$IMAGE
 
       - name: Upload Chaos Mesh
         env:


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

GitHub Action failed to build images for release: chaos-mesh/chaos-mesh/actions/runs/1633015443

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

rebuild `dev-env` and `build-env` with released version and daily builds.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
