### PR TITLE
cherry-pick logging updates into release-2.1

### DIFF
--- a/cmd/chaos-controller-manager/main.go
+++ b/cmd/chaos-controller-manager/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	stdlog "log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -31,7 +32,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -44,6 +44,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"
 	"github.com/chaos-mesh/chaos-mesh/pkg/ctrlserver"
 	grpcUtils "github.com/chaos-mesh/chaos-mesh/pkg/grpc"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector"
 	"github.com/chaos-mesh/chaos-mesh/pkg/version"
@@ -68,11 +69,20 @@ func main() {
 		os.Exit(0)
 	}
 
+	rootLogger, err := log.NewDefaultZapLogger()
+	if err != nil {
+		stdlog.Fatal("failed to create root logger", err)
+	}
+	log.ReplaceGlobals(rootLogger)
+	ctrl.SetLogger(rootLogger)
+
 	// set RPCTimeout config
 	grpcUtils.RPCTimeout = ccfg.ControllerCfg.RPCTimeout
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
 	app := fx.New(
+		fx.Logger(log.NewLogrPrinter(rootLogger.WithName("fx"))),
+		fx.Supply(controllermetrics.Registry),
+		fx.Supply(rootLogger),
+		fx.Provide(metrics.NewChaosControllerManagerMetricsCollector),
 		fx.Options(
 			provider.Module,
 			controllers.Module,

--- a/cmd/chaos-controller-manager/provider/controller.go
+++ b/cmd/chaos-controller-manager/provider/controller.go
@@ -132,10 +132,6 @@ func NewClient(mgr ctrl.Manager, scheme *runtime.Scheme) (client.Client, error) 
 	}, nil
 }
 
-func NewLogger() logr.Logger {
-	return ctrl.Log
-}
-
 type noCacheReader struct {
 	fx.Out
 
@@ -213,12 +209,12 @@ func NewClientSet(config *rest.Config) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
+// Module would provide objects to fx for dependency injection.
 var Module = fx.Provide(
 	NewOption,
 	NewClient,
 	NewClientSet,
 	NewManager,
-	NewLogger,
 	NewAuthCli,
 	NewScheme,
 	NewConfig,

--- a/cmd/chaos-controller-manager/provider/suit_test.go
+++ b/cmd/chaos-controller-manager/provider/suit_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test/manager"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -77,14 +78,17 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
+	rootLogger, err := log.NewDefaultZapLogger()
+	Expect(err).ToNot(HaveOccurred())
+
 	app = fx.New(
 		fx.Options(
 			fx.Supply(cfg),
+			fx.Supply(rootLogger),
 			fx.Provide(
 				NewOption,
 				NewClient,
 				manager.NewTestManager,
-				NewLogger,
 				NewAuthCli,
 				NewScheme,
 			),

--- a/controllers/common/suit_test.go
+++ b/controllers/common/suit_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/schedule/utils"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector"
 )
 
@@ -89,9 +90,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
+	rootLogger, err := log.NewDefaultZapLogger()
+	Expect(err).ToNot(HaveOccurred())
 	By("start application")
 	app = fx.New(
 		fx.Options(
+			fx.Supply(rootLogger),
 			test.Module,
 			chaosimpl.AllImpl,
 			selector.Module,

--- a/controllers/schedule/suit_test.go
+++ b/controllers/schedule/suit_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/controllers/types"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/workflow/controllers"
 )
 
@@ -85,8 +86,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
+	rootLogger, err := log.NewDefaultZapLogger()
+	Expect(err).ToNot(HaveOccurred())
+
 	app = fx.New(
 		fx.Options(
+			fx.Supply(rootLogger),
 			test.Module,
 			fx.Supply(config),
 			Module,

--- a/pkg/log/doc.go
+++ b/pkg/log/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Chaos Mesh Authors.
+// Copyright 2022 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,24 +13,8 @@
 // limitations under the License.
 //
 
-package test
-
-import (
-	"go.uber.org/fx"
-
-	"github.com/chaos-mesh/chaos-mesh/cmd/chaos-controller-manager/provider"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test/manager"
-)
-
-var Module = fx.Provide(
-	provider.NewOption,
-	provider.NewClient,
-	provider.NewAuthCli,
-	provider.NewScheme,
-	provider.NewNoCacheReader,
-	provider.NewGlobalCacheReader,
-	provider.NewControlPlaneCacheReader,
-	manager.NewTestManager,
-	recorder.NewRecorderBuilder,
-)
+// Package log contains series of utilities for setting up and accessing logger.
+// We use logr.Logger as the facade of each logger.
+//
+// See https://github.com/chaos-mesh/rfcs/blob/main/text/2021-12-09-logging.md for more details.
+package log

--- a/pkg/log/fx_logger.go
+++ b/pkg/log/fx_logger.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package log
 

--- a/pkg/log/fx_logger.go
+++ b/pkg/log/fx_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Chaos Mesh Authors.
+// Copyright 2022 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,26 +11,27 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
-package test
+package log
 
 import (
-	"go.uber.org/fx"
+	"fmt"
 
-	"github.com/chaos-mesh/chaos-mesh/cmd/chaos-controller-manager/provider"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/recorder"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test/manager"
+	"github.com/go-logr/logr"
 )
 
-var Module = fx.Provide(
-	provider.NewOption,
-	provider.NewClient,
-	provider.NewAuthCli,
-	provider.NewScheme,
-	provider.NewNoCacheReader,
-	provider.NewGlobalCacheReader,
-	provider.NewControlPlaneCacheReader,
-	manager.NewTestManager,
-	recorder.NewRecorderBuilder,
-)
+type LogrPrinter struct {
+	logger logr.Logger
+}
+
+func NewLogrPrinter(logger logr.Logger) *LogrPrinter {
+	return &LogrPrinter{logger: logger}
+}
+
+func (it *LogrPrinter) Printf(s string, i ...interface{}) {
+	it.logger.
+		// Here are 2 level wrapper for this logger, one is LogrPrinter, another is fxlog.Logger,
+		// so we use 2 here. It's a little tricky but would make fx logging better.
+		WithCallDepth(2).
+		Info(fmt.Sprintf(s, i...))
+}

--- a/pkg/log/global_logger.go
+++ b/pkg/log/global_logger.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package log
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// the way for management and access global logger is referenced from zap.
+var (
+	globalMu     sync.RWMutex
+	globalLogger = logr.Discard()
+)
+
+// L is the way to access the global logger. You could use it if there are no logger in your code context. Please notice
+// that the default value of "global logger" is a "discard logger" which means that all logs will be ignored. Make sure
+// that initialize the global logger by ReplaceGlobals before using it, for example, calling ReplaceGlobals at the beginning
+// of your main function.
+//
+// Do NOT save the global logger to a variable for long-term using, because it is possible that the global logger is
+// replaced by another. Keep calling L at each time.
+//
+// Deprecated: Do not use global logger anymore. For more detail, see
+// https://github.com/chaos-mesh/rfcs/blob/main/text/2021-12-09-logging.md#global-logger
+func L() logr.Logger {
+	globalMu.RLock()
+	result := globalLogger
+	globalMu.RUnlock()
+	return result
+}
+
+// ReplaceGlobals would replace the global logger with the given logger. It should be used when your application starting.
+//
+// Deprecated: Do not use global logger anymore. For more detail, see
+// https://github.com/chaos-mesh/rfcs/blob/main/text/2021-12-09-logging.md#global-logger
+func ReplaceGlobals(logger logr.Logger) {
+	globalMu.Lock()
+	globalLogger = logger
+	globalMu.Unlock()
+}

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+// NewDefaultZapLogger is the recommended way to create a new logger, you could call this function to initialize the root
+// logger of your application, and provide it to your components, by fx or manually.
+func NewDefaultZapLogger() (logr.Logger, error) {
+	// change the configuration in the future if needed.
+	zapLogger, err := zap.NewDevelopment()
+	if err != nil {
+		return logr.Discard(), err
+	}
+	logger := zapr.NewLogger(zapLogger)
+	return logger, nil
+}

--- a/pkg/workflow/controllers/suite_test.go
+++ b/pkg/workflow/controllers/suite_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/types"
 	"github.com/chaos-mesh/chaos-mesh/controllers/utils/test"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 )
 
 var app *fx.App
@@ -79,8 +80,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(kubeClient).ToNot(BeNil())
 
+	rootLogger, err := log.NewDefaultZapLogger()
+	Expect(err).ToNot(HaveOccurred())
+
 	app = fx.New(
 		fx.Options(
+			fx.Supply(rootLogger),
 			test.Module,
 			fx.Supply(restConfig),
 			types.ChaosObjects,


### PR DESCRIPTION

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

it is a part of https://github.com/chaos-mesh/chaos-mesh/issues/2969

### What's changed and how it works?

- cherry pick #2808 into release-2.1

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [x] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
