### PR TITLE
Adds simple custom daemon cert server name support

### DIFF
--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -31,6 +31,8 @@ type TLSConfig struct {
 	ChaosDaemonClientCert string `envconfig:"CHAOS_DAEMON_CLIENT_CERT" default:""`
 	// ChaosDaemonClientKey is the path of chaos daemon certificate key
 	ChaosDaemonClientKey string `envconfig:"CHAOS_DAEMON_CLIENT_KEY" default:""`
+	// ChaosDaemonServerName is the server name () defined in the certificate
+	ChaosDaemonServerName string `envconfig:"CHAOS_DAEMON_CERT_SERVER_NAME default:"chaos-daemon.chaos-mesh.org"`
 
 	// ChaosdCACert is the path of chaosd ca cert
 	ChaosdCACert string `envconfig:"CHAOSD_CA_CERT" default:""`

--- a/pkg/grpc/utils.go
+++ b/pkg/grpc/utils.go
@@ -27,6 +27,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	config "github.com/chaos-mesh/chaos-mesh/pkg/config"
 )
 
 // DefaultRPCTimeout specifies default timeout of RPC between controller and chaos-operator
@@ -35,7 +37,7 @@ const DefaultRPCTimeout = 60 * time.Second
 // RPCTimeout specifies timeout of RPC between controller and chaos-operator
 var RPCTimeout = DefaultRPCTimeout
 
-const ChaosDaemonServerName = "chaos-daemon.chaos-mesh.org"
+var ChaosDaemonServerName = config.TLSConfig.ChaosDaemonServerName
 
 type TLSRaw struct {
 	CaCert []byte


### PR DESCRIPTION
### What problem does this PR solve?

Adds simple support for a custom cert server name via env variable. 

This PR does not include any helm changes to render the environment variable, as I believe it may be easier to do a refactor of that in its own PR. 

(To expand on the reasoning above, currently these certs are rendered based on the if statement of the dashboard security being enabled)

Close #2734

### What's changed and how it works?

Changed CONST hardcoded value into a value populated by environment variable. (Which defaults to what the hardcode was set to)

### Related changes

### Checklist

Tests

N/A