### PR TITLE
refactor(pkg/selector/pod): extract methods into struct LegacyPodSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - CI: version unrelated manifests [#3293](https://github.com/chaos-mesh/chaos-mesh/pull/3293)
 - Bump chaos-tproxy to v0.4.6 [#3272](https://github.com/chaos-mesh/chaos-mesh/pull/3272)
 - Helm charts: using 0.0.0 as version and appVersion [#3311](https://github.com/chaos-mesh/chaos-mesh/pull/3311)
+- Refactor(pkg/selector/pod): extract methods into struct LegacyPodSelector [#3006](https://github.com/chaos-mesh/chaos-mesh/pull/3006)
 
 ### Deprecated
 

--- a/pkg/ctrl/server/k8s-utils.go
+++ b/pkg/ctrl/server/k8s-utils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	ctrlconfig "github.com/chaos-mesh/chaos-mesh/controllers/config"
 	"github.com/chaos-mesh/chaos-mesh/pkg/ctrl/server/model"
-	"github.com/chaos-mesh/chaos-mesh/pkg/selector/pod"
+	podselector "github.com/chaos-mesh/chaos-mesh/pkg/selector/pod"
 )
 
 const DefaultNamespace = "default"
@@ -61,7 +61,8 @@ func parseNamespacedName(namespacedName string) types.NamespacedName {
 
 // GetPods returns pod list and corresponding chaos daemon
 func GetPods(ctx context.Context, status v1alpha1.ChaosStatus, selectorSpec v1alpha1.PodSelectorSpec, c client.Client) ([]v1.Pod, []v1.Pod, error) {
-	pods, err := pod.SelectPods(ctx, c, c, selectorSpec, ctrlconfig.ControllerCfg.ClusterScoped, ctrlconfig.ControllerCfg.TargetNamespace, false)
+	legacyPodSelector := podselector.NewLegacyPodSelector(c, c, ctrlconfig.ControllerCfg.ClusterScoped, ctrlconfig.ControllerCfg.TargetNamespace, false)
+	pods, err := legacyPodSelector.SelectPods(ctx, selectorSpec)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to SelectPods")
 	}

--- a/pkg/dashboard/apiserver/common/common.go
+++ b/pkg/dashboard/apiserver/common/common.go
@@ -175,7 +175,8 @@ func (s *Service) listPods(c *gin.Context) {
 		return
 	}
 	ctx := context.TODO()
-	filteredPods, err := pod.SelectPods(ctx, kubeCli, nil, selector, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
@@ -303,7 +304,8 @@ func (s *Service) getLabels(c *gin.Context) {
 	selector.Namespaces = nsList
 
 	ctx := context.TODO()
-	filteredPods, err := pod.SelectPods(ctx, kubeCli, nil, selector, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))
@@ -355,7 +357,8 @@ func (s *Service) getAnnotations(c *gin.Context) {
 	selector.Namespaces = nsList
 
 	ctx := context.TODO()
-	filteredPods, err := pod.SelectPods(ctx, kubeCli, nil, selector, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		_ = c.Error(utils.ErrInternalServer.WrapWithNoMessage(err))

--- a/pkg/dashboard/apiserver/common/common.go
+++ b/pkg/dashboard/apiserver/common/common.go
@@ -175,7 +175,7 @@ func (s *Service) listPods(c *gin.Context) {
 		return
 	}
 	ctx := context.TODO()
-	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, nil, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
 	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
@@ -304,7 +304,7 @@ func (s *Service) getLabels(c *gin.Context) {
 	selector.Namespaces = nsList
 
 	ctx := context.TODO()
-	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, nil, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
 	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
@@ -357,7 +357,7 @@ func (s *Service) getAnnotations(c *gin.Context) {
 	selector.Namespaces = nsList
 
 	ctx := context.TODO()
-	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, kubeCli, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
+	legacyPodSelector := pod.NewLegacyPodSelector(kubeCli, nil, s.conf.ClusterScoped, s.conf.TargetNamespace, s.conf.EnableFilterNamespace)
 	filteredPods, err := legacyPodSelector.SelectPods(ctx, selector)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)

--- a/pkg/selector/pod/legacy.go
+++ b/pkg/selector/pod/legacy.go
@@ -1,0 +1,252 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package pod
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
+	genericnamespace "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/namespace"
+	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/registry"
+)
+
+// LegacyPodSelector is the temporary place to hold the legacy logic for selecting then filtering the Pod.
+type LegacyPodSelector struct {
+	// c is the kubernetes client which we usually use.
+	c client.Client
+	// r is actually the kubernetes client without indexing and caching, only used/required with fieldSelector.
+	r client.Reader
+	// clusterScoped means selector from all namespace.
+	clusterScoped bool
+	// targetNamespace means select from this namespace, only work with clusterScoped is true.
+	targetNamespace string
+	// enableFilterNamespace means select only from namespace annotated with generic.InjectAnnotationKey.
+	enableFilterNamespace bool
+}
+
+func NewLegacyPodSelector(c client.Client, r client.Reader, clusterScoped bool, targetNamespace string, enableFilterNamespace bool) *LegacyPodSelector {
+	return &LegacyPodSelector{c: c, r: r, clusterScoped: clusterScoped, targetNamespace: targetNamespace, enableFilterNamespace: enableFilterNamespace}
+}
+
+// SelectAndFilterPods returns the list of pods that filtered by selector and SelectorMode
+// Deprecated: use pod.SelectImpl as instead
+func (lps *LegacyPodSelector) SelectAndFilterPods(ctx context.Context, spec *v1alpha1.PodSelector) ([]v1.Pod, error) {
+	if pods := mock.On("MockSelectAndFilterPods"); pods != nil {
+		return pods.(func() []v1.Pod)(), nil
+	}
+	if err := mock.On("MockSelectedAndFilterPodsError"); err != nil {
+		return nil, err.(error)
+	}
+
+	selector := spec.Selector
+	mode := spec.Mode
+	value := spec.Value
+
+	pods, err := lps.SelectPods(ctx, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pods) == 0 {
+		err = errors.New("no pod is selected")
+		return nil, err
+	}
+
+	filteredPod, err := lps.filterPodsByMode(pods, mode, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return filteredPod, nil
+}
+
+//revive:disable:flag-parameter
+
+// SelectPods returns the list of pods that are available for pod chaos action.
+// It returns all pods that match the configured label, annotation and namespace selectors.
+// If pods are specifically specified by `selector.Pods`, it just returns the selector.Pods.
+//
+// Deprecated: try to avoid using this method. Only use it until you REALLY need the all possible pods before filtering.
+// For example, frontend hint for previewing/selecting pods.
+func (lps *LegacyPodSelector) SelectPods(ctx context.Context, selector v1alpha1.PodSelectorSpec) ([]v1.Pod, error) {
+	// pods are specifically specified
+	if len(selector.Pods) > 0 {
+		return lps.selectSpecifiedPods(ctx, selector)
+	}
+
+	selectorRegistry := newSelectorRegistry(ctx, lps.c, selector)
+	selectorChain, err := registry.Parse(selectorRegistry, selector.GenericSelectorSpec, generic.Option{
+		ClusterScoped:         lps.clusterScoped,
+		TargetNamespace:       lps.targetNamespace,
+		EnableFilterNamespace: lps.enableFilterNamespace,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lps.listPods(ctx, selector, selectorChain)
+}
+
+// CheckPodMeetSelector checks if this pod meets the selection criteria.
+func (lps *LegacyPodSelector) CheckPodMeetSelector(ctx context.Context, pod v1.Pod, selector v1alpha1.PodSelectorSpec) (bool, error) {
+	if len(selector.Pods) > 0 {
+		meet := false
+		for ns, names := range selector.Pods {
+			if pod.Namespace != ns {
+				continue
+			}
+
+			for _, name := range names {
+				if pod.Name == name {
+					meet = true
+				}
+			}
+
+			if !meet {
+				return false, nil
+			}
+		}
+	}
+
+	selectorRegistry := newSelectorRegistry(ctx, lps.c, selector)
+	selectorChain, err := registry.Parse(selectorRegistry, selector.GenericSelectorSpec, generic.Option{
+		ClusterScoped:         lps.clusterScoped,
+		TargetNamespace:       lps.targetNamespace,
+		EnableFilterNamespace: lps.enableFilterNamespace,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return selectorChain.Match(&pod), nil
+}
+
+func (lps *LegacyPodSelector) selectSpecifiedPods(ctx context.Context, spec v1alpha1.PodSelectorSpec) ([]v1.Pod, error) {
+	var pods []v1.Pod
+	namespaceCheck := make(map[string]bool)
+
+	for ns, names := range spec.Pods {
+		if !lps.clusterScoped {
+			if lps.targetNamespace != ns {
+				log.Info("skip namespace because ns is out of scope within namespace scoped mode", "namespace", ns)
+				continue
+			}
+		}
+
+		if lps.enableFilterNamespace {
+			allow, ok := namespaceCheck[ns]
+			if !ok {
+				allow = genericnamespace.CheckNamespace(ctx, lps.c, ns, log)
+				namespaceCheck[ns] = allow
+			}
+			if !allow {
+				continue
+			}
+		}
+		for _, name := range names {
+			var pod v1.Pod
+			err := lps.c.Get(ctx, types.NamespacedName{
+				Namespace: ns,
+				Name:      name,
+			}, &pod)
+			if err == nil {
+				pods = append(pods, pod)
+				continue
+			}
+
+			if apierrors.IsNotFound(err) {
+				log.Error(err, "Pod is not found", "namespace", ns, "pod name", name)
+				continue
+			}
+
+			return nil, err
+		}
+	}
+	return pods, nil
+}
+
+func (lps *LegacyPodSelector) listPods(ctx context.Context, spec v1alpha1.PodSelectorSpec,
+	selectorChain generic.SelectorChain) ([]v1.Pod, error) {
+	var pods []v1.Pod
+	namespaceCheck := make(map[string]bool)
+
+	if err := selectorChain.ListObjects(lps.c, lps.r,
+		func(listFunc generic.ListFunc, opts client.ListOptions) error {
+			var podList v1.PodList
+			if len(spec.Namespaces) > 0 {
+				for _, namespace := range spec.Namespaces {
+					if lps.enableFilterNamespace {
+						allow, ok := namespaceCheck[namespace]
+						if !ok {
+							allow = genericnamespace.CheckNamespace(ctx, lps.c, namespace, log)
+							namespaceCheck[namespace] = allow
+						}
+						if !allow {
+							continue
+						}
+					}
+
+					opts.Namespace = namespace
+					if err := listFunc(ctx, &podList, &opts); err != nil {
+						return err
+					}
+					pods = append(pods, podList.Items...)
+				}
+			} else {
+				// in fact, this will never happen
+				if err := listFunc(ctx, &podList, &opts); err != nil {
+					return err
+				}
+				pods = append(pods, podList.Items...)
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+
+	filterPods := make([]v1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		pod := pod
+		if selectorChain.Match(&pod) {
+			filterPods = append(filterPods, pod)
+		}
+	}
+	return filterPods, nil
+}
+
+// filterPodsByMode filters pods by mode from pod list
+func (lps *LegacyPodSelector) filterPodsByMode(pods []v1.Pod, mode v1alpha1.SelectorMode, value string) ([]v1.Pod, error) {
+	indexes, err := generic.FilterObjectsByMode(mode, value, len(pods))
+	if err != nil {
+		return nil, err
+	}
+
+	var filteredPods []v1.Pod
+
+	for _, index := range indexes {
+		index := index
+		filteredPods = append(filteredPods, pods[index])
+	}
+	return filteredPods, nil
+}

--- a/pkg/selector/pod/selector.go
+++ b/pkg/selector/pod/selector.go
@@ -21,14 +21,12 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/config"
-	"github.com/chaos-mesh/chaos-mesh/pkg/log"
-	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic"
 	genericannotation "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/annotation"
 	genericfield "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/field"
@@ -36,6 +34,8 @@ import (
 	genericnamespace "github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/namespace"
 	"github.com/chaos-mesh/chaos-mesh/pkg/selector/generic/registry"
 )
+
+var log = ctrl.Log.WithName("pod-selector")
 
 var ErrNoPodSelected = errors.New("no pod is selected")
 
@@ -61,8 +61,8 @@ func (impl *SelectImpl) Select(ctx context.Context, ps *v1alpha1.PodSelector) ([
 	if ps == nil {
 		return []*Pod{}, nil
 	}
-
-	pods, err := SelectAndFilterPods(ctx, impl.c, impl.r, ps, impl.ClusterScoped, impl.TargetNamespace, impl.EnableFilterNamespace)
+	legacyPodSelector := NewLegacyPodSelector(impl.c, impl.r, impl.ClusterScoped, impl.TargetNamespace, impl.EnableFilterNamespace)
+	pods, err := legacyPodSelector.SelectAndFilterPods(ctx, ps)
 	if err != nil {
 		return nil, err
 	}
@@ -97,143 +97,25 @@ func New(params Params) *SelectImpl {
 	}
 }
 
-// SelectAndFilterPods returns the list of pods that filtered by selector and SelectorMode
-// Deprecated: use pod.SelectImpl as instead
-func SelectAndFilterPods(ctx context.Context, c client.Client, r client.Reader, spec *v1alpha1.PodSelector, clusterScoped bool, targetNamespace string, enableFilterNamespace bool) ([]v1.Pod, error) {
-	if pods := mock.On("MockSelectAndFilterPods"); pods != nil {
-		return pods.(func() []v1.Pod)(), nil
-	}
-	if err := mock.On("MockSelectedAndFilterPodsError"); err != nil {
-		return nil, err.(error)
-	}
-
-	selector := spec.Selector
-	mode := spec.Mode
-	value := spec.Value
-
-	pods, err := SelectPods(ctx, c, r, selector, clusterScoped, targetNamespace, enableFilterNamespace)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(pods) == 0 {
-		return nil, ErrNoPodSelected
-	}
-
-	filteredPod, err := filterPodsByMode(pods, mode, value)
-	if err != nil {
-		return nil, err
-	}
-
-	return filteredPod, nil
-}
-
-//revive:disable:flag-parameter
-
-// SelectPods returns the list of pods that are available for pod chaos action.
-// It returns all pods that match the configured label, annotation and namespace selectors.
-// If pods are specifically specified by `selector.Pods`, it just returns the selector.Pods.
-func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector v1alpha1.PodSelectorSpec, clusterScoped bool, targetNamespace string, enableFilterNamespace bool) ([]v1.Pod, error) {
-	// pods are specifically specified
-	if len(selector.Pods) > 0 {
-		return selectSpecifiedPods(ctx, c, selector, clusterScoped, targetNamespace, enableFilterNamespace)
-	}
-
-	selectorRegistry := newSelectorRegistry(ctx, c, selector)
-	selectorChain, err := registry.Parse(selectorRegistry, selector.GenericSelectorSpec, generic.Option{
-		ClusterScoped:         clusterScoped,
-		TargetNamespace:       targetNamespace,
-		EnableFilterNamespace: enableFilterNamespace,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return listPods(ctx, c, r, selector, selectorChain, enableFilterNamespace)
-}
-
-func selectSpecifiedPods(ctx context.Context, c client.Client, spec v1alpha1.PodSelectorSpec,
-	clusterScoped bool, targetNamespace string, enableFilterNamespace bool) ([]v1.Pod, error) {
-	var pods []v1.Pod
-	namespaceCheck := make(map[string]bool)
-	logger, err := log.NewDefaultZapLogger()
-	if err != nil {
-		return pods, errors.Wrap(err, "failed to create logger")
-	}
-	for ns, names := range spec.Pods {
-		if !clusterScoped {
-			if targetNamespace != ns {
-				log.L().WithName("pod-selector").Info("skip namespace because ns is out of scope within namespace scoped mode", "namespace", ns)
-				continue
-			}
-		}
-
-		if enableFilterNamespace {
-			allow, ok := namespaceCheck[ns]
-			if !ok {
-				allow = genericnamespace.CheckNamespace(ctx, c, ns, logger)
-				namespaceCheck[ns] = allow
-			}
-			if !allow {
-				continue
-			}
-		}
-		for _, name := range names {
-			var pod v1.Pod
-			err := c.Get(ctx, types.NamespacedName{
-				Namespace: ns,
-				Name:      name,
-			}, &pod)
-			if err == nil {
-				pods = append(pods, pod)
-				continue
-			}
-
-			if apierrors.IsNotFound(err) {
-				log.L().WithName("pod-selector").Info("pod is not found, skip it", "namespace", ns, "pod name", name)
-				continue
-			}
-
-			return nil, err
-		}
-	}
-	return pods, nil
-}
-
 //revive:enable:flag-parameter
 
-// CheckPodMeetSelector checks if this pod meets the selection criteria.
-func CheckPodMeetSelector(ctx context.Context, c client.Client, pod v1.Pod, selector v1alpha1.PodSelectorSpec, clusterScoped bool, targetNamespace string, enableFilterNamespace bool) (bool, error) {
-	if len(selector.Pods) > 0 {
-		meet := false
-		for ns, names := range selector.Pods {
-			if pod.Namespace != ns {
-				continue
-			}
-
-			for _, name := range names {
-				if pod.Name == name {
-					meet = true
-				}
-			}
-
-			if !meet {
-				return false, nil
-			}
-		}
+// GetService get k8s service by service name
+func GetService(ctx context.Context, c client.Client, namespace, controllerNamespace string, serviceName string) (*v1.Service, error) {
+	// use the environment value if namespace is empty
+	if len(namespace) == 0 {
+		namespace = controllerNamespace
 	}
 
-	selectorRegistry := newSelectorRegistry(ctx, c, selector)
-	selectorChain, err := registry.Parse(selectorRegistry, selector.GenericSelectorSpec, generic.Option{
-		ClusterScoped:         clusterScoped,
-		TargetNamespace:       targetNamespace,
-		EnableFilterNamespace: enableFilterNamespace,
-	})
+	service := &v1.Service{}
+	err := c.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      serviceName,
+	}, service)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return selectorChain.Match(&pod), nil
+	return service, nil
 }
 
 func newSelectorRegistry(ctx context.Context, c client.Client, spec v1alpha1.PodSelectorSpec) registry.Registry {
@@ -249,72 +131,4 @@ func newSelectorRegistry(ctx context.Context, c client.Client, spec v1alpha1.Pod
 			return newPhaseSelector(spec)
 		},
 	}
-}
-
-func listPods(ctx context.Context, c client.Client, r client.Reader, spec v1alpha1.PodSelectorSpec,
-	selectorChain generic.SelectorChain, enableFilterNamespace bool) ([]v1.Pod, error) {
-	var pods []v1.Pod
-	namespaceCheck := make(map[string]bool)
-	logger, err := log.NewDefaultZapLogger()
-	if err != nil {
-		return pods, errors.Wrap(err, "failed to create logger")
-	}
-	if err := selectorChain.ListObjects(c, r,
-		func(listFunc generic.ListFunc, opts client.ListOptions) error {
-			var podList v1.PodList
-			if len(spec.Namespaces) > 0 {
-				for _, namespace := range spec.Namespaces {
-					if enableFilterNamespace {
-						allow, ok := namespaceCheck[namespace]
-						if !ok {
-							allow = genericnamespace.CheckNamespace(ctx, c, namespace, logger)
-							namespaceCheck[namespace] = allow
-						}
-						if !allow {
-							continue
-						}
-					}
-
-					opts.Namespace = namespace
-					if err := listFunc(ctx, &podList, &opts); err != nil {
-						return err
-					}
-					pods = append(pods, podList.Items...)
-				}
-			} else {
-				// in fact, this will never happen
-				if err := listFunc(ctx, &podList, &opts); err != nil {
-					return err
-				}
-				pods = append(pods, podList.Items...)
-			}
-			return nil
-		}); err != nil {
-		return nil, err
-	}
-
-	filterPods := make([]v1.Pod, 0, len(pods))
-	for _, pod := range pods {
-		pod := pod
-		if selectorChain.Match(&pod) {
-			filterPods = append(filterPods, pod)
-		}
-	}
-	return filterPods, nil
-}
-
-// filterPodsByMode filters pods by mode from pod list
-func filterPodsByMode(pods []v1.Pod, mode v1alpha1.SelectorMode, value string) ([]v1.Pod, error) {
-	indexes, err := generic.FilterObjectsByMode(mode, value, len(pods))
-	if err != nil {
-		return nil, err
-	}
-
-	var filteredPods []v1.Pod
-
-	for _, index := range indexes {
-		index := index
-		filteredPods = append(filteredPods, pods[index])
-	}
-	return filteredPods, nil
 }

--- a/pkg/selector/pod/selector.go
+++ b/pkg/selector/pod/selector.go
@@ -88,6 +88,7 @@ func New(params Params) *SelectImpl {
 	return &SelectImpl{
 		params.Client,
 		params.Reader,
+		// TODO: remove this reference to global values
 		generic.Option{
 			ClusterScoped:         config.ControllerCfg.ClusterScoped,
 			TargetNamespace:       config.ControllerCfg.TargetNamespace,

--- a/pkg/selector/pod/selector_test.go
+++ b/pkg/selector/pod/selector_test.go
@@ -159,12 +159,14 @@ func TestSelectPods(t *testing.T) {
 	}
 
 	var (
-		testCfgClusterScoped   = true
-		testCfgTargetNamespace = ""
+		testCfgClusterScoped         = true
+		testCfgTargetNamespace       = ""
+		testCfgEnableFilterNamespace = false
 	)
 
+	legacyPodSelector := NewLegacyPodSelector(c, r, testCfgClusterScoped, testCfgTargetNamespace, testCfgEnableFilterNamespace)
 	for _, tc := range tcs {
-		filteredPods, err := SelectPods(context.Background(), c, r, tc.selector, testCfgClusterScoped, testCfgTargetNamespace, false)
+		filteredPods, err := legacyPodSelector.SelectPods(context.Background(), tc.selector)
 		g.Expect(err).ShouldNot(HaveOccurred(), tc.name)
 		g.Expect(len(filteredPods)).To(Equal(len(tc.expectedPods)), tc.name)
 	}
@@ -429,12 +431,15 @@ func TestCheckPodMeetSelector(t *testing.T) {
 	}
 
 	var (
-		testCfgClusterScoped   = true
-		testCfgTargetNamespace = ""
+		testCfgClusterScoped         = true
+		testCfgTargetNamespace       = ""
+		testCfgEnableFilterNamespace = false
 	)
 
+	legacyPodSelector := NewLegacyPodSelector(c, c, testCfgClusterScoped, testCfgTargetNamespace, testCfgEnableFilterNamespace)
+
 	for _, tc := range tcs {
-		meet, err := CheckPodMeetSelector(context.Background(), c, tc.pod, tc.selector, testCfgClusterScoped, testCfgTargetNamespace, false)
+		meet, err := legacyPodSelector.CheckPodMeetSelector(context.Background(), tc.pod, tc.selector)
 		g.Expect(err).ShouldNot(HaveOccurred(), tc.name)
 		g.Expect(meet).To(Equal(tc.expectedValue), tc.name)
 	}

--- a/pkg/webhook/inject/inject.go
+++ b/pkg/webhook/inject/inject.go
@@ -94,8 +94,8 @@ func Inject(res *v1.AdmissionRequest, cli client.Client, cfg *config.Config, con
 	}
 
 	if injectionConfig.Selector != nil {
-		meet, err := podselector.CheckPodMeetSelector(context.Background(), cli, pod, *injectionConfig.Selector,
-			controllerCfg.ClusterScoped, controllerCfg.TargetNamespace, controllerCfg.EnableFilterNamespace)
+		legacyPodSelector := podselector.NewLegacyPodSelector(cli, cli, controllerCfg.ClusterScoped, controllerCfg.TargetNamespace, controllerCfg.EnableFilterNamespace)
+		meet, err := legacyPodSelector.CheckPodMeetSelector(context.Background(), pod, *injectionConfig.Selector)
 		if err != nil {
 			log.Error(err, "Failed to check pod selector", "namespace", pod.Namespace)
 			return &v1.AdmissionResponse{


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

- make codes in pkg/selector/pod cleaner and easier to read.
- it does not change the logic of the codes

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- `container.SelectImpl` now need a dependency with `pod.SelectImpl` instead of call `pod.SelectAndFilterPods` directlly 
- extract function `SelectAndFilterPods`, `SelectPods`, `CheckPodMeetSelector` and related unexported functions as methods of struct `LegacyPodSelector`

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [x] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
Signed-off-by: STRRL <str_ruiling@outlook.com>