### PR TITLE
validate cpu load

### DIFF
--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -160,7 +160,7 @@ type MemoryStressor struct {
 	// OOMScoreAdj sets the oom_score_adj of the stress process. See `man 5 proc` to know more
 	// about this option.
 	// +kubebuilder:validation:Minimum=-1000
-	// +kubebuilder:validation:Maximm=1000
+	// +kubebuilder:validation:Maximum=1000
 	// +kubebuilder:default=0
 	// +optional
 	OOMScoreAdj int `json:"oomScoreAdj,omitempty"`
@@ -175,6 +175,8 @@ type CPUStressor struct {
 	Stressor `json:",inline"`
 	// Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100
 	// is full loading.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
 	// +optional
 	Load *int `json:"load,omitempty"`
 

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -2537,6 +2537,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -2559,6 +2561,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:
@@ -8071,6 +8074,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -8095,6 +8100,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -8444,6 +8450,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -8468,6 +8476,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:

--- a/config/crd/bases/chaos-mesh.org_stresschaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_stresschaos.yaml
@@ -171,6 +171,8 @@ spec:
                       load:
                         description: Load specifies P percent loading per CPU worker.
                           0 is effectively a sleep (no load) and 100 is full loading.
+                        maximum: 100
+                        minimum: 0
                         type: integer
                       options:
                         description: extend stress-ng options
@@ -192,6 +194,7 @@ spec:
                         default: 0
                         description: OOMScoreAdj sets the oom_score_adj of the stress
                           process. See `man 5 proc` to know more about this option.
+                        maximum: 1000
                         minimum: -1000
                         type: integer
                       options:

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -4972,6 +4972,8 @@ spec:
                                 description: Load specifies P percent loading per
                                   CPU worker. 0 is effectively a sleep (no load) and
                                   100 is full loading.
+                                maximum: 100
+                                minimum: 0
                                 type: integer
                               options:
                                 description: extend stress-ng options
@@ -4994,6 +4996,7 @@ spec:
                                 description: OOMScoreAdj sets the oom_score_adj of
                                   the stress process. See `man 5 proc` to know more
                                   about this option.
+                                maximum: 1000
                                 minimum: -1000
                                 type: integer
                               options:
@@ -10685,6 +10688,8 @@ spec:
                                                 loading per CPU worker. 0 is effectively
                                                 a sleep (no load) and 100 is full
                                                 loading.
+                                              maximum: 100
+                                              minimum: 0
                                               type: integer
                                             options:
                                               description: extend stress-ng options
@@ -10709,6 +10714,7 @@ spec:
                                               description: OOMScoreAdj sets the oom_score_adj
                                                 of the stress process. See `man 5
                                                 proc` to know more about this option.
+                                              maximum: 1000
                                               minimum: -1000
                                               type: integer
                                             options:
@@ -11072,6 +11078,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -11096,6 +11104,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -14703,6 +14712,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -14725,6 +14736,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -5200,6 +5200,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -5224,6 +5226,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:
@@ -5564,6 +5567,8 @@ spec:
                                   description: Load specifies P percent loading per
                                     CPU worker. 0 is effectively a sleep (no load)
                                     and 100 is full loading.
+                                  maximum: 100
+                                  minimum: 0
                                   type: integer
                                 options:
                                   description: extend stress-ng options
@@ -5588,6 +5593,7 @@ spec:
                                   description: OOMScoreAdj sets the oom_score_adj
                                     of the stress process. See `man 5 proc` to know
                                     more about this option.
+                                  maximum: 1000
                                   minimum: -1000
                                   type: integer
                                 options:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -2537,6 +2537,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -2559,6 +2561,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:
@@ -8071,6 +8074,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -8095,6 +8100,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -8444,6 +8450,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -8468,6 +8476,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
@@ -171,6 +171,8 @@ spec:
                       load:
                         description: Load specifies P percent loading per CPU worker.
                           0 is effectively a sleep (no load) and 100 is full loading.
+                        maximum: 100
+                        minimum: 0
                         type: integer
                       options:
                         description: extend stress-ng options
@@ -192,6 +194,7 @@ spec:
                         default: 0
                         description: OOMScoreAdj sets the oom_score_adj of the stress
                           process. See `man 5 proc` to know more about this option.
+                        maximum: 1000
                         minimum: -1000
                         type: integer
                       options:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -4972,6 +4972,8 @@ spec:
                                 description: Load specifies P percent loading per
                                   CPU worker. 0 is effectively a sleep (no load) and
                                   100 is full loading.
+                                maximum: 100
+                                minimum: 0
                                 type: integer
                               options:
                                 description: extend stress-ng options
@@ -4994,6 +4996,7 @@ spec:
                                 description: OOMScoreAdj sets the oom_score_adj of
                                   the stress process. See `man 5 proc` to know more
                                   about this option.
+                                maximum: 1000
                                 minimum: -1000
                                 type: integer
                               options:
@@ -10685,6 +10688,8 @@ spec:
                                                 loading per CPU worker. 0 is effectively
                                                 a sleep (no load) and 100 is full
                                                 loading.
+                                              maximum: 100
+                                              minimum: 0
                                               type: integer
                                             options:
                                               description: extend stress-ng options
@@ -10709,6 +10714,7 @@ spec:
                                               description: OOMScoreAdj sets the oom_score_adj
                                                 of the stress process. See `man 5
                                                 proc` to know more about this option.
+                                              maximum: 1000
                                               minimum: -1000
                                               type: integer
                                             options:
@@ -11072,6 +11078,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -11096,6 +11104,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -14703,6 +14712,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -14725,6 +14736,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -5200,6 +5200,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -5224,6 +5226,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:
@@ -5564,6 +5567,8 @@ spec:
                                   description: Load specifies P percent loading per
                                     CPU worker. 0 is effectively a sleep (no load)
                                     and 100 is full loading.
+                                  maximum: 100
+                                  minimum: 0
                                   type: integer
                                 options:
                                   description: extend stress-ng options
@@ -5588,6 +5593,7 @@ spec:
                                   description: OOMScoreAdj sets the oom_score_adj
                                     of the stress process. See `man 5 proc` to know
                                     more about this option.
+                                  maximum: 1000
                                   minimum: -1000
                                   type: integer
                                 options:

--- a/manifests/crd-v1beta1.yaml
+++ b/manifests/crd-v1beta1.yaml
@@ -6789,6 +6789,8 @@ spec:
                         load:
                           description: Load specifies P percent loading per CPU worker.
                             0 is effectively a sleep (no load) and 100 is full loading.
+                          maximum: 100
+                          minimum: 0
                           type: integer
                         options:
                           description: extend stress-ng options
@@ -6809,6 +6811,7 @@ spec:
                         oomScoreAdj:
                           description: OOMScoreAdj sets the oom_score_adj of the stress
                             process. See `man 5 proc` to know more about this option.
+                          maximum: 1000
                           minimum: -1000
                           type: integer
                         options:
@@ -12201,6 +12204,8 @@ spec:
                                         description: Load specifies P percent loading
                                           per CPU worker. 0 is effectively a sleep
                                           (no load) and 100 is full loading.
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                       options:
                                         description: extend stress-ng options
@@ -12224,6 +12229,7 @@ spec:
                                         description: OOMScoreAdj sets the oom_score_adj
                                           of the stress process. See `man 5 proc`
                                           to know more about this option.
+                                        maximum: 1000
                                         minimum: -1000
                                         type: integer
                                       options:
@@ -12566,6 +12572,8 @@ spec:
                                     description: Load specifies P percent loading
                                       per CPU worker. 0 is effectively a sleep (no
                                       load) and 100 is full loading.
+                                    maximum: 100
+                                    minimum: 0
                                     type: integer
                                   options:
                                     description: extend stress-ng options
@@ -12589,6 +12597,7 @@ spec:
                                     description: OOMScoreAdj sets the oom_score_adj
                                       of the stress process. See `man 5 proc` to know
                                       more about this option.
+                                    maximum: 1000
                                     minimum: -1000
                                     type: integer
                                   options:
@@ -16251,6 +16260,8 @@ spec:
                     load:
                       description: Load specifies P percent loading per CPU worker.
                         0 is effectively a sleep (no load) and 100 is full loading.
+                      maximum: 100
+                      minimum: 0
                       type: integer
                     options:
                       description: extend stress-ng options
@@ -16271,6 +16282,7 @@ spec:
                     oomScoreAdj:
                       description: OOMScoreAdj sets the oom_score_adj of the stress
                         process. See `man 5 proc` to know more about this option.
+                      maximum: 1000
                       minimum: -1000
                       type: integer
                     options:
@@ -21547,6 +21559,8 @@ spec:
                               description: Load specifies P percent loading per CPU
                                 worker. 0 is effectively a sleep (no load) and 100
                                 is full loading.
+                              maximum: 100
+                              minimum: 0
                               type: integer
                             options:
                               description: extend stress-ng options
@@ -21568,6 +21582,7 @@ spec:
                               description: OOMScoreAdj sets the oom_score_adj of the
                                 stress process. See `man 5 proc` to know more about
                                 this option.
+                              maximum: 1000
                               minimum: -1000
                               type: integer
                             options:
@@ -27135,6 +27150,8 @@ spec:
                                             description: Load specifies P percent
                                               loading per CPU worker. 0 is effectively
                                               a sleep (no load) and 100 is full loading.
+                                            maximum: 100
+                                            minimum: 0
                                             type: integer
                                           options:
                                             description: extend stress-ng options
@@ -27158,6 +27175,7 @@ spec:
                                             description: OOMScoreAdj sets the oom_score_adj
                                               of the stress process. See `man 5 proc`
                                               to know more about this option.
+                                            maximum: 1000
                                             minimum: -1000
                                             type: integer
                                           options:
@@ -27510,6 +27528,8 @@ spec:
                                         description: Load specifies P percent loading
                                           per CPU worker. 0 is effectively a sleep
                                           (no load) and 100 is full loading.
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                       options:
                                         description: extend stress-ng options
@@ -27533,6 +27553,7 @@ spec:
                                         description: OOMScoreAdj sets the oom_score_adj
                                           of the stress process. See `man 5 proc`
                                           to know more about this option.
+                                        maximum: 1000
                                         minimum: -1000
                                         type: integer
                                       options:
@@ -31042,6 +31063,8 @@ spec:
                         load:
                           description: Load specifies P percent loading per CPU worker.
                             0 is effectively a sleep (no load) and 100 is full loading.
+                          maximum: 100
+                          minimum: 0
                           type: integer
                         options:
                           description: extend stress-ng options
@@ -31062,6 +31085,7 @@ spec:
                         oomScoreAdj:
                           description: OOMScoreAdj sets the oom_score_adj of the stress
                             process. See `man 5 proc` to know more about this option.
+                          maximum: 1000
                           minimum: -1000
                           type: integer
                         options:
@@ -39171,6 +39195,8 @@ spec:
                                     description: Load specifies P percent loading
                                       per CPU worker. 0 is effectively a sleep (no
                                       load) and 100 is full loading.
+                                    maximum: 100
+                                    minimum: 0
                                     type: integer
                                   options:
                                     description: extend stress-ng options
@@ -39194,6 +39220,7 @@ spec:
                                     description: OOMScoreAdj sets the oom_score_adj
                                       of the stress process. See `man 5 proc` to know
                                       more about this option.
+                                    maximum: 1000
                                     minimum: -1000
                                     type: integer
                                   options:
@@ -39528,6 +39555,8 @@ spec:
                                 description: Load specifies P percent loading per
                                   CPU worker. 0 is effectively a sleep (no load) and
                                   100 is full loading.
+                                maximum: 100
+                                minimum: 0
                                 type: integer
                               options:
                                 description: extend stress-ng options
@@ -39549,6 +39578,7 @@ spec:
                                 description: OOMScoreAdj sets the oom_score_adj of
                                   the stress process. See `man 5 proc` to know more
                                   about this option.
+                                maximum: 1000
                                 minimum: -1000
                                 type: integer
                               options:

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6809,6 +6809,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -6831,6 +6833,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:
@@ -12343,6 +12346,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -12367,6 +12372,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -12716,6 +12722,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -12740,6 +12748,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:
@@ -16472,6 +16481,8 @@ spec:
                       load:
                         description: Load specifies P percent loading per CPU worker.
                           0 is effectively a sleep (no load) and 100 is full loading.
+                        maximum: 100
+                        minimum: 0
                         type: integer
                       options:
                         description: extend stress-ng options
@@ -16493,6 +16504,7 @@ spec:
                         default: 0
                         description: OOMScoreAdj sets the oom_score_adj of the stress
                           process. See `man 5 proc` to know more about this option.
+                        maximum: 1000
                         minimum: -1000
                         type: integer
                       options:
@@ -21816,6 +21828,8 @@ spec:
                                 description: Load specifies P percent loading per
                                   CPU worker. 0 is effectively a sleep (no load) and
                                   100 is full loading.
+                                maximum: 100
+                                minimum: 0
                                 type: integer
                               options:
                                 description: extend stress-ng options
@@ -21838,6 +21852,7 @@ spec:
                                 description: OOMScoreAdj sets the oom_score_adj of
                                   the stress process. See `man 5 proc` to know more
                                   about this option.
+                                maximum: 1000
                                 minimum: -1000
                                 type: integer
                               options:
@@ -27529,6 +27544,8 @@ spec:
                                                 loading per CPU worker. 0 is effectively
                                                 a sleep (no load) and 100 is full
                                                 loading.
+                                              maximum: 100
+                                              minimum: 0
                                               type: integer
                                             options:
                                               description: extend stress-ng options
@@ -27553,6 +27570,7 @@ spec:
                                               description: OOMScoreAdj sets the oom_score_adj
                                                 of the stress process. See `man 5
                                                 proc` to know more about this option.
+                                              maximum: 1000
                                               minimum: -1000
                                               type: integer
                                             options:
@@ -27916,6 +27934,8 @@ spec:
                                           description: Load specifies P percent loading
                                             per CPU worker. 0 is effectively a sleep
                                             (no load) and 100 is full loading.
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         options:
                                           description: extend stress-ng options
@@ -27940,6 +27960,7 @@ spec:
                                           description: OOMScoreAdj sets the oom_score_adj
                                             of the stress process. See `man 5 proc`
                                             to know more about this option.
+                                          maximum: 1000
                                           minimum: -1000
                                           type: integer
                                         options:
@@ -31547,6 +31568,8 @@ spec:
                             description: Load specifies P percent loading per CPU
                               worker. 0 is effectively a sleep (no load) and 100 is
                               full loading.
+                            maximum: 100
+                            minimum: 0
                             type: integer
                           options:
                             description: extend stress-ng options
@@ -31569,6 +31592,7 @@ spec:
                             description: OOMScoreAdj sets the oom_score_adj of the
                               stress process. See `man 5 proc` to know more about
                               this option.
+                            maximum: 1000
                             minimum: -1000
                             type: integer
                           options:
@@ -39824,6 +39848,8 @@ spec:
                                       description: Load specifies P percent loading
                                         per CPU worker. 0 is effectively a sleep (no
                                         load) and 100 is full loading.
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                     options:
                                       description: extend stress-ng options
@@ -39848,6 +39874,7 @@ spec:
                                       description: OOMScoreAdj sets the oom_score_adj
                                         of the stress process. See `man 5 proc` to
                                         know more about this option.
+                                      maximum: 1000
                                       minimum: -1000
                                       type: integer
                                     options:
@@ -40188,6 +40215,8 @@ spec:
                                   description: Load specifies P percent loading per
                                     CPU worker. 0 is effectively a sleep (no load)
                                     and 100 is full loading.
+                                  maximum: 100
+                                  minimum: 0
                                   type: integer
                                 options:
                                   description: extend stress-ng options
@@ -40212,6 +40241,7 @@ spec:
                                   description: OOMScoreAdj sets the oom_score_adj
                                     of the stress process. See `man 5 proc` to know
                                     more about this option.
+                                  maximum: 1000
                                   minimum: -1000
                                   type: integer
                                 options:

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -3171,7 +3171,7 @@ var doc = `{
             "type": "object",
             "properties": {
                 "load": {
-                    "description": "Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100\nis full loading.\n+optional",
+                    "description": "Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100\nis full loading.\n+kubebuilder:validation:Minimum=0\n+kubebuilder:validation:Maximum=100\n+optional",
                     "type": "integer"
                 },
                 "options": {
@@ -3939,7 +3939,7 @@ var doc = `{
             "type": "object",
             "properties": {
                 "oomScoreAdj": {
-                    "description": "OOMScoreAdj sets the oom_score_adj of the stress process. See ` + "`" + `man 5 proc` + "`" + ` to know more\nabout this option.\n+kubebuilder:validation:Minimum=-1000\n+kubebuilder:validation:Maximm=1000\n+kubebuilder:default=0\n+optional",
+                    "description": "OOMScoreAdj sets the oom_score_adj of the stress process. See ` + "`" + `man 5 proc` + "`" + ` to know more\nabout this option.\n+kubebuilder:validation:Minimum=-1000\n+kubebuilder:validation:Maximum=1000\n+kubebuilder:default=0\n+optional",
                     "type": "integer"
                 },
                 "options": {

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -3155,7 +3155,7 @@
             "type": "object",
             "properties": {
                 "load": {
-                    "description": "Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100\nis full loading.\n+optional",
+                    "description": "Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100\nis full loading.\n+kubebuilder:validation:Minimum=0\n+kubebuilder:validation:Maximum=100\n+optional",
                     "type": "integer"
                 },
                 "options": {
@@ -3923,7 +3923,7 @@
             "type": "object",
             "properties": {
                 "oomScoreAdj": {
-                    "description": "OOMScoreAdj sets the oom_score_adj of the stress process. See `man 5 proc` to know more\nabout this option.\n+kubebuilder:validation:Minimum=-1000\n+kubebuilder:validation:Maximm=1000\n+kubebuilder:default=0\n+optional",
+                    "description": "OOMScoreAdj sets the oom_score_adj of the stress process. See `man 5 proc` to know more\nabout this option.\n+kubebuilder:validation:Minimum=-1000\n+kubebuilder:validation:Maximum=1000\n+kubebuilder:default=0\n+optional",
                     "type": "integer"
                 },
                 "options": {

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -643,6 +643,8 @@ definitions:
         description: |-
           Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100
           is full loading.
+          +kubebuilder:validation:Minimum=0
+          +kubebuilder:validation:Maximum=100
           +optional
         type: integer
       options:
@@ -1463,7 +1465,7 @@ definitions:
           OOMScoreAdj sets the oom_score_adj of the stress process. See `man 5 proc` to know more
           about this option.
           +kubebuilder:validation:Minimum=-1000
-          +kubebuilder:validation:Maximm=1000
+          +kubebuilder:validation:Maximum=1000
           +kubebuilder:default=0
           +optional
         type: integer


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->
Close #3064

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

set cpu stress load 150

then I get 

```
error.api.internal_server_error: admission webhook "vstresschaos.kb.io" denied the request: Spec.Stressors.CPUStressor.Load: Invalid value: 150: valid cpu load is from 0 to 100
Side effects
```

<img width="777" alt="image" src="https://user-images.githubusercontent.com/1636894/162736539-03d25d8c-3563-4884-99fc-26e46cba2750.png">

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
