### PR TITLE
fix wrong zero value of httpchaos replace body action

### DIFF
--- a/e2e-test/e2e/chaos/basic.go
+++ b/e2e-test/e2e/chaos/basic.go
@@ -300,6 +300,16 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			})
 		})
 
+		// http chaos case in [HTTPReplaceBody] context
+		ginkgo.Context("[HTTPReplaceBody]", func() {
+			ginkgo.It("[Schedule]", func() {
+				httpchaostestcases.TestcaseHttpReplaceBodyThenRecover(ns, cli, client, port)
+			})
+			ginkgo.It("[Pause]", func() {
+				httpchaostestcases.TestcaseHttpReplaceBodyPauseAndUnPause(ns, cli, client, port)
+			})
+		})
+
 		// http chaos case in [HTTPPatch] context
 		ginkgo.Context("[HTTPPatch]", func() {
 			ginkgo.It("[Schedule]", func() {

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -46,6 +46,348 @@ func TestcaseHttpReplaceThenRecover(
 	err := util.WaitHTTPE2EHelperReady(*c.C, c.IP, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http replace chaos CRD objects")
+	replaceSecret := "Foo!"
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+						Namespaces:     []string{ns},
+						LabelSelectors: map[string]string{"app": "http"},
+					},
+				},
+				Mode: v1alpha1.OneMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Replace: &v1alpha1.PodHttpChaosReplaceActions{
+					Headers: map[string]string{
+						SECRET: replaceSecret,
+					},
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	By("waiting for assertion HTTP replace")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+	By("apply http chaos successfully")
+
+	By("delete chaos CRD objects")
+	// delete chaos CRD
+	err = cli.Delete(ctx, httpChaos)
+	framework.ExpectNoError(err, "failed to delete http chaos")
+
+	By("waiting for assertion recovering")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+}
+
+func TestcaseHttpReplacePauseAndUnPause(
+	ns string,
+	cli client.Client,
+	c HTTPE2EClient,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitHTTPE2EHelperReady(*c.C, c.IP, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
+	secret := "Bar"
+
+	By("waiting for assertion normal behaviour")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "helper server doesn't work as expected")
+	By("deploy helper server successfully")
+
+	By("create http replace chaos CRD objects")
+	replaceSecret := "Foo!"
+
+	httpChaos := &v1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-chaos",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.HTTPChaosSpec{
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+						Namespaces:     []string{ns},
+						LabelSelectors: map[string]string{"app": "http"},
+					},
+				},
+				Mode: v1alpha1.OneMode,
+			},
+			Port:   8080,
+			Target: "Request",
+			PodHttpChaosActions: v1alpha1.PodHttpChaosActions{
+				Replace: &v1alpha1.PodHttpChaosReplaceActions{
+					Headers: map[string]string{
+						SECRET: replaceSecret,
+					},
+				},
+			},
+		},
+	}
+	err = cli.Create(ctx, httpChaos)
+	framework.ExpectNoError(err, "create http chaos error")
+
+	chaosKey := types.NamespacedName{
+		Namespace: ns,
+		Name:      "http-chaos",
+	}
+
+	By("waiting for assertion http chaos")
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "http chaos doesn't work as expected")
+
+	By("pause http replace chaos experiment")
+	// pause experiment
+	err = util.PauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "pause chaos error")
+
+	By("waiting for assertion about pause")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllRecovered {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check paused chaos failed")
+
+	// wait 1 min to check whether io replace still exists
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == secret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "fail to recover http chaos")
+	By("resume http replace chaos experiment")
+	// resume experiment
+	err = util.UnPauseChaos(ctx, cli, httpChaos)
+	framework.ExpectNoError(err, "resume chaos error")
+
+	By("assert that http replace is effective again")
+	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		chaos := &v1alpha1.HTTPChaos{}
+		err = cli.Get(ctx, chaosKey, chaos)
+		framework.ExpectNoError(err, "get http chaos error")
+
+		for _, c := range chaos.GetStatus().Conditions {
+			if c.Type == v1alpha1.ConditionAllInjected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			} else if c.Type == v1alpha1.ConditionSelected {
+				if c.Status != corev1.ConditionTrue {
+					return false, nil
+				}
+			}
+		}
+
+		return true, err
+	})
+	framework.ExpectNoError(err, "check resumed chaos failed")
+
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		resp, err := getPodHttp(c, port, secret, "")
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		s := resp.Header.Get(SECRET)
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+
+		klog.Infof("Status(%d), Secret(%s), Body(%s)", resp.StatusCode, s, string(b))
+
+		if s == replaceSecret {
+			return true, nil
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err, "HTTP chaos doesn't work as expected")
+
+	By("cleanup")
+	// cleanup
+	cli.Delete(ctx, httpChaos)
+}
+
+func TestcaseHttpReplaceBodyThenRecover(
+	ns string,
+	cli client.Client,
+	c HTTPE2EClient,
+	port uint16,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("waiting on e2e helper ready")
+	err := util.WaitHTTPE2EHelperReady(*c.C, c.IP, port)
+	framework.ExpectNoError(err, "wait e2e helper ready error")
+
 	body := "Hello World"
 	secret := "Bar"
 
@@ -160,7 +502,7 @@ func TestcaseHttpReplaceThenRecover(
 	framework.ExpectNoError(err, "fail to recover http chaos")
 }
 
-func TestcaseHttpReplacePauseAndUnPause(
+func TestcaseHttpReplaceBodyPauseAndUnPause(
 	ns string,
 	cli client.Client,
 	c HTTPE2EClient,

--- a/pkg/chaosdaemon/tproxyconfig/config.go
+++ b/pkg/chaosdaemon/tproxyconfig/config.go
@@ -176,7 +176,7 @@ type PodHttpChaosReplaceActions struct {
 
 	// Body is a rule to replace http message body in target.
 	// +optional
-	Body PodHttpChaosReplaceBody `json:"body,omitempty"`
+	Body *PodHttpChaosReplaceBody `json:"body,omitempty"`
 
 	// Queries is a rule to replace uri queries in http request.
 	// For example, with value `{ "foo": "unknown" }`, the `/?foo=bar` will be altered to `/?foo=unknown`,


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #2988

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Replace field [Body](https://github.com/chaos-mesh/chaos-mesh/blob/5005201fdab583f46bef71c2e9e536f6766cc7b6/pkg/chaosdaemon/tproxyconfig/config.go#L179) of PodHttpChaosReplaceActions with a pointer.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [x] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
