### PR TITLE
chaos-dashboard: use pkg log instead of controller-runtime log (#2973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix default value for concurrencyPolicy [#2836](https://github.com/chaos-mesh/chaos-mesh/pull/2836)
 - Fix PhysicalMachineChaos to make it able to create network bandwidth experiment. [#2850](https://github.com/chaos-mesh/chaos-mesh/pull/2850)
 - Fix workflow emit new events after accomplished [#2911](https://github.com/chaos-mesh/chaos-mesh/pull/2911)
+- Fix human unreadable logging timestamp [#2970](https://github.com/chaos-mesh/chaos-mesh/pull/2970) [#2973](https://github.com/chaos-mesh/chaos-mesh/pull/2973)
 
 ### Security
 

--- a/cmd/chaos-dashboard/main.go
+++ b/cmd/chaos-dashboard/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	stdlog "log"
 	"os"
 
 	"go.uber.org/fx"
@@ -29,17 +30,15 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	config "github.com/chaos-mesh/chaos-mesh/pkg/config/dashboard"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/apiserver"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/collector"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/store"
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/ttlcontroller"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/version"
 )
-
-var log = ctrl.Log.WithName("chaos-dashboard")
 
 // @title Chaos Mesh Dashboard API
 // @version 2.0
@@ -63,8 +62,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	mainLog := log.WithName("main")
+	rootLogger, err := log.NewDefaultZapLogger()
+	if err != nil {
+		stdlog.Fatal("failed to create root logger", err)
+	}
+
+	ctrl.SetLogger(rootLogger)
+	mainLog := rootLogger.WithName("main")
 
 	dashboardConfig, err := config.GetChaosDashboardEnv()
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

This PR is ready for review

It's a part of https://github.com/chaos-mesh/chaos-mesh/issues/2969;

### What's changed and how it works?

- use pkg/log instead of controller-runtime zap to initialize the root logger in chaos-dashboard

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
