### PR TITLE
combine groups together before group imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ failpoint-disable: images/dev-env/.dockerbuilt
 groupimports: SHELL:=$(RUN_IN_DEV_SHELL)
 groupimports: images/dev-env/.dockerbuilt
 	find . -type f -name '*.go' -not -path '**/zz_generated.*.go' -not -path './.cache/**' | xargs \
-		-d $$'\n' -n 10 goimports -w -l -local github.com/chaos-mesh/chaos-mesh
+		-d $$'\n' -n 10 goimports -combine -w -l -local github.com/chaos-mesh/chaos-mesh
 
 fmt: SHELL:=$(RUN_IN_DEV_SHELL)
 fmt: groupimports images/dev-env/.dockerbuilt

--- a/api/v1alpha1/awschaos_types_test.go
+++ b/api/v1alpha1/awschaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/awschaos_webhook.go
+++ b/api/v1alpha1/awschaos_webhook.go
@@ -18,9 +18,8 @@ package v1alpha1
 import (
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1/genericwebhook"
 )

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -18,10 +18,9 @@ package v1alpha1
 import (
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 const (

--- a/api/v1alpha1/dnschaos_type_test.go
+++ b/api/v1alpha1/dnschaos_type_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/gcpchaos_types_test.go
+++ b/api/v1alpha1/gcpchaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/gcpchaos_webhook.go
+++ b/api/v1alpha1/gcpchaos_webhook.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1/genericwebhook"

--- a/api/v1alpha1/genericwebhook/validater.go
+++ b/api/v1alpha1/genericwebhook/validater.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 

--- a/api/v1alpha1/httpchaos_types_test.go
+++ b/api/v1alpha1/httpchaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/iochaos_types_test.go
+++ b/api/v1alpha1/iochaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/jvmchaos_types_test.go
+++ b/api/v1alpha1/jvmchaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/networkchaos_types_test.go
+++ b/api/v1alpha1/networkchaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/networkchaos_webhook.go
+++ b/api/v1alpha1/networkchaos_webhook.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1/genericwebhook"

--- a/api/v1alpha1/physical_machine_chaos_types_test.go
+++ b/api/v1alpha1/physical_machine_chaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/physical_machine_types_test.go
+++ b/api/v1alpha1/physical_machine_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/physical_machine_webhook.go
+++ b/api/v1alpha1/physical_machine_webhook.go
@@ -21,9 +21,8 @@ import (
 	"reflect"
 	"strings"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var physicalMachineLog = logf.Log.WithName("physical-machine-resource")

--- a/api/v1alpha1/podchaos_types_test.go
+++ b/api/v1alpha1/podchaos_types_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/schedule_type_test.go
+++ b/api/v1alpha1/schedule_type_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/api/v1alpha1/stresschaos_webhook.go
+++ b/api/v1alpha1/stresschaos_webhook.go
@@ -20,9 +20,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1/genericwebhook"

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -18,9 +18,8 @@ package v1alpha1
 import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true

--- a/api/webhook/validate_auth.go
+++ b/api/webhook/validate_auth.go
@@ -21,13 +21,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/pkg/errors"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )

--- a/cmd/chaos-builder/main.go
+++ b/cmd/chaos-builder/main.go
@@ -25,9 +25,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
-
 	"github.com/pingcap/errors"
+	"go.uber.org/zap"
 )
 
 var (

--- a/cmd/chaos-controller-manager/provider/controller.go
+++ b/cmd/chaos-controller-manager/provider/controller.go
@@ -24,10 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru"
 	"go.uber.org/fx"
-
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-	"github.com/chaos-mesh/chaos-mesh/controllers/config"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -38,6 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/config"
 )
 
 var (

--- a/cmd/chaos-controller-manager/provider/updated_client_test.go
+++ b/cmd/chaos-controller-manager/provider/updated_client_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/cmd/chaos-dashboard/main.go
+++ b/cmd/chaos-dashboard/main.go
@@ -20,13 +20,11 @@ import (
 	"flag"
 	"os"
 
-	"go.uber.org/fx"
-
 	_ "github.com/jinzhu/gorm/dialects/mssql"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-
+	"go.uber.org/fx"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/cmd/watchmaker/main_linux_amd64.go
+++ b/cmd/watchmaker/main_linux_amd64.go
@@ -21,16 +21,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/time/utils"
-
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/ptrace"
-
-	"github.com/chaos-mesh/chaos-mesh/pkg/version"
-
 	"github.com/chaos-mesh/chaos-mesh/pkg/time"
+	"github.com/chaos-mesh/chaos-mesh/pkg/time/utils"
+	"github.com/chaos-mesh/chaos-mesh/pkg/version"
 )
 
 var (

--- a/controllers/chaosimpl/gcpchaos/diskloss/impl.go
+++ b/controllers/chaosimpl/gcpchaos/diskloss/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	compute "google.golang.org/api/compute/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/controllers/chaosimpl/gcpchaos/nodereset/impl.go
+++ b/controllers/chaosimpl/gcpchaos/nodereset/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"

--- a/controllers/chaosimpl/gcpchaos/nodestop/impl.go
+++ b/controllers/chaosimpl/gcpchaos/nodestop/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"

--- a/controllers/chaosimpl/gcpchaos/utils/utils.go
+++ b/controllers/chaosimpl/gcpchaos/utils/utils.go
@@ -19,12 +19,11 @@ import (
 	"context"
 	"encoding/base64"
 
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	compute "google.golang.org/api/compute/v1"
-	"google.golang.org/api/option"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )

--- a/controllers/chaosimpl/httpchaos/impl.go
+++ b/controllers/chaosimpl/httpchaos/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/chaosimpl/httpchaos/podhttpchaosmanager/manager.go
+++ b/controllers/chaosimpl/httpchaos/podhttpchaosmanager/manager.go
@@ -18,9 +18,8 @@ package podhttpchaosmanager
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/chaosimpl/iochaos/impl.go
+++ b/controllers/chaosimpl/iochaos/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/chaosimpl/iochaos/podiochaosmanager/podiochaosmanager.go
+++ b/controllers/chaosimpl/iochaos/podiochaosmanager/podiochaosmanager.go
@@ -18,9 +18,8 @@ package podiochaosmanager
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/chaosimpl/networkchaos/partition/impl.go
+++ b/controllers/chaosimpl/networkchaos/partition/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/chaosimpl/networkchaos/podnetworkchaosmanager/podnetworkchaosmanager.go
+++ b/controllers/chaosimpl/networkchaos/podnetworkchaosmanager/podnetworkchaosmanager.go
@@ -18,9 +18,8 @@ package podnetworkchaosmanager
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/chaosimpl/timechaos/impl.go
+++ b/controllers/chaosimpl/timechaos/impl.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/controllers/chaosimpl/utils/record.go
+++ b/controllers/chaosimpl/utils/record.go
@@ -18,10 +18,9 @@ package utils
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"

--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-
 	"github.com/go-logr/logr"
 	"go.uber.org/fx"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
@@ -30,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	chaosimpltypes "github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/types"
 	"github.com/chaos-mesh/chaos-mesh/controllers/common/pipeline"
 	"github.com/chaos-mesh/chaos-mesh/controllers/config"

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -19,10 +19,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/config"
 )

--- a/controllers/podnetworkchaos/ipset/ipset.go
+++ b/controllers/podnetworkchaos/ipset/ipset.go
@@ -19,11 +19,9 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"

--- a/controllers/podnetworkchaos/iptable/iptable.go
+++ b/controllers/podnetworkchaos/iptable/iptable.go
@@ -19,11 +19,9 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"

--- a/controllers/podnetworkchaos/tc/tc.go
+++ b/controllers/podnetworkchaos/tc/tc.go
@@ -19,11 +19,9 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"

--- a/controllers/utils/controller/key.go
+++ b/controllers/utils/controller/key.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/controllers/utils/recorder/annotations.go
+++ b/controllers/utils/recorder/annotations.go
@@ -21,9 +21,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/iancoleman/strcase"
+	"github.com/pkg/errors"
 )
 
 var ErrInvalidType = errors.New("invalid type of fields")

--- a/controllers/utils/recorder/recorder.go
+++ b/controllers/utils/recorder/recorder.go
@@ -21,8 +21,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
-
 	"github.com/go-logr/logr"
 	"github.com/iancoleman/strcase"
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +31,8 @@ import (
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
 )
 
 type ChaosRecorder interface {

--- a/e2e-test/action.go
+++ b/e2e-test/action.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,8 +31,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/e2econst"
 	e2eutil "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"

--- a/e2e-test/e2e/chaos/basic.go
+++ b/e2e-test/e2e/chaos/basic.go
@@ -36,13 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config"
-	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/e2econst"
-	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
-	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
-	"github.com/chaos-mesh/chaos-mesh/pkg/portforward"
-
-	// testcases
 	dnschaostestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/dnschaos"
 	httpchaostestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/httpchaos"
 	iochaostestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/iochaos"
@@ -51,6 +44,11 @@ import (
 	sidecartestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/sidecar"
 	stresstestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/stresschaos"
 	timechaostestcases "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos/timechaos"
+	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/e2econst"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
+	"github.com/chaos-mesh/chaos-mesh/pkg/portforward" // testcases
 )
 
 var _ = ginkgo.Describe("[Basic]", func() {

--- a/e2e-test/e2e/chaos/dnschaos/dns.go
+++ b/e2e-test/e2e/chaos/dnschaos/dns.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"

--- a/e2e-test/e2e/chaos/networkchaos/misc.go
+++ b/e2e-test/e2e/chaos/networkchaos/misc.go
@@ -25,11 +25,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )

--- a/e2e-test/e2e/chaos/networkchaos/network_partition.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_partition.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"

--- a/e2e-test/e2e/chaos/podchaos/pod_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_kill.go
@@ -19,10 +19,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
-	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +29,10 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
 )
 
 func TestcasePodKillOnceThenDelete(ns string, kubeCli kubernetes.Interface, cli client.Client) {

--- a/e2e-test/e2e/e2e.go
+++ b/e2e-test/e2e/e2e.go
@@ -16,8 +16,7 @@
 package e2e
 
 import (
-	"context"
-	// load pprof
+	"context" // load pprof
 	_ "net/http/pprof"
 	"os/exec"
 	"time"
@@ -27,6 +26,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -36,10 +36,7 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	test "github.com/chaos-mesh/chaos-mesh/e2e-test"
-	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config"
-
-	// ensure auth plugins are loaded
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config" // ensure auth plugins are loaded
 )
 
 const namespaceCleanupTimeout = 15 * time.Minute

--- a/e2e-test/e2e/e2e_test.go
+++ b/e2e-test/e2e/e2e_test.go
@@ -36,10 +36,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 
-	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config"
-
-	// test sources
 	_ "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/chaos"
+	e2econfig "github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config" // test sources
 )
 
 // handleFlags sets up all flags and parses the command line.

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -6,10 +6,14 @@ ENV GO111MODULE=on
 ENV GOPATH /go
 ENV CGO_ENABLED 0
 
+RUN mkdir -p /go/src/github.com/YangKeao/tools
+WORKDIR /go/src/github.com/YangKeao/tools
+RUN git clone https://github.com/YangKeao/tools.git -b v0.1.9-with-combine --depth 1 .
+RUN go install ./cmd/goimports
+
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 RUN go install github.com/mgechev/revive@v1.0.2-0.20200225072153-6219ca02fffb
 RUN go install github.com/pingcap/failpoint/failpoint-ctl@v0.0.0-20200210140405-f8f9fb234798
-RUN go install golang.org/x/tools/cmd/goimports@v0.1.4
 RUN go install github.com/securego/gosec/cmd/gosec@v0.0.0-20200401082031-e946c8c39989
 RUN go install github.com/99designs/gqlgen@v0.13.0
 RUN go install github.com/golang/protobuf/protoc-gen-go@v1.4.2

--- a/pkg/chaosctl/physicalmachine/init.go
+++ b/pkg/chaosctl/physicalmachine/init.go
@@ -23,17 +23,16 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/pkg/errors"
-
-	"github.com/chaos-mesh/chaos-mesh/pkg/chaosctl/common"
-	"github.com/chaos-mesh/chaos-mesh/pkg/label"
-
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/keyutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosctl/common"
+	"github.com/chaos-mesh/chaos-mesh/pkg/label"
 )
 
 type PhysicalMachineInitOptions struct {

--- a/pkg/chaosdaemon/container_test.go
+++ b/pkg/chaosdaemon/container_test.go
@@ -18,10 +18,9 @@ package chaosdaemon
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"

--- a/pkg/chaosdaemon/crclients/client_test.go
+++ b/pkg/chaosdaemon/crclients/client_test.go
@@ -18,10 +18,9 @@ package crclients
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"

--- a/pkg/chaosdaemon/crclients/containerd/client_test.go
+++ b/pkg/chaosdaemon/crclients/containerd/client_test.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"

--- a/pkg/chaosdaemon/crclients/docker/client_test.go
+++ b/pkg/chaosdaemon/crclients/docker/client_test.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"

--- a/pkg/chaosdaemon/ipset_server_test.go
+++ b/pkg/chaosdaemon/ipset_server_test.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"

--- a/pkg/chaosdaemon/iptables_server_test.go
+++ b/pkg/chaosdaemon/iptables_server_test.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"

--- a/pkg/chaosdaemon/setup_test.go
+++ b/pkg/chaosdaemon/setup_test.go
@@ -18,10 +18,9 @@ package chaosdaemon
 import (
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
 
 func TestAPIs(t *testing.T) {

--- a/pkg/chaosdaemon/tc_server.go
+++ b/pkg/chaosdaemon/tc_server.go
@@ -21,15 +21,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/pkg/errors"
-
 	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
-
-	"github.com/golang/protobuf/ptypes/empty"
 )
 
 const (

--- a/pkg/chaosdaemon/time_server.go
+++ b/pkg/chaosdaemon/time_server.go
@@ -18,11 +18,10 @@ package chaosdaemon
 import (
 	"context"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/time"
-
 	"github.com/golang/protobuf/ptypes/empty"
 
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/time"
 )
 
 func (s *DaemonServer) SetTimeOffset(ctx context.Context, req *pb.TimeRequest) (*empty.Empty, error) {

--- a/pkg/chaosdaemon/time_server_test.go
+++ b/pkg/chaosdaemon/time_server_test.go
@@ -18,14 +18,12 @@ package chaosdaemon
 import (
 	"context"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )

--- a/pkg/clientpool/client.go
+++ b/pkg/clientpool/client.go
@@ -20,9 +20,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"

--- a/pkg/dashboard/apiserver/utils/auth.go
+++ b/pkg/dashboard/apiserver/utils/auth.go
@@ -18,10 +18,9 @@ package utils
 import (
 	"net/http"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/gin-gonic/gin"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/clientpool"
 	config "github.com/chaos-mesh/chaos-mesh/pkg/config/dashboard"

--- a/pkg/dashboard/collector/collector.go
+++ b/pkg/dashboard/collector/collector.go
@@ -19,10 +19,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/dashboard/collector/schedule_collector.go
+++ b/pkg/dashboard/collector/schedule_collector.go
@@ -19,10 +19,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-logr/logr"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/dashboard/core/workflow_test.go
+++ b/pkg/dashboard/core/workflow_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"

--- a/pkg/dashboard/store/event/event_test.go
+++ b/pkg/dashboard/store/event/event_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
-
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/jinzhu/gorm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
 
 func TestEvent(t *testing.T) {

--- a/pkg/dashboard/store/store.go
+++ b/pkg/dashboard/store/store.go
@@ -18,9 +18,8 @@ package store
 import (
 	"context"
 
-	"go.uber.org/fx"
-
 	"github.com/jinzhu/gorm"
+	"go.uber.org/fx"
 	ctrl "sigs.k8s.io/controller-runtime"
 	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 

--- a/pkg/dashboard/ttlcontroller/ttlcontroller.go
+++ b/pkg/dashboard/ttlcontroller/ttlcontroller.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
-
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
 
 var (

--- a/pkg/portforward/portforward.go
+++ b/pkg/portforward/portforward.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/pkg/selector/generic/annotation/selector_test.go
+++ b/pkg/selector/generic/annotation/selector_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
-
 	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
 )
 

--- a/pkg/selector/generic/field/selector_test.go
+++ b/pkg/selector/generic/field/selector_test.go
@@ -18,9 +18,8 @@ package field
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"

--- a/pkg/selector/generic/namespace/selector.go
+++ b/pkg/selector/generic/namespace/selector.go
@@ -18,12 +18,11 @@ package namespace
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"

--- a/pkg/selector/generic/namespace/selector_test.go
+++ b/pkg/selector/generic/namespace/selector_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
-
 	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
 )
 

--- a/pkg/selector/nodevolumepath/selector.go
+++ b/pkg/selector/nodevolumepath/selector.go
@@ -18,12 +18,11 @@ package nodevolumepath
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/config"

--- a/pkg/selector/physicalmachine/selector.go
+++ b/pkg/selector/physicalmachine/selector.go
@@ -19,9 +19,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-
 	"go.uber.org/fx"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/selector/pod/node_selector_test.go
+++ b/pkg/selector/pod/node_selector_test.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
-
 	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
 )
 

--- a/pkg/selector/pod/phase_selector.go
+++ b/pkg/selector/pod/phase_selector.go
@@ -18,12 +18,11 @@ package pod
 import (
 	"strings"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"

--- a/pkg/selector/pod/phase_selector_test.go
+++ b/pkg/selector/pod/phase_selector_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
-
 	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
 )
 

--- a/pkg/selector/pod/selector.go
+++ b/pkg/selector/pod/selector.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,16 +26,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
-	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/registry"
-
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
 	genericannotation "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/annotation"
 	genericfield "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/field"
 	genericlabel "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/label"
 	genericnamespace "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/namespace"
+	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/registry"
 )
 
 var log = ctrl.Log.WithName("pod-selector")

--- a/pkg/selector/pod/selector_test.go
+++ b/pkg/selector/pod/selector_test.go
@@ -19,16 +19,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-
 	. "github.com/onsi/gomega"
-
-	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	. "github.com/chaos-mesh/chaos-mesh/pkg/testutils"
 )
 
 func TestSelectPods(t *testing.T) {

--- a/pkg/testutils/generate.go
+++ b/pkg/testutils/generate.go
@@ -18,11 +18,11 @@ package testutils
 import (
 	"fmt"
 
-	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
 // PodArg by default use `Status=corev1.PodRunning` and `Namespace=metav1.NamespaceDefault`.

--- a/pkg/time/utils.go
+++ b/pkg/time/utils.go
@@ -17,7 +17,6 @@ package time
 
 import (
 	"github.com/go-logr/logr"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/pkg/time/utils/utils_test.go
+++ b/pkg/time/utils/utils_test.go
@@ -16,9 +16,9 @@
 package utils
 
 import (
-	. "github.com/onsi/gomega"
-
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestEncodeClkIds(t *testing.T) {

--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"

--- a/pkg/webhook/config/watcher/watcher.go
+++ b/pkg/webhook/config/watcher/watcher.go
@@ -22,22 +22,19 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/ghodss/yaml"
-
-	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
-	"github.com/chaos-mesh/chaos-mesh/pkg/webhook/config"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
+	"github.com/pkg/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
+	"github.com/chaos-mesh/chaos-mesh/pkg/webhook/config"
 )
 
 var log = ctrl.Log.WithName("inject-webhook")

--- a/pkg/webhook/config/watcher/watcher_test.go
+++ b/pkg/webhook/config/watcher/watcher_test.go
@@ -18,14 +18,12 @@ package watcher
 import (
 	"fmt"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ = Describe("webhook config watcher", func() {

--- a/pkg/webhook/inject/inject.go
+++ b/pkg/webhook/inject/inject.go
@@ -22,21 +22,18 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/annotation"
 	controllerCfg "github.com/chaos-mesh/chaos-mesh/pkg/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
+	genericnamespace "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/namespace"
 	podselector "github.com/chaos-mesh/chaos-mesh/pkg/selector/pod"
 	"github.com/chaos-mesh/chaos-mesh/pkg/webhook/config"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	genericnamespace "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/namespace"
 )
 
 var log = ctrl.Log.WithName("inject-webhook")

--- a/pkg/workflow/controllers/chaos_node_test.go
+++ b/pkg/workflow/controllers/chaos_node_test.go
@@ -21,13 +21,12 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )

--- a/pkg/workflow/controllers/new_node.go
+++ b/pkg/workflow/controllers/new_node.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )

--- a/pkg/workflow/controllers/serial_node_reconciler_test.go
+++ b/pkg/workflow/controllers/serial_node_reconciler_test.go
@@ -21,13 +21,12 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Chaos Mesh has its own dev-env now, so we can use our own goimports 😄 . It can combine and sort all groups together.

### What's changed and how it works?

The single commit is here: https://github.com/YangKeao/tools/commit/2075ebeb37071f8ac14648e2b72c6498b76ec068

It adds a flag to the goimports, to sort after combining all manually split groups together.