### PR TITLE
chore: specify env tags for each branches (#3071)

### DIFF
--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -24,10 +24,8 @@ jobs:
       - name: Extract Image Tag
         shell: bash
         run: |
-          IMAGE_TAG=${GITHUB_REF##*/}
-          if [ "${IMAGE_TAG}" = "master" ] ; then
-            IMAGE_TAG=latest; 
-          fi
+          # we assume that both image tags of build-env and dev-env are same during this workflow
+          IMAGE_TAG=$(./hack/env-image-tag.sh build-env)
 
           echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
         id: image_tag
@@ -80,7 +78,7 @@ jobs:
           docker manifest create ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE-env:$IMAGE_TAG \
             ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE-env:$IMAGE_TAG-amd64 \
             ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE-env:$IMAGE_TAG-arm64
-          
+
           docker manifest annotate ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE-env:$IMAGE_TAG \
             ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE-env:$IMAGE_TAG-amd64 \
             --os linux --arch amd64

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 GO_TARGET_PHONY += $(1)
 endef
 
-BUILD_INDOCKER_ARG := --env IN_DOCKER=1 --env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTPS_PROXY} --env GOPROXY=${GOPROXY} --volume $(ROOT):/mnt --user $(shell id -u):$(shell id -g)
+BUILD_INDOCKER_ARG := --env IN_DOCKER=1 --env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTPS_PROXY} --env GOPROXY=${GOPROXY} --env IMAGE_BUILD_ENV_TAG=${IMAGE_BUILD_ENV_TAG} --env IMAGE_DEV_ENV_TAG=${IMAGE_DEV_ENV_TAG} --volume $(ROOT):/mnt --user $(shell id -u):$(shell id -g)
 
 ifneq ($(TARGET_PLATFORM),)
 	BUILD_INDOCKER_ARG += --platform=linux/$(TARGET_PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ OUTPUT_BIN=$(ROOT)/output/bin
 HELM_BIN=$(OUTPUT_BIN)/helm
 
 # Every branch should have its own image tag for build-env and dev-env
+# using := with ifeq instead of ?= for performance issue
+ifeq ($(IMAGE_BUILD_ENV_TAG),)
+IMAGE_BUILD_ENV_TAG := $(shell ./hack/env-image-tag.sh build-env)
+endif
+ifeq ($(IMAGE_DEV_ENV_TAG),)
+IMAGE_DEV_ENV_TAG := $(shell ./hack/env-image-tag.sh dev-env)
+endif
+
+# Every branch should have its own image tag for build-env and dev-env
 IMAGE_BUILD_ENV_PROJECT ?= chaos-mesh
 IMAGE_BUILD_ENV_REGISTRY ?= ghcr.io
 IMAGE_BUILD_ENV_BUILD ?= 0

--- a/env-images.yaml
+++ b/env-images.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Note: This file should be updated with the new release-<version> branch created.
+
+# specify which tag of ghcr.io/chaos-mesh/build-env image should be used with the current branch
+build-env:
+  tag: "latest"
+# specify which tag of ghcr.io/chaos-mesh/dev-env image should be used with the current branch
+dev-env:
+  tag: "latest"

--- a/env-images.yaml
+++ b/env-images.yaml
@@ -17,7 +17,7 @@
 
 # specify which tag of ghcr.io/chaos-mesh/build-env image should be used with the current branch
 build-env:
-  tag: "latest"
+  tag: "release-2.1"
 # specify which tag of ghcr.io/chaos-mesh/dev-env image should be used with the current branch
 dev-env:
-  tag: "latest"
+  tag: "release-2.1"

--- a/hack/env-image-tag.sh
+++ b/hack/env-image-tag.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2022 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script would report the tag of build-env and dev-env to use based on configuartion file env-images.yaml.
+#
+# Usage:
+# On master branch:
+# ./hack/env-image-tag.sh build-env, output: latest
+# ./hack/env-image-tag.sh dev-env, output: latest
+# On release-2.1 branch:
+# ./hack/env-image-tag.sh build-env, output: release-2.1
+# ./hack/env-image-tag.sh dev-env, output: release-2.1
+
+set -euo pipefail
+
+DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
+PROJECT_DIR="$(dirname "$DIR")"
+
+if [ "$#" -eq  "0" ]; then
+  echo "Usage: $0 <env-image-name>"
+  exit 1
+fi
+
+if [[ "$1" == "dev-env" || "$1" == "build-env"  ]]; then
+  docker run -i mikefarah/yq:latest ".$1.tag" < $PROJECT_DIR/env-images.yaml
+  exit 0
+fi
+
+echo "Error: $1 is not a valid env-image name, available: dev-env, build-env"
+exit 1


### PR DESCRIPTION
### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

cherry-pick https://github.com/chaos-mesh/chaos-mesh/pull/3071 into release-2.1

specify certain env images for release-2.1

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
