### PR TITLE
dnschaos: Make possible to have more than one dns chaos server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Refine logging in pkg/dashboard/store, removed global the log [#3143](https://github.com/chaos-mesh/chaos-mesh/pull/3143)
 - Renamed namespace from chaos-testing to chaos-mesh [#3353](https://github.com/chaos-mesh/chaos-mesh/pull/3353)
 - Use ContainerSelector in kernel chaos [#3395](https://github.com/chaos-mesh/chaos-mesh/pull/3395)
+- Make possible to have more than one dns chaos server [#3381](https://github.com/chaos-mesh/chaos-mesh/pull/3381)
 
 ### Deprecated
 

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -22,10 +22,7 @@ metadata:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-dns-server
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  replicas: {{ .Values.dnsServer.replicas | default 1 }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -397,6 +397,8 @@ dnsServer:
   name: chaos-mesh-dns-server
   # grpc port for chaos-dns-server
   grpcPort: 9288
+  # Number of replicas
+  replicas: 1
   # CPU/Memory resource requests/limits for chaos-dns-server pod
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
This PR enables to have more than one dns chaos servers running inside a k8s cluster (which might help to have dns chaos in a production environment with high load).
<!-- Uncomment this line if some issues to close -->
Close #2409 

### What's changed and how it works?
Basically, the patch's logic is to retrieve all the dns pods fulfilling the label selector returned by the dns chaos service. Once the pods list filled, we iterate over it and we apply/recover the given dnschaos.
<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [x] Need to update `chaos-mesh/website` (for documentation)

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [x] E2E test
- [ ] No code
- [x] Manual test (add steps below)

steps:
Tried to increase/decrease `replicas` field in `dnsServer` helm value to check if dnschaos were applied/recovered correctly ✅.