### PR TITLE
chore: use github token to avoid GitHub API Rate Limiting with e2e tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -98,6 +98,7 @@ jobs:
           minikube version: v1.24.0
           kubernetes version: ${{ matrix.kubernetes-version }}
           start args: --cni flannel
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: load image into minikube
         run: |
           minikube image load ghcr.io/chaos-mesh/chaos-dashboard:latest


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>


### What problem does this PR solve?

Avoiding failure caused by GitHub API Rate Limiting like https://github.com/chaos-mesh/chaos-mesh/runs/5781739841?check_suite_focus=true

`actions-setup-minikube` provides parameter `github token`: https://github.com/manusa/actions-setup-minikube#optional-input-parameters

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- append one more parameter `github token`

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
