### PR TITLE
re-trigger ci 'must_update_changelog' when labels change

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,13 +12,10 @@ on:
     branches:
       - master
       - release-*
-env: 
-  NOT_TARGET_LABELED: ${{ github.event.action == 'labeled' && github.event.label.name != 'rebuild-build-env-image' && github.event.label.name != 'rebuild-dev-env-image' }}
-
 jobs:
   build-image:
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
+    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -83,7 +80,7 @@ jobs:
 
   build-e2e-binary:
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
+    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -112,7 +109,7 @@ jobs:
       - build-image
       - build-e2e-binary
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
+    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     strategy:
       fail-fast: false
       matrix:
@@ -215,7 +212,7 @@ jobs:
   pass:
     name: E2E Test Passed
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
+    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - run: exit 0
     needs:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -3,19 +3,12 @@ name: E2E Test
 on:
   workflow_dispatch: {}
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
     branches:
       - master
       - release-*
 jobs:
   build-image:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -80,7 +73,6 @@ jobs:
 
   build-e2e-binary:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -109,7 +101,6 @@ jobs:
       - build-image
       - build-e2e-binary
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     strategy:
       fail-fast: false
       matrix:
@@ -212,7 +203,6 @@ jobs:
   pass:
     name: E2E Test Passed
     runs-on: ubuntu-latest
-    if: ${{ github.event.action != 'labeled'|| github.event.label.name == 'rebuild-build-env-image' || github.event.label.name == 'rebuild-dev-env-image' }}
     steps:
       - run: exit 0
     needs:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,11 +12,13 @@ on:
     branches:
       - master
       - release-*
+env: 
+  NOT_TARGET_LABELED: ${{ github.event.action == 'labeled' && github.event.label.name != 'rebuild-build-env-image' && github.event.label.name != 'rebuild-dev-env-image' }}
+
 jobs:
   build-image:
     runs-on: ubuntu-latest
-    env: 
-      NOT_TARGET_LABELED: ${{ github.event.action == 'labeled' && github.event.label.name != 'rebuild-build-env-image' && github.event.label.name != 'rebuild-dev-env-image' }}
+    if: ${{ env.NOT_TARGET_LABELED == false }}
     steps:
       - name: "Skip if labeled not target label"
         id: "skip-if-not-target"
@@ -88,6 +90,7 @@ jobs:
 
   build-e2e-binary:
     runs-on: ubuntu-latest
+    if: ${{ env.NOT_TARGET_LABELED == false }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -116,6 +119,7 @@ jobs:
       - build-image
       - build-e2e-binary
     runs-on: ubuntu-latest
+    if: ${{ env.NOT_TARGET_LABELED == false }}
     strategy:
       fail-fast: false
       matrix:
@@ -218,6 +222,7 @@ jobs:
   pass:
     name: E2E Test Passed
     runs-on: ubuntu-latest
+    if: ${{ env.NOT_TARGET_LABELED == false }}
     steps:
       - run: exit 0
     needs:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -3,13 +3,28 @@ name: E2E Test
 on:
   workflow_dispatch: {}
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
     branches:
       - master
       - release-*
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    env: 
+      NOT_TARGET_LABELED: ${{ github.event.action == 'labeled' && github.event.label.name != 'rebuild-build-env-image' && github.event.label.name != 'rebuild-dev-env-image' }}
     steps:
+      - name: "Skip if labeled not target label"
+        id: "skip-if-not-target"
+        run: |
+          if [ "${NOT_TARGET_LABELED}" = "true" ]; then
+            echo "the label name is not 'rebuild-build-env-image' or 'rebuild-dev-env-image', skip"
+            exit 0
+          fi
       - name: checkout codes
         uses: actions/checkout@v2
       - name: Build Chaos Mesh Build Env

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-image:
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == false }}
+    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
 
   build-e2e-binary:
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == false }}
+    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -112,7 +112,7 @@ jobs:
       - build-image
       - build-e2e-binary
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == false }}
+    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -215,7 +215,7 @@ jobs:
   pass:
     name: E2E Test Passed
     runs-on: ubuntu-latest
-    if: ${{ env.NOT_TARGET_LABELED == false }}
+    if: ${{ env.NOT_TARGET_LABELED == 'false' }}
     steps:
       - run: exit 0
     needs:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ env.NOT_TARGET_LABELED == false }}
     steps:
-      - name: "Skip if labeled not target label"
-        id: "skip-if-not-target"
-        run: |
-          if [ "${NOT_TARGET_LABELED}" = "true" ]; then
-            echo "the label name is not 'rebuild-build-env-image' or 'rebuild-dev-env-image', skip"
-            exit 0
-          fi
       - name: checkout codes
         uses: actions/checkout@v2
       - name: Build Chaos Mesh Build Env

--- a/.github/workflows/must_update_changelog.yml
+++ b/.github/workflows/must_update_changelog.yml
@@ -4,6 +4,12 @@
 name: "Must Update CHANGELOG"
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
     branches:
       - master
       - release-*
@@ -16,7 +22,6 @@ jobs:
     steps:
       - name: "Skip if label exists"
         id: "skip-if-label-exists"
-
         run: |
           if [ "${LABEL_EXISTS}" = "true" ] ; then
             echo "no-need-update-changelog exists, skipping this check"


### PR DESCRIPTION
Signed-off-by: xixi <i@hexilee.me>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The result of CI `must_update_changelog` depends on the label "no-need-update-changelog", but it won't re-run when labels change. This PR resolved a part of #3301.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.2
  - [x] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
