### PR TITLE
make container runtime socket path and containerd ns configurable and change the socket volume path in pod

### DIFF
--- a/cmd/chaos-daemon/main.go
+++ b/cmd/chaos-daemon/main.go
@@ -45,6 +45,7 @@ func init() {
 	flag.IntVar(&conf.HTTPPort, "http-port", 31766, "the port which http server listens on")
 	flag.StringVar(&conf.CrClientConfig.Runtime, "runtime", "docker", "current container runtime")
 	flag.StringVar(&conf.CrClientConfig.SocketPath, "runtime-socket-path", "", "current container runtime socket path")
+	flag.StringVar(&conf.CrClientConfig.ContainerdNS, "containerd-ns", "k8s.io", "namespace used for containerd")
 	flag.StringVar(&conf.CaCert, "ca", "", "ca certificate of grpc server")
 	flag.StringVar(&conf.Cert, "cert", "", "certificate of grpc server")
 	flag.StringVar(&conf.Key, "key", "", "key of grpc server")

--- a/cmd/chaos-daemon/main.go
+++ b/cmd/chaos-daemon/main.go
@@ -27,13 +27,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/fusedev"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/version"
 )
 
 var (
-	conf = &chaosdaemon.Config{Host: "0.0.0.0"}
+	conf = &chaosdaemon.Config{Host: "0.0.0.0", CrClientConfig: &crclients.CrClientConfig{}}
 
 	printVersion bool
 )
@@ -42,7 +43,8 @@ func init() {
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
 	flag.IntVar(&conf.GRPCPort, "grpc-port", 31767, "the port which grpc server listens on")
 	flag.IntVar(&conf.HTTPPort, "http-port", 31766, "the port which http server listens on")
-	flag.StringVar(&conf.Runtime, "runtime", "docker", "current container runtime")
+	flag.StringVar(&conf.CrClientConfig.Runtime, "runtime", "docker", "current container runtime")
+	flag.StringVar(&conf.CrClientConfig.SocketPath, "runtime-socket-path", "", "current container runtime socket path")
 	flag.StringVar(&conf.CaCert, "ca", "", "ca certificate of grpc server")
 	flag.StringVar(&conf.Cert, "cert", "", "certificate of grpc server")
 	flag.StringVar(&conf.Key, "key", "", "key of grpc server")

--- a/hack/update_install_script.sh
+++ b/hack/update_install_script.sh
@@ -29,8 +29,8 @@ sed -i.bak 's/ca.crt:.*/ca.crt: \"\$\{CA_BUNDLE\}\"/g' $tmp_file
 sed -i.bak 's/tls.crt:.*/tls.crt: \"\$\{TLS_CRT\}\"/g' $tmp_file
 sed -i.bak 's/tls.key:.*/tls.key: \"\$\{TLS_KEY\}\"/g' $tmp_file
 sed -i.bak 's/caBundle:.*/caBundle: \"\$\{CA_BUNDLE\}\"/g' $tmp_file
-sed -i.bak 's/mountPath: \/var\/run\/docker.sock/mountPath: \$\{mountPath\}/g' $tmp_file
-sed -i.bak 's/path: \/var\/run\/docker.sock/path: \$\{socketPath\}/g' $tmp_file
+sed -i.bak 's/\/host-run\/docker.sock/\/host-run\/$\{socketName\}/g' $tmp_file
+sed -i.bak 's/path: \/var\/run/path: \$\{socketDir\}/g' $tmp_file
 sed -i.bak 's/- docker/- $\{runtime\}/g' $tmp_file
 sed -i.bak 's/hostNetwork: true/hostNetwork: \$\{host_network\}/g' $tmp_file
 sed -i.bak 's/ghcr.io\/chaos-mesh\/chaos-mesh:.*/\${IMAGE_REGISTRY_PREFIX}\/chaos-mesh\/chaos-mesh:\$\{VERSION_TAG\}/g' $tmp_file

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -79,6 +79,14 @@ spec:
             - --key
             - /etc/chaos-daemon/cert/tls.key
           {{- end }}
+            - --runtime-socket-path
+          {{- if eq .Values.chaosDaemon.runtime "docker" }}
+            -  /host-run/docker.sock
+          {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
+            -  /host-run/containerd.sock
+          {{- else if eq .Values.chaosDaemon.runtime "crio" }}
+            -  /host-run/crio.sock
+          {{- end }}
           env:
             {{- if .Values.chaosDaemon.env }}
             {{- include "chaos-mesh.helpers.listEnvVars" .Values.chaosDaemon | trim | nindent 12 }}
@@ -108,11 +116,11 @@ spec:
           volumeMounts:
             - name: socket-path
               {{- if eq .Values.chaosDaemon.runtime "docker" }}
-              mountPath: /var/run/docker.sock
+              mountPath: /host-run/docker.sock
               {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
-              mountPath: /run/containerd/containerd.sock
+              mountPath: /host-run/containerd.sock
               {{- else if eq .Values.chaosDaemon.runtime "crio" }}
-              mountPath: /var/run/crio/crio.sock
+              mountPath: /host-run/crio.sock
               {{- end }}
             - name: sys-path
               mountPath: /host-sys

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -80,13 +80,17 @@ spec:
             - /etc/chaos-daemon/cert/tls.key
           {{- end }}
             - --runtime-socket-path
+        {{- if .Values.chaosDaemon.socketPath }}
+            - /host-run/{{ .Values.chaosDaemon.socketPath | base }}
+        {{- else }}
           {{- if eq .Values.chaosDaemon.runtime "docker" }}
-            -  /host-run/docker.sock
+            - /host-run/docker.sock
           {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
-            -  /host-run/containerd.sock
+            - /host-run/containerd.sock
           {{- else if eq .Values.chaosDaemon.runtime "crio" }}
-            -  /host-run/crio.sock
+            - /host-run/crio.sock
           {{- end }}
+        {{- end }}
           env:
             {{- if .Values.chaosDaemon.env }}
             {{- include "chaos-mesh.helpers.listEnvVars" .Values.chaosDaemon | trim | nindent 12 }}
@@ -115,13 +119,7 @@ spec:
             {{- end }}
           volumeMounts:
             - name: socket-path
-              {{- if eq .Values.chaosDaemon.runtime "docker" }}
-              mountPath: /host-run/docker.sock
-              {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
-              mountPath: /host-run/containerd.sock
-              {{- else if eq .Values.chaosDaemon.runtime "crio" }}
-              mountPath: /host-run/crio.sock
-              {{- end }}
+              mountPath: /host-run
             - name: sys-path
               mountPath: /host-sys
             - name: lib-modules
@@ -184,7 +182,19 @@ spec:
       volumes:
         - name: socket-path
           hostPath:
-            path: {{ .Values.chaosDaemon.socketPath | default "/var/run/docker.sock" }}
+          {{- if .Values.chaosDaemon.socketPath }}
+            path: {{ .Values.chaosDaemon.socketPath | dir }}
+          {{- else if .Values.chaosDaemon.socketDir }}
+            path: {{ .Values.chaosDaemon.socketDir }}
+          {{- else }}
+            {{- if eq .Values.chaosDaemon.runtime "docker" }}
+            path: /var/run
+            {{- else if eq .Values.chaosDaemon.runtime "containerd" }}
+            path: /run/containerd
+            {{- else if eq .Values.chaosDaemon.runtime "crio" }}
+            path: /var/run/crio
+            {{- end }}
+          {{- end }}
         - name: sys-path
           hostPath:
             path: /sys

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -193,6 +193,9 @@ chaosDaemon:
   # runtime: crio
   # socketPath: /var/run/crio/crio.sock
 
+  # You can customize socket dir via socketDir
+  # If you set socketPath and socketDir at the same time, only socketPath will work.
+
   # CPU/Memory resource requests/limits for chaosDaemon container
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/install.sh
+++ b/install.sh
@@ -752,21 +752,21 @@ gen_chaos_mesh_manifests() {
     local host_network=$5
     local docker_registry=$6
     local microk8s=$7
-    local socketPath="/var/run/docker.sock"
-    local mountPath="/var/run/docker.sock"
+    local socketDir="/var/run"
+    local socketName="docker.sock"
     if [ "${runtime}" == "containerd" ]; then
-        socketPath="/run/containerd/containerd.sock"
-        mountPath="/run/containerd/containerd.sock"
+        socketDir="/run/containerd"
+        socketName="containerd.sock"
     fi
 
     if [ "${k3s}" == "true" ]; then
-        socketPath="/run/k3s/containerd/containerd.sock"
-        mountPath="/run/containerd/containerd.sock"
+        socketDir="/run/k3s/containerd"
+        socketName="containerd.sock"
     fi
 
     if [ "${microk8s}" == "true" ]; then
-        socketPath="/var/snap/microk8s/common/run/containerd.sock"
-        mountPath="/run/containerd/containerd.sock"
+        socketDir="/var/snap/microk8s/common/run"
+        socketName="containerd.sock"
     fi
 
     need_cmd mktemp
@@ -1225,6 +1225,8 @@ spec:
             - --grpc-port
             - !!str 31767
             - --pprof
+            - --runtime-socket-path
+            - /host-run/${socketName}
           env:
             - name: TZ
               value: ${timezone}
@@ -1235,7 +1237,7 @@ spec:
                 - SYS_PTRACE
           volumeMounts:
             - name: socket-path
-              mountPath: ${mountPath}
+              mountPath: /host-run
             - name: sys-path
               mountPath: /host-sys
             - name: lib-modules
@@ -1249,7 +1251,7 @@ spec:
       volumes:
         - name: socket-path
           hostPath:
-            path: ${socketPath}
+            path: ${socketDir}
         - name: sys-path
           hostPath:
             path: /sys

--- a/pkg/chaosdaemon/container_test.go
+++ b/pkg/chaosdaemon/container_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
-	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
@@ -33,7 +33,8 @@ var _ = Describe("container kill", func() {
 	defer mock.With("MockContainerdClient", &test.MockClient{})()
 	logger, err := log.NewDefaultZapLogger()
 	Expect(err).To(BeNil())
-	s, _ := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+	s, _ := newDaemonServer(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 
 	Context("ContainerKill", func() {
 		It("should work", func() {

--- a/pkg/chaosdaemon/crclients/client.go
+++ b/pkg/chaosdaemon/crclients/client.go
@@ -30,12 +30,19 @@ const (
 	ContainerRuntimeContainerd = "containerd"
 	ContainerRuntimeCrio       = "crio"
 
-	// TODO(yeya24): make socket and ns configurable
+	// TODO(yeya24): make ns configurable
 	defaultDockerSocket     = "unix:///var/run/docker.sock"
 	defaultContainerdSocket = "/run/containerd/containerd.sock"
 	defaultCrioSocket       = "/var/run/crio/crio.sock"
 	containerdDefaultNS     = "k8s.io"
 )
+
+// CrClientConfig contains the basic cr client configuration.
+type CrClientConfig struct {
+	// Support docker, containerd, crio for now
+	Runtime    string
+	SocketPath string
+}
 
 // ContainerRuntimeInfoClient represents a struct which can give you information about container runtime
 type ContainerRuntimeInfoClient interface {
@@ -47,30 +54,42 @@ type ContainerRuntimeInfoClient interface {
 }
 
 // CreateContainerRuntimeInfoClient creates a container runtime information client.
-func CreateContainerRuntimeInfoClient(containerRuntime string) (ContainerRuntimeInfoClient, error) {
+func CreateContainerRuntimeInfoClient(clientConfig *CrClientConfig) (ContainerRuntimeInfoClient, error) {
 	// TODO: support more container runtime
 
 	var cli ContainerRuntimeInfoClient
 	var err error
-	switch containerRuntime {
+	socketPath := clientConfig.SocketPath
+	switch clientConfig.Runtime {
 	case ContainerRuntimeDocker:
-		cli, err = docker.New(defaultDockerSocket, "", nil, nil)
+		if socketPath == "" {
+			socketPath = defaultDockerSocket
+		} else {
+			socketPath = "unix://" + socketPath
+		}
+		cli, err = docker.New(socketPath, "", nil, nil)
 		if err != nil {
 			return nil, err
 		}
 	case ContainerRuntimeContainerd:
 		// TODO(yeya24): add more options?
-		cli, err = containerd.New(defaultContainerdSocket, containerd.WithDefaultNamespace(containerdDefaultNS))
+		if socketPath == "" {
+			socketPath = defaultContainerdSocket
+		}
+		cli, err = containerd.New(socketPath, containerd.WithDefaultNamespace(containerdDefaultNS))
 		if err != nil {
 			return nil, err
 		}
 	case ContainerRuntimeCrio:
-		cli, err = crio.New(defaultCrioSocket)
+		if socketPath == "" {
+			socketPath = defaultCrioSocket
+		}
+		cli, err = crio.New(socketPath)
 		if err != nil {
 			return nil, err
 		}
 	default:
-		return nil, errors.Errorf("only docker/containerd/crio is supported, but got %s", containerRuntime)
+		return nil, errors.Errorf("only docker/containerd/crio is supported, but got %s", clientConfig.Runtime)
 	}
 
 	return cli, nil

--- a/pkg/chaosdaemon/crclients/client.go
+++ b/pkg/chaosdaemon/crclients/client.go
@@ -30,7 +30,6 @@ const (
 	ContainerRuntimeContainerd = "containerd"
 	ContainerRuntimeCrio       = "crio"
 
-	// TODO(yeya24): make ns configurable
 	defaultDockerSocket     = "unix:///var/run/docker.sock"
 	defaultContainerdSocket = "/run/containerd/containerd.sock"
 	defaultCrioSocket       = "/var/run/crio/crio.sock"
@@ -40,8 +39,9 @@ const (
 // CrClientConfig contains the basic cr client configuration.
 type CrClientConfig struct {
 	// Support docker, containerd, crio for now
-	Runtime    string
-	SocketPath string
+	Runtime      string
+	SocketPath   string
+	ContainerdNS string
 }
 
 // ContainerRuntimeInfoClient represents a struct which can give you information about container runtime
@@ -76,7 +76,11 @@ func CreateContainerRuntimeInfoClient(clientConfig *CrClientConfig) (ContainerRu
 		if socketPath == "" {
 			socketPath = defaultContainerdSocket
 		}
-		cli, err = containerd.New(socketPath, containerd.WithDefaultNamespace(containerdDefaultNS))
+		containerdNS := containerdDefaultNS
+		if clientConfig.ContainerdNS != "" {
+			containerdNS = clientConfig.ContainerdNS
+		}
+		cli, err = containerd.New(socketPath, containerd.WithDefaultNamespace(containerdNS))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/chaosdaemon/crclients/client_test.go
+++ b/pkg/chaosdaemon/crclients/client_test.go
@@ -28,7 +28,20 @@ import (
 
 var _ = Describe("chaosdaemon util", func() {
 	Context("CreateContainerRuntimeInfoClient", func() {
-		It("should work", func() {
+		It("should work without socket path", func() {
+			_, err := CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeDocker})
+			Expect(err).To(BeNil())
+			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeDocker})
+			Expect(err).To(BeNil())
+			defer func() {
+				err := mock.With("MockContainerdClient", &test.MockClient{})()
+				Expect(err).To(BeNil())
+			}()
+			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeContainerd})
+			Expect(err).To(BeNil())
+		})
+
+		It("should work with socket path", func() {
 			_, err := CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeDocker})
 			Expect(err).To(BeNil())
 			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{
@@ -39,7 +52,21 @@ var _ = Describe("chaosdaemon util", func() {
 				err := mock.With("MockContainerdClient", &test.MockClient{})()
 				Expect(err).To(BeNil())
 			}()
-			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeContainerd})
+			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{
+				Runtime:    ContainerRuntimeContainerd,
+				SocketPath: "/foo/bar/containerd.socket"})
+			Expect(err).To(BeNil())
+		})
+
+		It("should work with socket path and ns", func() {
+			defer func() {
+				err := mock.With("MockContainerdClient", &test.MockClient{})()
+				Expect(err).To(BeNil())
+			}()
+			_, err := CreateContainerRuntimeInfoClient(&CrClientConfig{
+				Runtime:      ContainerRuntimeContainerd,
+				SocketPath:   "/foo/bar/containerd.socket",
+				ContainerdNS: "chaos-mesh.org"})
 			Expect(err).To(BeNil())
 		})
 

--- a/pkg/chaosdaemon/crclients/client_test.go
+++ b/pkg/chaosdaemon/crclients/client_test.go
@@ -29,13 +29,17 @@ import (
 var _ = Describe("chaosdaemon util", func() {
 	Context("CreateContainerRuntimeInfoClient", func() {
 		It("should work", func() {
-			_, err := CreateContainerRuntimeInfoClient(ContainerRuntimeDocker)
+			_, err := CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeDocker})
+			Expect(err).To(BeNil())
+			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{
+				Runtime:    ContainerRuntimeDocker,
+				SocketPath: "/foo/bar/docker.socket"})
 			Expect(err).To(BeNil())
 			defer func() {
 				err := mock.With("MockContainerdClient", &test.MockClient{})()
 				Expect(err).To(BeNil())
 			}()
-			_, err = CreateContainerRuntimeInfoClient(ContainerRuntimeContainerd)
+			_, err = CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeContainerd})
 			Expect(err).To(BeNil())
 		})
 
@@ -46,7 +50,7 @@ var _ = Describe("chaosdaemon util", func() {
 				err := mock.With("NewContainerdClientError", errors.New(errorStr))()
 				Expect(err).To(BeNil())
 			}()
-			_, err := CreateContainerRuntimeInfoClient(ContainerRuntimeContainerd)
+			_, err := CreateContainerRuntimeInfoClient(&CrClientConfig{Runtime: ContainerRuntimeContainerd})
 			Expect(err).ToNot(BeNil())
 			Expect(fmt.Sprintf("%s", err)).To(Equal(errorStr))
 		})

--- a/pkg/chaosdaemon/ipset_server_test.go
+++ b/pkg/chaosdaemon/ipset_server_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
-	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
@@ -36,7 +36,8 @@ var _ = Describe("ipset server", func() {
 	defer mock.With("MockContainerdClient", &test.MockClient{})()
 	logger, err := log.NewDefaultZapLogger()
 	Expect(err).To(BeNil())
-	s, _ := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+	s, _ := newDaemonServer(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 
 	Context("createIPSet", func() {
 		It("should work", func() {

--- a/pkg/chaosdaemon/iptables_server_test.go
+++ b/pkg/chaosdaemon/iptables_server_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
-	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
@@ -35,7 +35,8 @@ var _ = Describe("iptables server", func() {
 	defer mock.With("MockContainerdClient", &test.MockClient{})()
 	logger, err := log.NewDefaultZapLogger()
 	Expect(err).To(BeNil())
-	s, _ := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+	s, _ := newDaemonServer(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 
 	Context("FlushIptables", func() {
 		It("should work", func() {

--- a/pkg/chaosdaemon/server_test.go
+++ b/pkg/chaosdaemon/server_test.go
@@ -32,13 +32,17 @@ var _ = Describe("netem server", func() {
 
 	Context("newDaemonServer", func() {
 		It("should work", func() {
+			_, err := newDaemonServer(&crclients.CrClientConfig{
+				Runtime:    crclients.ContainerRuntimeDocker,
+				SocketPath: "/foo/bar/docker.socket"}, nil, logger)
+			Expect(err).To(BeNil())
 			defer mock.With("MockContainerdClient", &test.MockClient{})()
-			_, err := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+			_, err = newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 			Expect(err).To(BeNil())
 		})
 
 		It("should fail on CreateContainerRuntimeInfoClient", func() {
-			_, err := newDaemonServer("invalid-runtime", nil, logger)
+			_, err := newDaemonServer(&crclients.CrClientConfig{Runtime: "invalid-runtime"}, nil, logger)
 			Expect(err).ToNot(BeNil())
 		})
 	})
@@ -46,7 +50,7 @@ var _ = Describe("netem server", func() {
 	Context("newGRPCServer", func() {
 		It("should work", func() {
 			defer mock.With("MockContainerdClient", &test.MockClient{})()
-			daemonServer, err := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+			daemonServer, err := newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 			Expect(err).To(BeNil())
 			_, err = newGRPCServer(daemonServer, &MockRegisterer{}, tlsConfig{})
 			Expect(err).To(BeNil())
@@ -56,7 +60,7 @@ var _ = Describe("netem server", func() {
 			Ω(func() {
 				defer mock.With("MockContainerdClient", &test.MockClient{})()
 				defer mock.With("PanicOnMustRegister", "mock panic")()
-				daemonServer, err := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+				daemonServer, err := newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 				Expect(err).To(BeNil())
 				_, err = newGRPCServer(daemonServer, &MockRegisterer{}, tlsConfig{})
 				Expect(err).To(BeNil())

--- a/pkg/chaosdaemon/server_test.go
+++ b/pkg/chaosdaemon/server_test.go
@@ -31,13 +31,29 @@ var _ = Describe("netem server", func() {
 	Expect(err).To(BeNil())
 
 	Context("newDaemonServer", func() {
-		It("should work", func() {
+		It("should work without socket path", func() {
+			_, err := newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeDocker}, nil, logger)
+			Expect(err).To(BeNil())
+			defer mock.With("MockContainerdClient", &test.MockClient{})()
+			_, err = newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
+			Expect(err).To(BeNil())
+		})
+
+		It("should work with socket path", func() {
 			_, err := newDaemonServer(&crclients.CrClientConfig{
 				Runtime:    crclients.ContainerRuntimeDocker,
 				SocketPath: "/foo/bar/docker.socket"}, nil, logger)
 			Expect(err).To(BeNil())
+		})
+
+		It("should work with socket path and ns", func() {
 			defer mock.With("MockContainerdClient", &test.MockClient{})()
-			_, err = newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
+			_, err := newDaemonServer(&crclients.CrClientConfig{Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
+			Expect(err).To(BeNil())
+			_, err = newDaemonServer(&crclients.CrClientConfig{
+				Runtime:      crclients.ContainerRuntimeContainerd,
+				SocketPath:   "/foo/bar/containerd.socket",
+				ContainerdNS: "chaos-mesh.org"}, nil, logger)
 			Expect(err).To(BeNil())
 		})
 

--- a/pkg/chaosdaemon/time_server_test.go
+++ b/pkg/chaosdaemon/time_server_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
-	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
@@ -33,7 +33,8 @@ var _ = Describe("time server", func() {
 	defer mock.With("MockContainerdClient", &test.MockClient{})()
 	logger, err := log.NewDefaultZapLogger()
 	Expect(err).To(BeNil())
-	s, _ := newDaemonServer(crclients.ContainerRuntimeContainerd, nil, logger)
+	s, _ := newDaemonServer(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
 
 	Context("SetTimeOffset", func() {
 		It("should work", func() {


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
close #3072 

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?
- [x] make container runtime socket path configurable
- [x] change the socket volume path in pod to fix #3072 
- [x] make container containerd ns configurable, to make all cr client configs configurable


<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Make container runtime socket path and containerd ns configurable, and change the socket volume path in pod
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```

Signed-off-by: xianglingao <xianglingao@tencent.com>