### PR TITLE
JVMChaos: update the error message that can be ignored

### DIFF
--- a/pkg/chaosdaemon/jvm_server.go
+++ b/pkg/chaosdaemon/jvm_server.go
@@ -111,7 +111,7 @@ func (s *DaemonServer) InstallJVMRules(ctx context.Context,
 
 		// this error is caused by the different attach result codes in different java versions. In fact, the agent has attached success, just ignore it here.
 		// refer to https://stackoverflow.com/questions/54340438/virtualmachine-attach-throws-com-sun-tools-attach-agentloadexception-0-when-usi/54454418#54454418
-		errMsg4 := "install com.sun.tools.attach.AgentLoadException"
+		errMsg4 := "com.sun.tools.attach.AgentLoadException"
 		if !strings.Contains(string(output), errMsg1) && !strings.Contains(string(output), errMsg2) &&
 			!strings.Contains(string(output), errMsg3) && !strings.Contains(string(output), errMsg4) {
 			log.Error(err, string(output))


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

fix issue https://github.com/chaos-mesh/chaos-mesh/issues/3330
The agent attached success, but return error, this error can be ignored

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
