### PR TITLE
chore: use development logger for chaos-builder

### DIFF
--- a/cmd/chaos-builder/main.go
+++ b/cmd/chaos-builder/main.go
@@ -17,14 +17,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/errors"
 )

--- a/cmd/chaos-builder/main.go
+++ b/cmd/chaos-builder/main.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -25,11 +27,11 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
-	log = zap.New(zap.UseDevMode(true))
+	zapLogger, _ = zap.NewDevelopment()
+	log          = zapr.NewLogger(zapLogger)
 )
 
 type metadata struct {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

human unreadable time in chaos-builder's log.

### What's changed and how it works?

use the default development configuration for zap.

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [x] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
