### PR TITLE
Set certificate.spec.privateKey.rotationPolicy on Certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add `chaosDaemon.updateStrategy` to Helm chart to allow configuring `DaemonSetUpdateStrategy` for chaos-daemon [#3108](https://github.com/chaos-mesh/chaos-mesh/pull/3108)
 - Add AArch64 support for TimeChaos [#3088](https://github.com/chaos-mesh/chaos-mesh/pull/3088)
 - Add integration test and link test on arm [#3177](https://github.com/chaos-mesh/chaos-mesh/pull/3177)
+- Add `spec.privateKey.rotationPolicy` to Certificates, to comply with requirements in cert-manager 1.8 [#3325](https://github.com/chaos-mesh/chaos-mesh/pull/3325)
 
 ### Changed
 

--- a/helm/chaos-mesh/templates/cert-manager-certs.yaml
+++ b/helm/chaos-mesh/templates/cert-manager-certs.yaml
@@ -58,6 +58,8 @@ spec:
   isCA: true
   issuerRef:
     name: chaos-mesh-selfsigned
+  privateKey:
+    rotationPolicy: Never
 ---
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
@@ -105,6 +107,8 @@ spec:
   secretName: {{ template "chaos-mesh.webhook.certs" . }}
   issuerRef:
     name: chaos-mesh-ca
+  privateKey:
+    rotationPolicy: Never
 ---
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
@@ -130,6 +134,8 @@ spec:
   secretName: {{ template "chaos-mesh.daemon-client.certs" . }}
   issuerRef:
     name: chaos-mesh-ca
+  privateKey:
+    rotationPolicy: Never
 ---
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
@@ -155,4 +161,6 @@ spec:
   secretName: {{ template "chaos-mesh.daemon.certs" . }}
   issuerRef:
     name: chaos-mesh-ca
+  privateKey:
+    rotationPolicy: Never
 {{- end }}


### PR DESCRIPTION
### What problem does this PR solve?

As of cert-manager version 1.8, the field spec.privateKey.rotationPolicy on Certificate objects is validated. Valid values are 'Always' or 'Never'.
See the cert-manager release notes for more information: https://cert-manager.io/docs/release-notes/release-notes-1.8#breaking-changes-you-must-read-this-before-you-upgrade

<!-- Uncomment this line if some issues to close -->
This will close #3324 

### What's changed and how it works?

This adds the following to the four Certificates created by chaos-mesh:

```
privateKey:
  rotationPolicy: Never
```

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

1. Set webhook.certManager.enabled: true in values.yaml
2. Run `helm template chaos-mesh .`
3. Look at the created Certificates

The created Certificates should have a value set for spec.privateKey.rotationPolicy, like this:

```
apiVersion: cert-manager.io/v1alpha2
kind: Certificate
metadata:
  name: chaos-mesh-cert
  namespace: "default"
  labels:
    helm.sh/chart: chaos-mesh-v0.2.1
    app.kubernetes.io/name: chaos-mesh
    app.kubernetes.io/instance: chaos-mesh
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: chaos-mesh
    app.kubernetes.io/version: v0.9.0
    app.kubernetes.io/component: chaos-mesh-cert
spec:
  duration: 43800h #5year
  dnsNames:
    - chaos-mesh-controller-manager
    - chaos-mesh-controller-manager.default
    - chaos-mesh-controller-manager.default.svc
  isCA: false
  secretName: chaos-mesh-webhook-certs
  issuerRef:
    name: chaos-mesh-ca
  privateKey:
    rotationPolicy: Never
```

Side effects

- [ ] Breaking backward compatibility

Looking at older cert-manager API docs, the rotationPolicy property looks like it has been there at least as far back as v1alpha2. As such I don't expect any problems with backwards compatibility.

https://cert-manager.io/v1.1-docs/reference/api-docs/#cert-manager.io/v1alpha2.PrivateKeyRotationPolicy
https://cert-manager.io/v1.1-docs/reference/api-docs/#cert-manager.io/v1alpha3.PrivateKeyRotationPolicy
https://cert-manager.io/v1.1-docs/reference/api-docs/#cert-manager.io/v1beta1.PrivateKeyRotationPolicy