### PR TITLE
update description of memory stressors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
-- Nothing
+- Update description of memory stressors [#3225](https://github.com/chaos-mesh/chaos-mesh/pull/3225)
 
 ### Security
 

--- a/ui/app/src/components/NewExperimentNext/form/Stress.tsx
+++ b/ui/app/src/components/NewExperimentNext/form/Stress.tsx
@@ -104,7 +104,7 @@ const Stress: React.FC<StressProps> = ({ onSubmit }) => {
             <LabelField
               name="stressors.memory.options"
               label="Options of Memory stressors"
-              helperText="Type string and end with a space to generate the stress-ng options"
+              helperText="Type string and end with a space to generate the memStress options"
             />
           </Space>
 


### PR DESCRIPTION
Signed-off-by: FingerLeader <wanxfinger@gmail.com>

Because we use `memStress` to implement memory stressors now, this field has to be updated.
