### PR TITLE
cherry-pick: fix default percent field in iochaos (#3018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix PhysicalMachineChaos to make it able to create network bandwidth experiment. [#2850](https://github.com/chaos-mesh/chaos-mesh/pull/2850)
 - Fix workflow emit new events after accomplished [#2911](https://github.com/chaos-mesh/chaos-mesh/pull/2911)
 - Fix human unreadable logging timestamp [#2970](https://github.com/chaos-mesh/chaos-mesh/pull/2970) [#2973](https://github.com/chaos-mesh/chaos-mesh/pull/2973)
+- Fix default value of percent field in iochaos [#3018](https://github.com/chaos-mesh/chaos-mesh/pull/3018)
 
 ### Security
 

--- a/api/v1alpha1/iochaos_types.go
+++ b/api/v1alpha1/iochaos_types.go
@@ -82,6 +82,7 @@ type IOChaosSpec struct {
 	// Percent defines the percentage of injection errors and provides a number from 0-100.
 	// default: 100.
 	// +optional
+	// +kubebuilder:default=100
 	Percent int `json:"percent,omitempty" webhook:"Percent"`
 
 	// VolumePath represents the mount path of injected volume

--- a/config/crd/bases/chaos-mesh.org_iochaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_iochaos.yaml
@@ -190,6 +190,7 @@ spec:
                   action.
                 type: string
               percent:
+                default: 100
                 description: 'Percent defines the percentage of injection errors and
                   provides a number from 0-100. default: 100.'
                 type: integer

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -656,6 +656,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -3122,6 +3123,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'
@@ -5350,6 +5352,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -672,6 +672,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -2749,6 +2750,7 @@ spec:
                           I/O chaos action.
                         type: string
                       percent:
+                        default: 100
                         description: 'Percent defines the percentage of injection
                           errors and provides a number from 0-100. default: 100.'
                         type: integer
@@ -5262,6 +5264,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
@@ -7559,6 +7562,7 @@ spec:
                                         for injecting I/O chaos action.
                                       type: string
                                     percent:
+                                      default: 100
                                       description: 'Percent defines the percentage
                                         of injection errors and provides a number
                                         from 0-100. default: 100.'

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -704,6 +704,7 @@ spec:
                             I/O chaos action.
                           type: string
                         percent:
+                          default: 100
                           description: 'Percent defines the percentage of injection
                             errors and provides a number from 0-100. default: 100.'
                           type: integer
@@ -2863,6 +2864,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'

--- a/helm/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
@@ -190,6 +190,7 @@ spec:
                   action.
                 type: string
               percent:
+                default: 100
                 description: 'Percent defines the percentage of injection errors and
                   provides a number from 0-100. default: 100.'
                 type: integer

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -656,6 +656,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -3122,6 +3123,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'
@@ -5350,6 +5352,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -672,6 +672,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -2749,6 +2750,7 @@ spec:
                           I/O chaos action.
                         type: string
                       percent:
+                        default: 100
                         description: 'Percent defines the percentage of injection
                           errors and provides a number from 0-100. default: 100.'
                         type: integer
@@ -5262,6 +5264,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
@@ -7559,6 +7562,7 @@ spec:
                                         for injecting I/O chaos action.
                                       type: string
                                     percent:
+                                      default: 100
                                       description: 'Percent defines the percentage
                                         of injection errors and provides a number
                                         from 0-100. default: 100.'

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -704,6 +704,7 @@ spec:
                             I/O chaos action.
                           type: string
                         percent:
+                          default: 100
                           description: 'Percent defines the percentage of injection
                             errors and provides a number from 0-100. default: 100.'
                           type: integer
@@ -2863,6 +2864,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1046,6 +1046,7 @@ spec:
                   action.
                 type: string
               percent:
+                default: 100
                 description: 'Percent defines the percentage of injection errors and
                   provides a number from 0-100. default: 100.'
                 type: integer
@@ -4344,6 +4345,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -6810,6 +6812,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'
@@ -9038,6 +9041,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
@@ -15735,6 +15739,7 @@ spec:
                       chaos action.
                     type: string
                   percent:
+                    default: 100
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
@@ -17812,6 +17817,7 @@ spec:
                           I/O chaos action.
                         type: string
                       percent:
+                        default: 100
                         description: 'Percent defines the percentage of injection
                           errors and provides a number from 0-100. default: 100.'
                         type: integer
@@ -20325,6 +20331,7 @@ spec:
                                     injecting I/O chaos action.
                                   type: string
                                 percent:
+                                  default: 100
                                   description: 'Percent defines the percentage of
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
@@ -22622,6 +22629,7 @@ spec:
                                         for injecting I/O chaos action.
                                       type: string
                                     percent:
+                                      default: 100
                                       description: 'Percent defines the percentage
                                         of injection errors and provides a number
                                         from 0-100. default: 100.'
@@ -32218,6 +32226,7 @@ spec:
                             I/O chaos action.
                           type: string
                         percent:
+                          default: 100
                           description: 'Percent defines the percentage of injection
                             errors and provides a number from 0-100. default: 100.'
                           type: integer
@@ -34377,6 +34386,7 @@ spec:
                                 I/O chaos action.
                               type: string
                             percent:
+                              default: 100
                               description: 'Percent defines the percentage of injection
                                 errors and provides a number from 0-100. default:
                                 100.'

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -3097,7 +3097,7 @@ var doc = `{
                     "type": "string"
                 },
                 "percent": {
-                    "description": "Percent defines the percentage of injection errors and provides a number from 0-100.\ndefault: 100.\n+optional",
+                    "description": "Percent defines the percentage of injection errors and provides a number from 0-100.\ndefault: 100.\n+optional\n+kubebuilder:default=100",
                     "type": "integer"
                 },
                 "selector": {

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -3081,7 +3081,7 @@
                     "type": "string"
                 },
                 "percent": {
-                    "description": "Percent defines the percentage of injection errors and provides a number from 0-100.\ndefault: 100.\n+optional",
+                    "description": "Percent defines the percentage of injection errors and provides a number from 0-100.\ndefault: 100.\n+optional\n+kubebuilder:default=100",
                     "type": "integer"
                 },
                 "selector": {

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -982,6 +982,7 @@ definitions:
           Percent defines the percentage of injection errors and provides a number from 0-100.
           default: 100.
           +optional
+          +kubebuilder:default=100
         type: integer
       selector:
         $ref: '#/definitions/v1alpha1.PodSelectorSpec'


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Cherry-pick #3018

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
