### PR TITLE
Fix Workflow Validating Webhook Panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - SC2004: Remove unnecessary $ on arithmetic variables [#3247](https://github.com/chaos-mesh/chaos-mesh/pull/3247)
 - PhysicalMachineChaos: update stress options type [#3347](https://github.com/chaos-mesh/chaos-mesh/pull/3347)
 - StressChaos: run `pause` before `choom` [#3405](https://github.com/chaos-mesh/chaos-mesh/pull/3405)
+- Fix Workflow Validating Webhook Panic [#3413](https://github.com/chaos-mesh/chaos-mesh/pull/3413)
 
 ### Security
 

--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -203,6 +203,7 @@ func shouldNotSetupDurationInTheChaos(path *field.Path, template Template) field
 
 	if template.EmbedChaos == nil {
 		result = append(result, field.Invalid(path.Child(string(template.Type)), nil, fmt.Sprintf("the value of chaos %s is required", template.Type)))
+		return result
 	}
 
 	spec := reflect.ValueOf(template.EmbedChaos).Elem().FieldByName(string(template.Type))

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -426,6 +426,20 @@ func Test_shouldNotSetupDurationInTheChaos(t *testing.T) {
 		want field.ErrorList
 	}{
 		{
+			name: "should return error when embed chaos is not set",
+			args: args{
+				path: templatesPath,
+				template: Template{
+					Name:       "invalid-pod-chaos",
+					Type:       TypePodChaos,
+					EmbedChaos: nil,
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(templatesPath.Child(string(TypePodChaos)), nil, fmt.Sprintf("the value of chaos %s is required", string(TypePodChaos))),
+			},
+		},
+		{
 			name: "should not set duration in the chaos",
 			args: args{
 				path: templatesPath,


### PR DESCRIPTION


### What problem does this PR solve?

When using a malformed Workflow that would contain no EmbedChaos,
the validating webhook was having a panic because the
shouldNotSetupDurationInTheChaos function was not returning early
and access a nil value afterwards.

### What's changed and how it works?

`shouldNotSetupDurationInTheChaos` returns early when EmbedChaos is nil, avoiding the line
`	spec := reflect.ValueOf(template.EmbedChaos).Elem().FieldByName(string(template.Type))
`
to be reached, thus removing a panic.

This problem was happening to me when applying a misconfigured Workflow:

```yaml
apiVersion: chaos-mesh.org/v1alpha1
kind: Workflow
metadata:
  name: workflow-fail
  namespace: kube-system
spec:
  entry: entry
  templates:
  - name: entry
    templateType: Serial
    deadline: 5m
    children:
    - kill-coredns
  - name: kill-coredns
    templateType: PodChaos
    schedule:
      schedule: "@every 50s"
      concurrencyPolicy: Forbid
      type: PodChaos
      podChaos:
        selector:
          namespaces:
          - kube-system
          labelSelectors:
            k8s-app: kube-dns
        mode: one
        action: pod-kill
```

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
