### PR TITLE
build: fix environment variables in build scripts

### DIFF
--- a/build/build_image.py
+++ b/build/build_image.py
@@ -120,8 +120,8 @@ def main():
     cmd = []
     if get_image_build(name) == "1":
         if os.getenv("DOCKER_CACHE") == "1":
-            env = {"DOCKER_BUILDKIT": "1",
-                   "DOCKER_CLI_EXPERIMENTAL": "enabled"}
+            env.update({"DOCKER_BUILDKIT": "1",
+                   "DOCKER_CLI_EXPERIMENTAL": "enabled"})
             cache_dir = os.getenv(
                 "DOCKER_CACHE_DIR", f"{os.getcwd()}/.cache/image-{name}")
             pathlib.Path(cache_dir).mkdir(parents=True, exist_ok=True)
@@ -136,7 +136,7 @@ def main():
                 cmd += ["--cache-from", f"type=local,src={cache_dir}"]
         else:
             if os.getenv("TARGET_PLATFORM") is not None:
-                env = {"DOCKER_BUILDKIT": "1"}
+                env.update({"DOCKER_BUILDKIT": "1"})
                 cmd = [
                     "docker",
                     "buildx",
@@ -147,7 +147,7 @@ def main():
             else:
                 # This branch is split to avoid to use `buildx`, as `buildx` is
                 # not supported on some CI environment
-                env = {"DOCKER_BUILDKIT": "1"}
+                env.update({"DOCKER_BUILDKIT": "1"})
                 cmd = ["docker", "build"]
 
         for env_key in common.export_env_variables:

--- a/build/common.py
+++ b/build/common.py
@@ -25,5 +25,4 @@ export_env_variables = [
     "LDFLAGS",
     "CRATES_MIRROR",
     "GO_BUILD_CACHE",
-    "LDFLAGS",
 ]

--- a/build/get_env_shell.py
+++ b/build/get_env_shell.py
@@ -101,6 +101,9 @@ def main():
         cmd += ["--volume", f"{tmp_go_dir}:/tmp/go"]
         cmd += ["--volume", f"{tmp_go_build_dir}:/tmp/go-build"]
 
+    for env_key in common.export_env_variables:
+        pass_env_to_docker_arg(cmd, env_key)
+
     cmd += ["--workdir", cwd]
     cmd += [env_image_full_name]
     cmd += ["/bin/bash"]


### PR DESCRIPTION
### What problem does this PR solve?

1. Don't override environment variable in the build-script
2. Pass environment variable like `HTTP_PROXY` and `HTTPS_PROXY`... to the dev environment.