### PR TITLE
fix wrong comment on workflow Dashboard HTTP API

### DIFF
--- a/pkg/dashboard/apiserver/workflow/workflow.go
+++ b/pkg/dashboard/apiserver/workflow/workflow.go
@@ -254,7 +254,7 @@ func (it *Service) getWorkflowDetailByUID(c *gin.Context) {
 // @Success 200 {object} core.WorkflowDetail
 // @Failure 400 {object} utils.APIError
 // @Failure 500 {object} utils.APIError
-// @Router /workflows/new [post]
+// @Router /workflows [post]
 func (it *Service) createWorkflow(c *gin.Context) {
 	payload := v1alpha1.Workflow{}
 

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -1806,9 +1806,7 @@ var doc = `{
                         }
                     }
                 }
-            }
-        },
-        "/workflows/new": {
+            },
             "post": {
                 "description": "Create a new workflow.",
                 "produces": [

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -1790,9 +1790,7 @@
                         }
                     }
                 }
-            }
-        },
-        "/workflows/new": {
+            },
             "post": {
                 "description": "Create a new workflow.",
                 "produces": [

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -3692,6 +3692,33 @@ paths:
       summary: List workflows from Kubernetes cluster.
       tags:
       - workflows
+    post:
+      description: Create a new workflow.
+      parameters:
+      - description: Request body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/v1alpha1.Workflow'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/core.WorkflowDetail'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.APIError'
+      summary: Create a new workflow.
+      tags:
+      - workflows
   /workflows/{uid}:
     delete:
       description: Delete the specified workflow.
@@ -3781,34 +3808,6 @@ paths:
           schema:
             $ref: '#/definitions/utils.APIError'
       summary: Update a workflow.
-      tags:
-      - workflows
-  /workflows/new:
-    post:
-      description: Create a new workflow.
-      parameters:
-      - description: Request body
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/v1alpha1.Workflow'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/core.WorkflowDetail'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/utils.APIError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/utils.APIError'
-      summary: Create a new workflow.
       tags:
       - workflows
   /workflows/parse-task/http:


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

the comment of `createWorkflow` is wrong

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
