### PR TITLE
ci: run build image on self-hosted arm machine

### DIFF
--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build-specific-architecture:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
         image: [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-kernel, chaos-dlv]
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@master
         with:
@@ -46,8 +46,6 @@ jobs:
           IMAGE: ${{ matrix.image }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
           if [ "${IMAGE}" = "chaos-dashboard" ]; then
             UI=1
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Nothing
 
+### Changed
+
+- Run build image ci on self-hosted machine [#3429](https://github.com/chaos-mesh/chaos-mesh/pull/3429)
+
 ### Removed
 
 - Nothing


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Run build image ci on self-hosted arm machine

### What's changed and how it works?



### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.2
  - [x] release-2.1
