### PR TITLE
[BugBash] SC2068: Double quote array expansions to avoid re-splitting elements

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -336,4 +336,4 @@ if [ -n "${ARTIFACTS}" -a -z "$SKIP_DUMP" ]; then
 fi
 
 echo "info: run 'kubetest2 ${kubetest2_args[@]} -- hack/run-e2e.sh $@'"
-$KUBETSTS2_BIN ${kubetest2_args[@]} -- hack/run-e2e.sh "$@"
+$KUBETSTS2_BIN "${kubetest2_args[@]}" -- hack/run-e2e.sh "$@"

--- a/hack/local-up-chaos-mesh.sh
+++ b/hack/local-up-chaos-mesh.sh
@@ -118,7 +118,7 @@ images=(
     $IMAGE_REGISTRY_PREFIX/chaos-mesh/chaos-dashboard:${IMAGE_TAG}
     $IMAGE_REGISTRY_PREFIX/chaos-mesh/chaos-daemon:${IMAGE_TAG}
 )
-for n in ${images[@]}; do
+for n in "${images[@]}"; do
     echo "info: loading image $n"
     $KIND_BIN load docker-image --name $CLUSTER $n
 done

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -74,8 +74,8 @@ function e2e::image_load() {
         local nodes=$($KIND_BIN get nodes --name $CLUSTER | grep -v 'control-plane$')
         echo $nodes
         echo "info: load images ${images[@]}"
-        for image in ${images[@]}; do
-            $KIND_BIN load docker-image --name $CLUSTER ${IMAGE_REGISTRY}/$image:$IMAGE_TAG --nodes $(hack::join ',' ${nodes[@]})
+        for image in "${images[@]}"; do
+            $KIND_BIN load docker-image --name $CLUSTER ${IMAGE_REGISTRY}/$image:$IMAGE_TAG --nodes $(hack::join ',' "${nodes[@]}")
         done
 
         # bypassing docker pull rate limit inner the kind container: kindest/node has no credentials
@@ -85,9 +85,9 @@ function e2e::image_load() {
         docker pull pingcap/coredns:v0.2.0
         docker pull nginx:latest
         docker pull gcr.io/google-containers/pause:latest
-        $KIND_BIN load docker-image --name $CLUSTER pingcap/coredns:v0.2.0 --nodes $(hack::join ',' ${nodes[@]})
-        $KIND_BIN load docker-image --name $CLUSTER nginx:latest --nodes $(hack::join ',' ${nodes[@]})
-        $KIND_BIN load docker-image --name $CLUSTER gcr.io/google-containers/pause:latest --nodes $(hack::join ',' ${nodes[@]})
+        $KIND_BIN load docker-image --name $CLUSTER pingcap/coredns:v0.2.0 --nodes $(hack::join ',' "${nodes[@]}")
+        $KIND_BIN load docker-image --name $CLUSTER nginx:latest --nodes $(hack::join ',' "${nodes[@]}")
+        $KIND_BIN load docker-image --name $CLUSTER gcr.io/google-containers/pause:latest --nodes $(hack::join ',' "${nodes[@]}")
     fi
 }
 
@@ -180,4 +180,4 @@ if [ -n "$REPORT_DIR" ]; then
 fi
 
 echo "info: docker ${docker_args[@]} $E2E_IMAGE ${e2e_args[@]}"
-docker ${docker_args[@]} $E2E_IMAGE ${e2e_args[@]}
+docker "${docker_args[@]}" $E2E_IMAGE "${e2e_args[@]}"


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Double quote array expansions to avoid re-splitting elements

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.1
  - [ ] release-2.0

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
