### PR TITLE
removed namespace field

### DIFF
--- a/examples/burn-cpu.yaml
+++ b/examples/burn-cpu.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: StressChaos
 metadata:
   name: burn-cpu
-  namespace: chaos-testing
 spec:
   mode: one
   selector:
@@ -28,4 +27,3 @@ spec:
       load: 100
       options: ["--cpu 2", "--timeout 600", "--hdd 1"]
   duration: "30s"
-

--- a/examples/container-kill-example.yaml
+++ b/examples/container-kill-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: PodChaos
 metadata:
   name: container-kill-example
-  namespace: chaos-testing
 spec:
   action: container-kill
   mode: one
@@ -24,4 +23,4 @@ spec:
     labelSelectors:
       app.kubernetes.io/component: monitor
   containerNames:
-  - prometheus
+    - prometheus

--- a/examples/dns-chaos-example.yaml
+++ b/examples/dns-chaos-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: DNSChaos
 metadata:
   name: dns-chaos-example
-  namespace: chaos-testing
 spec:
   action: random
   mode: all

--- a/examples/io-attr-example.yaml
+++ b/examples/io-attr-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: IOChaos
 metadata:
   name: io-attr-example
-  namespace: chaos-testing
 spec:
   action: attrOverride
   mode: one

--- a/examples/io-delay-example.yaml
+++ b/examples/io-delay-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: IOChaos
 metadata:
   name: io-delay-example
-  namespace: chaos-testing
 spec:
   action: latency
   mode: one

--- a/examples/io-errno-example.yaml
+++ b/examples/io-errno-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: IOChaos
 metadata:
   name: io-errno-example
-  namespace: chaos-testing
 spec:
   action: fault
   mode: one

--- a/examples/jvm/app.yaml
+++ b/examples/jvm/app.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: helloworld
-  namespace: helloworld
 spec:
   containers:
     - name: helloworld

--- a/examples/jvm/jvm-exception-example.yaml
+++ b/examples/jvm/jvm-exception-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: JVMChaos
 metadata:
   name: exception
-  namespace: helloworld
 spec:
   action: exception
   class: Main

--- a/examples/jvm/jvm-return-example.yaml
+++ b/examples/jvm/jvm-return-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: JVMChaos
 metadata:
   name: return
-  namespace: helloworld
 spec:
   action: return
   class: Main

--- a/examples/jvm/jvm-rule-data-example.yaml
+++ b/examples/jvm/jvm-rule-data-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: JVMChaos
 metadata:
   name: modify-return
-  namespace: helloworld
 spec:
   action: ruleData
   ruleData: "RULE modify return value\nCLASS Main\nMETHOD getnum\nAT ENTRY\nIF true\nDO\n    return 9999\nENDRULE"

--- a/examples/network-bandwidth-example.yaml
+++ b/examples/network-bandwidth-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-bandwidth-example
-  namespace: chaos-testing
 spec:
   action: bandwidth
   mode: one

--- a/examples/network-corrupt-example.yaml
+++ b/examples/network-corrupt-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-corrupt-example
-  namespace: chaos-testing
 spec:
   action: corrupt
   mode: one

--- a/examples/network-delay-example.yaml
+++ b/examples/network-delay-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-delay-example
-  namespace: chaos-testing
 spec:
   action: delay
   mode: one

--- a/examples/network-delay-with-external-target-example.yaml
+++ b/examples/network-delay-with-external-target-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-delay-example
-  namespace: chaos-testing
 spec:
   action: delay
   mode: one

--- a/examples/network-delay-with-target-example.yaml
+++ b/examples/network-delay-with-target-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-delay-example
-  namespace: chaos-testing
 spec:
   action: delay
   mode: one

--- a/examples/network-duplicate-example.yaml
+++ b/examples/network-duplicate-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-duplicate-example
-  namespace: chaos-testing
 spec:
   action: duplicate
   mode: one

--- a/examples/network-loss-example.yaml
+++ b/examples/network-loss-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-loss-example
-  namespace: chaos-testing
 spec:
   action: loss
   mode: one

--- a/examples/network-netem-example.yaml
+++ b/examples/network-netem-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-netem-example
-  namespace: chaos-testing
 spec:
   action: netem
   mode: one

--- a/examples/network-netem-with-target-example.yaml
+++ b/examples/network-netem-with-target-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-netem-example
-  namespace: chaos-testing
 spec:
   action: netem
   mode: one

--- a/examples/network-partition-example.yaml
+++ b/examples/network-partition-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-partition-example
-  namespace: chaos-testing
 spec:
   action: partition
   mode: one

--- a/examples/network-partition-with-external-targets-example.yaml
+++ b/examples/network-partition-with-external-targets-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
   name: network-partition-example
-  namespace: chaos-testing
 spec:
   action: partition
   mode: one

--- a/examples/nginx/http-patch-response.yaml
+++ b/examples/nginx/http-patch-response.yaml
@@ -16,7 +16,6 @@
 kind: HTTPChaos
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  namespace: default
   name: nginx-http-patch
 spec:
   selector:

--- a/examples/pod-failure-example.yaml
+++ b/examples/pod-failure-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: PodChaos
 metadata:
   name: pod-failure-example
-  namespace: chaos-testing
 spec:
   action: pod-failure
   mode: one

--- a/examples/pod-kill-example.yaml
+++ b/examples/pod-kill-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: PodChaos
 metadata:
   name: pod-kill-example
-  namespace: chaos-testing
 spec:
   action: pod-kill
   mode: one

--- a/examples/time-chaos-example.yaml
+++ b/examples/time-chaos-example.yaml
@@ -16,7 +16,6 @@ apiVersion: chaos-mesh.org/v1alpha1
 kind: TimeChaos
 metadata:
   name: time-shift-example
-  namespace: chaos-testing
 spec:
   mode: one
   selector:


### PR DESCRIPTION
### What problem does this PR solve?
The namespace in the YAML files in the example folder can now be overwritten through Kubernetes Command Line.

close https://github.com/chaos-mesh/chaos-mesh/issues/2819

### What's changed and how it works?

Removed Namespace in YAML Files.

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)
