### PR TITLE
Respect flag enableProfiling in chaos-dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix Workflow Validating Webhook Panic [#3413](https://github.com/chaos-mesh/chaos-mesh/pull/3413)
 - Overwrite $IMAGE_BUILD_ENV_TAG with $IMAGE_TAG-$ARCH in `upload_env_image.yml` github action [#3444](https://github.com/chaos-mesh/chaos-mesh/pull/3444)
 - Add a judgement of `enterNS` in `getAllInterfaces()` [#3459](https://github.com/chaos-mesh/chaos-mesh/pull/3459)
+- Respect flag `enableProfiling` and do not register profiler endpoints when it's false [#3474](https://github.com/chaos-mesh/chaos-mesh/pull/3474)
 
 ### Security
 

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -87,6 +87,8 @@ spec:
               value: "{{ .Values.dnsServer.create }}"
             - name: ROOT_URL
               value: "{{ .Values.dashboard.rootUrl }}"
+            - name: ENABLE_PROFILING
+              value: "{{ .Values.enableProfiling }}"
           volumeMounts:
             - name: storage-volume
               mountPath: {{ .Values.dashboard.persistentVolume.mountPath }}

--- a/install.sh
+++ b/install.sh
@@ -1388,7 +1388,7 @@ spec:
               containerPort: 31766
       volumes:
         - name: socket-path
-          hostPath:
+          hostPath: 
             path: ${socketDir}
         - name: sys-path
           hostPath:

--- a/install.sh
+++ b/install.sh
@@ -1388,7 +1388,7 @@ spec:
               containerPort: 31766
       volumes:
         - name: socket-path
-          hostPath: 
+          hostPath:
             path: ${socketDir}
         - name: sys-path
           hostPath:
@@ -1495,6 +1495,8 @@ spec:
               value: "false"
             - name: ROOT_URL
               value: "http://localhost:2333"
+            - name: ENABLE_PROFILING
+              value: "true"
           volumeMounts:
             - name: storage-volume
               mountPath: /data

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -50,6 +50,9 @@ type ChaosDashboardConfig struct {
 
 	RootUrl string `envconfig:"ROOT_URL" default:"http://localhost:2333" json:"root_path"`
 
+	// enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon
+	EnableProfiling bool `envconfig:"ENABLE_PROFILING" default:"true"`
+
 	DNSServerCreate bool   `envconfig:"DNS_SERVER_CREATE" default:"false" json:"dns_server_create"`
 	Version         string `json:"version"`
 }

--- a/pkg/dashboard/apiserver/server.go
+++ b/pkg/dashboard/apiserver/server.go
@@ -60,8 +60,10 @@ func register(r *gin.Engine, conf *config.ChaosDashboardConfig) {
 func newEngine(config *config.ChaosDashboardConfig) *gin.Engine {
 	r := gin.Default()
 
-	// default is "/debug/pprof"
-	pprof.Register(r)
+	if config.EnableProfiling {
+		// default is "/debug/pprof"
+		pprof.Register(r)
+	}
 
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 		v.RegisterValidation("NameValid", apivalidator.NameValid)

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -2385,6 +2385,11 @@ const docTemplate = `{
                     "type": "boolean",
                     "default": false
                 },
+                "enableProfiling": {
+                    "description": "enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon",
+                    "type": "boolean",
+                    "default": true
+                },
                 "gcp_security_mode": {
                     "description": "GcpSecurityMode will use the gcloud authentication to login to GKE user",
                     "type": "boolean",

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -2377,6 +2377,11 @@
                     "type": "boolean",
                     "default": false
                 },
+                "enableProfiling": {
+                    "description": "enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon",
+                    "type": "boolean",
+                    "default": true
+                },
                 "gcp_security_mode": {
                     "description": "GcpSecurityMode will use the gcloud authentication to login to GKE user",
                     "type": "boolean",

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -20,6 +20,11 @@ definitions:
           EnableFilterNamespace will filter namespace with annotation. Only the pods/containers in namespace
           annotated with `chaos-mesh.org/inject=enabled` will be injected.
         type: boolean
+      enableProfiling:
+        default: true
+        description: enableProfiling is a flag to enable pprof in controller-manager
+          and chaos-daemon
+        type: boolean
       gcp_security_mode:
         default: false
         description: GcpSecurityMode will use the gcloud authentication to login to


### PR DESCRIPTION
Signed-off-by: brnck <a.berneckas@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #3456

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [X] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [X] Manual test (add steps below)

* Deploy chaos-mesh
* `curl <domain>:<port>/debug/pprof/` - will return HTML with profiler endpoints
* Check chaos-dashboard logs - you will see that it registers endpoints
* set `enableProfiling` parameter to `false` and redeploy
* Check chaos-dashboard logs - you will see that it does not register endpoints
* `curl <domain>:<port>/debug/pprof/` - won't return HTML with profiler endpoints. WIll return homepage instead

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
