### PR TITLE
Add a comment to the flag size of memory stress in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - CI: version unrelated manifests [#3293](https://github.com/chaos-mesh/chaos-mesh/pull/3293)
 - Bump chaos-tproxy to v0.4.6 [#3272](https://github.com/chaos-mesh/chaos-mesh/pull/3272)
 - Helm charts: using 0.0.0 as version and appVersion [#3311](https://github.com/chaos-mesh/chaos-mesh/pull/3311)
+- Add a comment to the flag size of memory stress in the dashboard [#3359](https://github.com/chaos-mesh/chaos-mesh/pull/3359)
 
 ### Deprecated
 

--- a/ui/app/src/components/NewExperimentNext/form/Stress.tsx
+++ b/ui/app/src/components/NewExperimentNext/form/Stress.tsx
@@ -100,7 +100,10 @@ const Stress: React.FC<StressProps> = ({ onSubmit }) => {
               error={getIn(errors, 'stressors.memory.workers') ? true : false}
               inputProps={{ min: 0 }}
             />
-            <TextField name="stressors.memory.size" label="Size" helperText="Memory size" />
+            <TextField name="stressors.memory.size" 
+              label="Size" 
+              helperText="Memory size specifies the memory size to be occupied or a percentage of the total memory size" 
+            />
             <LabelField
               name="stressors.memory.options"
               label="Options of Memory stressors"


### PR DESCRIPTION
Signed-off-by: FingerLeader <wanxfinger@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Add a comment to the flag `size` of memory stress in the dashboard, so that users can easily know they can set the `size` to a percentage. 

### What's changed and how it works?
A sigle comment at the front end.
<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [x] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
