### PR TITLE
cherry-pick(3462): implement some missing methods in ctrl server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
-- Nothing
+- Implement some missing methods in ctrl server [#3470](https://github.com/chaos-mesh/chaos-mesh/pull/3470)
 
 ### Deprecated
 

--- a/pkg/ctrl/server/schema.resolvers.go
+++ b/pkg/ctrl/server/schema.resolvers.go
@@ -1157,7 +1157,7 @@ func (r *queryResolver) Pods(ctx context.Context, selector model.PodSelectorInpu
 }
 
 func (r *rawIPSetResolver) IPSetType(ctx context.Context, obj *v1alpha1.RawIPSet) (string, error) {
-	panic(fmt.Errorf("not implemented"))
+	return string(obj.IPSetType), nil
 }
 
 func (r *rawIptablesResolver) Direction(ctx context.Context, obj *v1alpha1.RawIptables) (string, error) {
@@ -1222,7 +1222,11 @@ func (r *stressChaosSpecResolver) Mode(ctx context.Context, obj *v1alpha1.Stress
 }
 
 func (r *stressChaosStatusResolver) Instances(ctx context.Context, obj *v1alpha1.StressChaosStatus) (map[string]interface{}, error) {
-	panic(fmt.Errorf("not implemented"))
+	instances := make(map[string]interface{})
+	for k, v := range obj.Instances {
+		instances[k] = v
+	}
+	return instances, nil
 }
 
 // AttrOverrideSpec returns generated.AttrOverrideSpecResolver implementation.


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Some methods in ctrl server are unimplemented, they may panic when you use chaosctl.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [x] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
