### PR TITLE
Protect chaos available namespace and filter namespaces if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix Workflow Validating Webhook Panic [#3413](https://github.com/chaos-mesh/chaos-mesh/pull/3413)
 - Overwrite $IMAGE_BUILD_ENV_TAG with $IMAGE_TAG-$ARCH in `upload_env_image.yml` github action [#3444](https://github.com/chaos-mesh/chaos-mesh/pull/3444)
 - Add a judgement of `enterNS` in `getAllInterfaces()` [#3459](https://github.com/chaos-mesh/chaos-mesh/pull/3459)
+- Protect chaos available namespace and filter namespaces if needed [#3473](https://github.com/chaos-mesh/chaos-mesh/pull/3473)
 
 ### Security
 


### PR DESCRIPTION
Signed-off-by: brnck <a.berneckas@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #3452 

### What's changed and how it works?

This PR fixes endpoint `/api/common/chaos-available-namespaces` when **SecurityMode** and ** enableFilterNamespace** - both set to true.

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [X] Manual test (add steps below)

Steps to test:
* Deploy chaos-mesh
* `curl <domain.tld>:<port>/api/common/chaos-available-namespaces` - will return all namespaces
* Set `enableFilterNamespace` to true and redeploy.
* `curl <domain.tld>:<port>/api/common/chaos-available-namespaces` - will return `[]`
* `kubectl annotate ns chaos-mesh chaos-mesh.org/inject=enabled`
* `curl <domain.tld>:<port>/api/common/chaos-available-namespaces` - will return `["chaos-mesh"]`
* Set `SecurityMode` to true and redeploy.
* `curl <domain.tld>:<port>/api/common/chaos-available-namespaces` - will return empty body
* Create token using **token generator** feature in dashboard UI
* `curl -H "Authorization: Bearer <generated_token>" <domain.tld>:<port>/api/common/chaos-available-namespaces` - will return `["chaos-mesh"]`

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
