### PR TITLE
ci: ignore microsoft within markdown link check

### DIFF
--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^#"
+    },
+    {
+      "pattern": "^https://www.microsoft.com"
     }
   ],
   "aliveStatusCodes": [200, 403, 500, 502, 503]


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

"markdown-link-check" usually failed because of `https://www.microsoft.com/` in the last several weeks, I  think it might relate to the robot access policy of MS.

But we have no other way except ignore that error.

- try to fix CI "markdown-link-check" failed with `https://www.microsoft.com/`

I have created an issue https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/140 on upstream.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- ignore `https://www.microsoft.com/` with CI markdown-link-check

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.2
  - [x] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```text
Please add a release note.

You can safely ignore this section if you don't think this PR needs a release note.
```

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
