### PR TITLE
bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ## [Unreleased]
 
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- Nothing
+
+### Security
+
+- Nothing
+
+## [2.2.1] - 2022-06-29
+
 ### Added
 
 - JVMChaos: support inject fault into MySQL client [#3189](https://github.com/chaos-mesh/chaos-mesh/pull/3189)

--- a/helm/chaos-mesh/Chart.yaml
+++ b/helm/chaos-mesh/Chart.yaml
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 apiVersion: v2
-appVersion: "2.2.0"
+appVersion: "2.2.1"
 description: Chaos Mesh is a cloud-native Chaos Engineering platform that orchestrates chaos on Kubernetes environments.
 home: https://chaos-mesh.org
 icon: https://raw.githubusercontent.com/pingcap/chaos-mesh/master/static/logo.svg
 sources:
   - https://github.com/pingcap/chaos-mesh
 name: chaos-mesh
-version: "2.2.0"
+version: "2.2.1"
 keywords:
   - chaos-engineering
   - resiliency

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -48,7 +48,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "v2.2.0"
+  tag: "v2.2.1"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ FLAGS:
         --microk8s           Install chaos-mesh in microk8s environment
         --host-network       Install chaos-mesh using hostNetwork
 OPTIONS:
-    -v, --version            Version of chaos-mesh, default value: v2.2.0
+    -v, --version            Version of chaos-mesh, default value: v2.2.1
     -l, --local [kind]       Choose a way to run a local kubernetes cluster, supported value: kind,
                              If this value is not set and the Kubernetes is not installed, this script will exit with 1.
     -n, --name               Name of Kubernetes cluster, default value: kind
@@ -60,7 +60,7 @@ EOF
 
 main() {
     local local_kube=""
-    local cm_version="v2.2.0"
+    local cm_version="v2.2.1"
     local kind_name="kind"
     local kind_version="v0.11.1"
     local node_num=3
@@ -827,7 +827,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-daemon
 ---
 # Source: chaos-mesh/templates/chaos-dashboard-rbac.yaml
@@ -855,7 +855,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
@@ -882,7 +882,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
@@ -909,7 +909,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: webhook-secret
 type: Opaque
 data:
@@ -927,7 +927,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 rules:
   # chaos-dashboard could list namespace for selector hints
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 rules:
   # chaos dashboard could list pods for selector hints
@@ -992,7 +992,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1034,7 +1034,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1081,7 +1081,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1102,7 +1102,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-daemon
 spec:
   clusterIP: None
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 spec:
   type: ClusterIP
@@ -1327,7 +1327,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
 spec:
   selector:
     matchLabels:
@@ -1340,7 +1340,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.0
+        app.kubernetes.io/version: 2.2.1
         app.kubernetes.io/component: chaos-daemon
       annotations:
     spec:
@@ -1417,7 +1417,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: chaos-dashboard
 spec:
   replicas: 1
@@ -1432,7 +1432,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.0
+        app.kubernetes.io/version: 2.2.1
         app.kubernetes.io/component: chaos-dashboard
       annotations:
     spec:
@@ -1529,7 +1529,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: controller-manager
 spec:
   replicas: 3
@@ -1544,7 +1544,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.0
+        app.kubernetes.io/version: 2.2.1
         app.kubernetes.io/component: controller-manager
       annotations:
         rollme: "install.sh"
@@ -1852,7 +1852,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - name: admission-webhook.chaos-mesh.org
@@ -2255,7 +2255,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - clientConfig:
@@ -2625,7 +2625,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.1
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - clientConfig:


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Bump version to 2.2.1

### Release Note

Here is the draft of release note:

# v2.2.1 Release Notes

This release introduces several new features, enhancements, bug fixes for Chaos Mesh.

## Enhancements

- JVMChaos: support inject fault into MySQL client [#3189](https://github.com/chaos-mesh/chaos-mesh/pull/3189)

## Fixes

- PhysicalMachineChaos: update stress options type [#3354](https://github.com/chaos-mesh/chaos-mesh/pull/3354)
- StressChaos: run `pause` before `choom` [#3405](https://github.com/chaos-mesh/chaos-mesh/pull/3405)
