### PR TITLE
chore: setup go 1.15 for github actions

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -19,7 +19,9 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
       - name: Install Chaos Mesh
         run: |
           export CLUSTER="chart-testing"

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -27,7 +27,9 @@
          with:
            # Must use at least depth 2!
            fetch-depth: 2
-
+       - uses: actions/setup-go@v2
+         with:
+           go-version: '1.15'
        - uses: actions/setup-python@v2
        - name: Configure awscli
          run: |

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -20,6 +20,9 @@ jobs:
           fetch-depth: 2
 
       - uses: actions/setup-python@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
       - name: Configure awscli
         run: |
           pip3 install awscli


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->
It's a part of https://github.com/chaos-mesh/chaos-mesh/issues/2783.

### What's changed and how it works?

setup go 1.15 for github actions

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
