### PR TITLE
ci: ignore internal link/anchor

### DIFF
--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -8,6 +8,9 @@
     },
     {
       "pattern": "url"
+    },
+    {
+      "pattern": "^#"
     }
   ],
   "aliveStatusCodes": [200, 403, 500, 502, 503]


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

 - fix  https://github.com/chaos-mesh/chaos-mesh/issues/3161

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- update ignore patterns, ignore links (anchor) start with `#`

as https://github.com/gaurav-nelson/github-action-markdown-link-check/pull/129#issuecomment-1103317932 says, a available solution is to disable checks on anchors. So I set a ignore pattern for that

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.1
  - [ ] release-2.0

### Checklist

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

I tested it with `act` on my local machine. :)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
