### PR TITLE
chore: use docker with --rm and certain yq image

### DIFF
--- a/hack/env-image-tag.sh
+++ b/hack/env-image-tag.sh
@@ -35,7 +35,7 @@ if [ "$#" -eq  "0" ]; then
 fi
 
 if [[ "$1" == "dev-env" || "$1" == "build-env"  ]]; then
-  docker run -i mikefarah/yq:latest ".$1.tag" < $PROJECT_DIR/env-images.yaml
+  docker run -i --rm mikefarah/yq:4.24.5 ".$1.tag" < $PROJECT_DIR/env-images.yaml
   exit 0
 fi
 


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

### What problem does this PR solve?

- it did not cleanup completed contained within `./hack/env-image-tag.sh`
- use the `yq` docker image with certain tag , for avoiding outdated images on docker registry mirror 

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
