### PR TITLE
e2e: upload build image cache to the github (#3097)

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,11 +12,30 @@ jobs:
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
+
+      # once the https://github.com/actions/cache/pull/498 gets merged,
+      # we can switch to the official cache action
+      - name: Restore build cache
+        id: cache
+        uses: martijnhols/actions-cache/restore@main
+        with:
+          path: cache
+          # don't worry about the branch, the github cache
+          # is only accessible in the same branch (or a pull_request
+          # whose target is the branch)
+          key: e2e-image-build-cache-${{ runner.os }}
+
       - name: build e2e images
         env:
           DOCKER_REGISTRY: ghcr.io
+          DOCKER_CACHE: 1
+          DOCKER_CACHE_DIR: ${{ github.workspace }}/cache
+          GO_BUILD_CACHE: ${{ github.workspace }}/cache
+          DOCKER_CLI_EXPERIMENTAL: enabled 
         run: |
-          make image e2e-image
+          docker buildx create --use --name chaos-mesh-builder
+          make -j4 image e2e-image
+
       - name: save docker images
         run: |
           mkdir -p ./output/saved-images
@@ -24,18 +43,30 @@ jobs:
           docker image save ghcr.io/chaos-mesh/chaos-daemon:latest > ./output/saved-images/chaos-daemon.tgz
           docker image save ghcr.io/chaos-mesh/chaos-mesh:latest > ./output/saved-images/chaos-mesh.tgz
           docker image save ghcr.io/pingcap/e2e-helper:latest > ./output/saved-images/e2e-helper.tgz
+
       - name: upload saved images
         uses: actions/upload-artifact@v2
         with:
           name: saved-images
           path: ./output/saved-images
           retention-days: 7
+
   build-e2e-binary:
     runs-on: ubuntu-latest
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
+      - name: Restore build cache
+        id: cache
+        uses: martijnhols/actions-cache/restore@main
+        with:
+          path: cache
+          key: e2e-binary-build-cache-${{ runner.os }}
       - name: build e2e binary
+        env:
+          DOCKER_CACHE: 1
+          DOCKER_CACHE_DIR: ${{ github.workspace }}/cache
+          GO_BUILD_CACHE: ${{ github.workspace }}/cache
         run: |
           make e2e-build
       - name: upload e2e binary
@@ -44,6 +75,7 @@ jobs:
           name: e2e-binary
           path: ./e2e-test/image/e2e/bin
           retention-days: 7
+
   e2e-test-matrix:
     needs:
       - build-image
@@ -73,12 +105,6 @@ jobs:
         with:
           name: saved-images
           path: ./output/saved-images
-      - name: restore e2e images
-        run: |
-          docker load -i ./output/saved-images/chaos-dashboard.tgz
-          docker load -i ./output/saved-images/chaos-daemon.tgz
-          docker load -i ./output/saved-images/chaos-mesh.tgz
-          docker load -i ./output/saved-images/e2e-helper.tgz
       - name: download e2e binary
         uses: actions/download-artifact@v2
         with:
@@ -101,10 +127,10 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: load image into minikube
         run: |
-          minikube image load ghcr.io/chaos-mesh/chaos-dashboard:latest
-          minikube image load ghcr.io/chaos-mesh/chaos-daemon:latest
-          minikube image load ghcr.io/chaos-mesh/chaos-mesh:latest
-          minikube image load ghcr.io/pingcap/e2e-helper:latest
+          minikube image load ./output/saved-images/chaos-dashboard.tgz
+          minikube image load ./output/saved-images/chaos-daemon.tgz
+          minikube image load ./output/saved-images/chaos-mesh.tgz
+          minikube image load ./output/saved-images/e2e-helper.tgz
       - name: Setup Helm
         uses: azure/setup-helm@v1
       - name: Install Chaos Mesh

--- a/.github/workflows/e2e_test_upload_cache.yml
+++ b/.github/workflows/e2e_test_upload_cache.yml
@@ -1,0 +1,47 @@
+name: E2E Test Upload Cache
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+      - release-*
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout codes
+        uses: actions/checkout@v2
+      - name: build e2e images
+        env:
+          DOCKER_CACHE: 1
+          DOCKER_CACHE_DIR: ${{github.workspace}}/cache
+          GO_BUILD_CACHE: ${{github.workspace}}/cache
+          DOCKER_CLI_EXPERIMENTAL: enabled 
+        run: |
+          docker buildx create --use --name chaos-mesh-builder
+          make -j4 image e2e-image
+      - name: upload build cache
+        uses: martijnhols/actions-cache/save@main
+        with:
+          path: cache
+          key: e2e-image-build-cache-${{ runner.os }}
+
+  build-e2e-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout codes
+        uses: actions/checkout@v2
+      - name: build e2e binary
+        env:
+          DOCKER_CACHE: 1
+          DOCKER_CACHE_DIR: ${{github.workspace}}/cache
+          GO_BUILD_CACHE: ${{github.workspace}}/cache
+        run: |
+          make e2e-build
+      - name: upload build cache
+        uses: martijnhols/actions-cache/save@main
+        with:
+          path: cache
+          key: e2e-binary-build-cache-${{ runner.os }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
-- Nothing
+- Add e2e build image cache [#3097](https://github.com/chaos-mesh/chaos-mesh/pull/3151)
 
 ### Changed
 


### PR DESCRIPTION
Cherry Pick #3097 

### What's changed and how it works?

1. Upload the build cache for every commit in the master/release branch.
2. Automatically download the cache from the github to accelerate the build.
3. `minikube image load` from the archive directly.

![image](https://user-images.githubusercontent.com/5244316/161370675-f7947979-bfd7-463a-a819-631b82e89154.png)

The build time can be shrunken to 1min25s