### PR TITLE
chore: configure QPS and Burst for chaos dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add implementation of blockchaos in chaos-daemon [#2907](https://github.com/chaos-mesh/chaos-mesh/pull/2907)
 - Bump chaos-tproxy to v0.5.1 [#3412](https://github.com/chaos-mesh/chaos-mesh/pull/3412)
 - Allow importing external workflows and copying flow nodes in next generation `New Workflow` [#3368](https://github.com/chaos-mesh/chaos-mesh/pull/3368)
+- Add `QPS` and `Burst` for Chaos Dashboard Configuration [#3476](https://github.com/chaos-mesh/chaos-mesh/pull/3476)
 
 ### Changed
 

--- a/pkg/config/dashboard/dashboard.go
+++ b/pkg/config/dashboard/dashboard.go
@@ -52,6 +52,11 @@ type ChaosDashboardConfig struct {
 
 	DNSServerCreate bool   `envconfig:"DNS_SERVER_CREATE" default:"false" json:"dns_server_create"`
 	Version         string `json:"version"`
+
+	// The QPS config for kubernetes client
+	QPS float32 `envconfig:"QPS" default:"200"`
+	// The Burst config for kubernetes client
+	Burst int `envconfig:"BURST" default:"300"`
 }
 
 // PersistTTLConfig defines the configuration of ttl

--- a/pkg/dashboard/collector/server.go
+++ b/pkg/dashboard/collector/server.go
@@ -78,6 +78,12 @@ func NewServer(
 	var err error
 
 	cfg := ctrl.GetConfigOrDie()
+
+	if conf.QPS > 0 {
+		cfg.QPS = conf.QPS
+		cfg.Burst = conf.Burst
+	}
+
 	s.Manager, err = ctrl.NewManager(cfg, options)
 	if err != nil {
 		logger.Error(err, "unable to start collector")

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -2366,6 +2366,11 @@ const docTemplate = `{
         "config.ChaosDashboardConfig": {
             "type": "object",
             "properties": {
+                "burst": {
+                    "description": "The Burst config for kubernetes client",
+                    "type": "integer",
+                    "default": 300
+                },
                 "cluster_mode": {
                     "description": "ClusterScoped means control Chaos Object in cluster level(all namespace).",
                     "type": "boolean",
@@ -2392,6 +2397,11 @@ const docTemplate = `{
                 "listen_port": {
                     "type": "integer",
                     "default": 2333
+                },
+                "qps": {
+                    "description": "The QPS config for kubernetes client",
+                    "type": "number",
+                    "default": 200
                 },
                 "root_path": {
                     "type": "string",

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -2358,6 +2358,11 @@
         "config.ChaosDashboardConfig": {
             "type": "object",
             "properties": {
+                "burst": {
+                    "description": "The Burst config for kubernetes client",
+                    "type": "integer",
+                    "default": 300
+                },
                 "cluster_mode": {
                     "description": "ClusterScoped means control Chaos Object in cluster level(all namespace).",
                     "type": "boolean",
@@ -2384,6 +2389,11 @@
                 "listen_port": {
                     "type": "integer",
                     "default": 2333
+                },
+                "qps": {
+                    "description": "The QPS config for kubernetes client",
+                    "type": "number",
+                    "default": 200
                 },
                 "root_path": {
                     "type": "string",

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -2,6 +2,10 @@ basePath: /api
 definitions:
   config.ChaosDashboardConfig:
     properties:
+      burst:
+        default: 300
+        description: The Burst config for kubernetes client
+        type: integer
       cluster_mode:
         default: true
         description: ClusterScoped means control Chaos Object in cluster level(all
@@ -27,6 +31,10 @@ definitions:
       listen_port:
         default: 2333
         type: integer
+      qps:
+        default: 200
+        description: The QPS config for kubernetes client
+        type: number
       root_path:
         default: http://localhost:2333
         type: string


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

close #3475

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- append `QPS` and `Burst` to `ChaosDashboardConfig`
- when initializing kubernetes client, respect these configurations.

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.3
  - [x] release-2.2
  - [x] release-2.1


### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
