### PR TITLE
fix gitVersion while compling in GithubAction

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -17,6 +17,9 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@master
+        with:
+          # it requires all the tags and branch for generation the correct GitVersion with hack/version.sh
+          fetch-depth: 0
 
       - name: Extract Image Tag
         shell: bash

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -19,7 +19,8 @@ set -euo pipefail
 function chaos_mesh::version::get_version_vars() {
   if [[ -n ${GIT_COMMIT-} ]] || GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null); then
     # Use git describe to find the version based on tags.
-    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
+    # --always would show the unique abbr commit as fallback.
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --always --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
       # if current commit is not on a certain tag
       if ! git describe --tags --exact-match >/dev/null 2>&1 ; then
         # GIT_VERSION=gitBranch-gitCommitHash


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

close #2659 

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

- with step `action/checkout@master`, setup `fetch-depth: 0` to fetch all the tags and branches
- setup `--always` with `git describe`, it would give the commit hash as fallback instead of fatal then nothing be set with `GIT_VERSION`. 

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [x] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

I manually tested it at https://github.com/STRRL/chaos-mesh/actions/workflows/fix_git_version.yml.

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
Signed-off-by: STRRL <str_ruiling@outlook.com>