### PR TITLE
Add support for ingressClass objects in Chaos Mesh dashboard ingress

### DIFF
--- a/helm/chaos-mesh/Chart.yaml
+++ b/helm/chaos-mesh/Chart.yaml
@@ -20,7 +20,7 @@ icon: https://raw.githubusercontent.com/pingcap/chaos-mesh/master/static/logo.sv
 sources:
   - https://github.com/pingcap/chaos-mesh
 name: chaos-mesh
-version: v0.2.1
+version: v0.2.2
 keywords:
   - chaos-engineering
   - resiliency

--- a/helm/chaos-mesh/templates/ingress.yaml
+++ b/helm/chaos-mesh/templates/ingress.yaml
@@ -32,6 +32,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.dashboard.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.dashboard.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.dashboard.ingress.hosts }}
     - host: {{ .name | quote }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -332,6 +332,10 @@ dashboard:
     ## Set to true to enable ingress record generation
     enabled: false
 
+    ## For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 


### PR DESCRIPTION
### What problem does this PR solve?

It adds support for ingressClass objects in the Ingress Template for Chaos Mesh Helm chart. 

### What's changed and how it works?

ingressClassName should be specified in values.yaml instead of kubernetes.io/ingress.class: nginx annotation for Kubernetes >= 1.18

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [X] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
- Add support for ingressClass objects in Chaos Mesh dashboard ingress
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
