### PR TITLE
Specify image tag in e2e tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -138,10 +138,10 @@ jobs:
         run: |
           # if kubernetes does not support apiextensions.k8s.io/v1, fallback to apiextensions.k8s.io/v1beta1
           if kubectl api-resources | grep -w apiextensions.k8s.io/v1; then
-            helm install --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true --set dashboard.create=true
+            helm install --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true --set dashboard.create=true --set images.tag=latest
           else
             kubectl create --validate=false -f ./manifests/crd-v1beta1.yaml && \
-            helm install --skip-crds --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true --set dashboard.create=true
+            helm install --skip-crds --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true --set dashboard.create=true --set images.tag=latest
           fi
       - name: e2e tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Migrate e2e tests from self-hosted Jenkins to Github Action [#2986](https://github.com/chaos-mesh/chaos-mesh/pull/2986)
 - Bump minimist from 1.2.5 to 1.2.6 in /ui [#3058](https://github.com/chaos-mesh/chaos-mesh/pull/3058)
 - Specify image tag of `build-env` and `dev-env` for each branch [#3071](https://github.com/chaos-mesh/chaos-mesh/pull/3071)
+- Specify image tag in e2e tests [#3147](https://github.com/chaos-mesh/chaos-mesh/pull/3147)
 
 ### Deprecated
 


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #3144 

### What's changed and how it works?

- bootstrap environment always with images with the tag `latest` because `make image` would always build images with `latest` 

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
