### PR TITLE
fix(ui): `space` to `enter` in helper texts

### DIFF
--- a/ui/app/src/i18n/en.json
+++ b/ui/app/src/i18n/en.json
@@ -158,7 +158,7 @@
         "imageHelper": "The image of container",
         "imageValidation": "The image is required",
         "command": "Command",
-        "commandHelper": "Optional. Specifies the command running in the container, enter the string and ends a space to create a single command."
+        "commandHelper": "Optional. Specifies the command running in the container, enter the string and ends Enter to create a single command."
       },
       "conditionalBranches": {
         "title": "Conditional branches (Optional)",
@@ -335,7 +335,7 @@
     "durationHelper": "Supported formats of the duration are: ms / s / m / h.",
     "edit": "Edit",
     "ip": "IP address",
-    "isKVHelperText": "Type key:value and end with a TAB to generate a key/value pair",
+    "isKVHelperText": "Type key:value and end with Enter to generate a key/value pair",
     "logout": "Logout",
     "logoutDesc": "You need to re-enter the token after logging out",
     "multiOptions": "Support mutiple options",
@@ -396,6 +396,6 @@
   },
   "physic": {
     "address": "Address",
-    "addressHelper": "Type and end with a space to add one or more chaosd addresses"
+    "addressHelper": "Type and end with Enter to add one or more chaosd addresses"
   }
 }

--- a/ui/app/src/i18n/zh.json
+++ b/ui/app/src/i18n/zh.json
@@ -174,7 +174,7 @@
         "imageHelper": "容器的镜像",
         "imageValidation": "镜像不能为空",
         "command": "命令",
-        "commandHelper": "可选项。指定在容器中运行的命令，输入字符串并以空格结尾来创建单条命令。"
+        "commandHelper": "可选项。指定在容器中运行的命令，输入字符串并以回车结束来创建单条命令。"
       },
       "conditionalBranches": {
         "title": "条件分支（可选）",
@@ -394,6 +394,6 @@
   },
   "physic": {
     "address": "地址",
-    "addressHelper": "键入并以空格结尾来添加一个或多个 chaosd 地址"
+    "addressHelper": "键入并以回车结束来添加一个或多个 chaosd 地址"
   }
 }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

As the title.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
