### PR TITLE
bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ## [Unreleased]
 
+### Added
+
+- Nothing
+
+### Changed
+
 - Nothing
 
 ### Deprecated
@@ -16,7 +22,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
-- Run build image ci on self-hosted machine [#3429](https://github.com/chaos-mesh/chaos-mesh/pull/3429)
+- Nothing
 
 ### Removed
 
@@ -28,14 +34,19 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Security
 
-- Nothing
+## [2.2.2] - 2022-07-07
+
+### Changed
+
+- Bump chaos-tproxy to v0.5.1 [#3426](https://github.com/chaos-mesh/chaos-mesh/pull/3426)
+- Run build image ci on self-hosted machine [#3429](https://github.com/chaos-mesh/chaos-mesh/pull/3429)
 
 ## [2.2.1] - 2022-06-29
 
 ### Added
 
 - JVMChaos: support inject fault into MySQL client [#3189](https://github.com/chaos-mesh/chaos-mesh/pull/3189)
-- Bump chaos-tproxy to v0.5.1
+
 ### Changed
 
 - Nothing

--- a/helm/chaos-mesh/Chart.yaml
+++ b/helm/chaos-mesh/Chart.yaml
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 apiVersion: v2
-appVersion: "2.2.1"
+appVersion: "2.2.2"
 description: Chaos Mesh is a cloud-native Chaos Engineering platform that orchestrates chaos on Kubernetes environments.
 home: https://chaos-mesh.org
 icon: https://raw.githubusercontent.com/pingcap/chaos-mesh/master/static/logo.svg
 sources:
   - https://github.com/pingcap/chaos-mesh
 name: chaos-mesh
-version: "2.2.1"
+version: "2.2.2"
 keywords:
   - chaos-engineering
   - resiliency

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -48,7 +48,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "v2.2.1"
+  tag: "v2.2.2"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/install.sh
+++ b/install.sh
@@ -827,7 +827,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-daemon
 ---
 # Source: chaos-mesh/templates/chaos-dashboard-rbac.yaml
@@ -855,7 +855,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 ---
 # Source: chaos-mesh/templates/controller-manager-rbac.yaml
@@ -882,7 +882,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 ---
 # Source: chaos-mesh/templates/secrets-configuration.yaml
@@ -909,7 +909,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: webhook-secret
 type: Opaque
 data:
@@ -927,7 +927,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 rules:
   # chaos-dashboard could list namespace for selector hints
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 rules:
   # chaos dashboard could list pods for selector hints
@@ -992,7 +992,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1034,7 +1034,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1081,7 +1081,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1102,7 +1102,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-daemon
 spec:
   clusterIP: None
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 spec:
   type: ClusterIP
@@ -1327,7 +1327,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
 spec:
   selector:
     matchLabels:
@@ -1340,7 +1340,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.1
+        app.kubernetes.io/version: 2.2.2
         app.kubernetes.io/component: chaos-daemon
       annotations:
     spec:
@@ -1417,7 +1417,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: chaos-dashboard
 spec:
   replicas: 1
@@ -1432,7 +1432,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.1
+        app.kubernetes.io/version: 2.2.2
         app.kubernetes.io/component: chaos-dashboard
       annotations:
     spec:
@@ -1529,7 +1529,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: controller-manager
 spec:
   replicas: 3
@@ -1544,7 +1544,7 @@ spec:
         app.kubernetes.io/name: chaos-mesh
         app.kubernetes.io/instance: chaos-mesh
         app.kubernetes.io/part-of: chaos-mesh
-        app.kubernetes.io/version: 2.2.1
+        app.kubernetes.io/version: 2.2.2
         app.kubernetes.io/component: controller-manager
       annotations:
         rollme: "install.sh"
@@ -1852,7 +1852,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - name: admission-webhook.chaos-mesh.org
@@ -2255,7 +2255,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - clientConfig:
@@ -2625,7 +2625,7 @@ metadata:
     app.kubernetes.io/name: chaos-mesh
     app.kubernetes.io/instance: chaos-mesh
     app.kubernetes.io/part-of: chaos-mesh
-    app.kubernetes.io/version: 2.2.1
+    app.kubernetes.io/version: 2.2.2
     app.kubernetes.io/component: admission-webhook
 webhooks:
   - clientConfig:


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Bump version to 2.2.1

### Release Note

Here is the draft of release note:

# v2.2.2 Release Notes

This release introduces one bug fix for Chaos Mesh.

## Changed

- Bump chaos-tproxy to v0.5.1 [#3426](https://github.com/chaos-mesh/chaos-mesh/pull/3426)
- Run build image ci on self-hosted machine [#3429](https://github.com/chaos-mesh/chaos-mesh/pull/3429)