### PR TITLE
refactor: move GetService out of package pod selector

### DIFF
--- a/pkg/selector/pod/selector.go
+++ b/pkg/selector/pod/selector.go
@@ -198,25 +198,6 @@ func selectSpecifiedPods(ctx context.Context, c client.Client, spec v1alpha1.Pod
 
 //revive:enable:flag-parameter
 
-// GetService get k8s service by service name
-func GetService(ctx context.Context, c client.Client, namespace, controllerNamespace string, serviceName string) (*v1.Service, error) {
-	// use the environment value if namespace is empty
-	if len(namespace) == 0 {
-		namespace = controllerNamespace
-	}
-
-	service := &v1.Service{}
-	err := c.Get(ctx, client.ObjectKey{
-		Namespace: namespace,
-		Name:      serviceName,
-	}, service)
-	if err != nil {
-		return nil, err
-	}
-
-	return service, nil
-}
-
 // CheckPodMeetSelector checks if this pod meets the selection criteria.
 func CheckPodMeetSelector(ctx context.Context, c client.Client, pod v1.Pod, selector v1alpha1.PodSelectorSpec, clusterScoped bool, targetNamespace string, enableFilterNamespace bool) (bool, error) {
 	if len(selector.Pods) > 0 {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Refactoring `pkg/selector/pod`, move `GetService` near to DNSChaos implementation, make it unexported, and remove the unused parameter

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

It could be compiled with no error.

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
