### PR TITLE
cherry-pick(#3300): re-trigger ci 'must_update_changelog' when labels change

### DIFF
--- a/.github/workflows/must_update_changelog.yml
+++ b/.github/workflows/must_update_changelog.yml
@@ -4,6 +4,12 @@
 name: "Must Update CHANGELOG"
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
     branches:
       - master
       - release-*
@@ -16,7 +22,6 @@ jobs:
     steps:
       - name: "Skip if label exists"
         id: "skip-if-label-exists"
-
         run: |
           if [ "${LABEL_EXISTS}" = "true" ] ; then
             echo "no-need-update-changelog exists, skipping this check"


### PR DESCRIPTION
cherry-pick(#3300)

--------------------

* re-trigger ci 'must_update_changelog' and 'e2e_test' when labels change

Signed-off-by: xixi <i@hexilee.me>

* update skip check for e2e_test

Signed-off-by: xixi <i@hexilee.me>

* delete unused steps

Signed-off-by: xixi <i@hexilee.me>

* fix e2e_test

Signed-off-by: xixi <i@hexilee.me>

* fix e2e_test again

Signed-off-by: xixi <i@hexilee.me>

* revoke e2e_test

Signed-off-by: xixi <i@hexilee.me>

* trigger ci

Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

Co-authored-by: YangKeao <yangkeao@chunibyo.icu>
Co-authored-by: Ti Chi Robot <ti-community-prow-bot@tidb.io>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
