### PR TITLE
stresschaos: run pause before choom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix make check does not respect the env-images.yaml [#3210] (https://github.com/chaos-mesh/chaos-mesh/pull/3210)
 - SC2004: Remove unnecessary $ on arithmetic variables [#3247](https://github.com/chaos-mesh/chaos-mesh/pull/3247)
 - PhysicalMachineChaos: update stress options type [#3347](https://github.com/chaos-mesh/chaos-mesh/pull/3347)
-
+- StressChaos: run `pause` before `choom` [#3405](https://github.com/chaos-mesh/chaos-mesh/pull/3405)
 
 ### Security
 

--- a/pkg/bpm/build_linux.go
+++ b/pkg/bpm/build_linux.go
@@ -45,14 +45,19 @@ func (b *CommandBuilder) Build(ctx context.Context) *ManagedCommand {
 		cmd = nsexecPath
 	}
 
-	if b.pause {
-		args = append([]string{cmd}, args...)
-		cmd = pausePath
-	}
-
 	if b.oomScoreAdj != 0 {
 		args = append([]string{"-n", strconv.Itoa(b.oomScoreAdj), "--", cmd}, args...)
 		cmd = "choom"
+	}
+
+	// pause should always be the first command to execute because the
+	// `stress_server` will check whether the /proc/PID/comm is `pause` to
+	// determine whether it should continue to send `SIGCONT`. If the first
+	// command is not `pause`, the real `pause` program may not receive the
+	// command successfully.
+	if b.pause {
+		args = append([]string{cmd}, args...)
+		cmd = pausePath
 	}
 
 	if c := mock.On("MockProcessBuild"); c != nil {

--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -187,6 +187,7 @@ func (s *DaemonServer) ExecCPUStressors(ctx context.Context,
 		log.Info("send signal to resume process")
 		time.Sleep(time.Millisecond)
 
+		// TODO: integrate the resume process into the bpm
 		comm, err := util.ReadCommName(cmd.Process.Pid)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

To modify the `oom_score_adj`, we used the `choom` program. Then the whole process would be: `choom pause nsexec memStress`. However, if the `choom` runs not that fast, when the chaos-daemon is sending SIGCONT to the subprocess, it may find the comm is `choom` and thought this process has resumed.

```go
comm, err := util.ReadCommName(cmd.Process.Pid)
if err != nil {
	return nil, err
}
if comm != "pause\n" {
	log.Info("pause has been resumed", "comm", comm)
	break
}
```

So, the `pause` should always be the first command to execute.

### What's changed and how it works?

Reorder the command executed by bpm.
