### PR TITLE
chore: use empty array when no value provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix Workflow Validating Webhook Panic [#3413](https://github.com/chaos-mesh/chaos-mesh/pull/3413)
 - Overwrite $IMAGE_BUILD_ENV_TAG with $IMAGE_TAG-$ARCH in `upload_env_image.yml` github action [#3444](https://github.com/chaos-mesh/chaos-mesh/pull/3444)
 - Add a judgement of `enterNS` in `getAllInterfaces()` [#3459](https://github.com/chaos-mesh/chaos-mesh/pull/3459)
+- Fix the blank screen after create chaos experiment with "By YAML" [#3489](https://github.com/chaos-mesh/chaos-mesh/pull/3489)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add a judgement of `enterNS` in `getAllInterfaces()` [#3459](https://github.com/chaos-mesh/chaos-mesh/pull/3459)
 - Respect flag `enableProfiling` and do not register profiler endpoints when it's false [#3474](https://github.com/chaos-mesh/chaos-mesh/pull/3474)
 - Fix JVMChaos loading missing jar file for injection [#3491](https://github.com/chaos-mesh/chaos-mesh/pull/3491)
-- Fix the blank screen after create chaos experiment with "By YAML" [#3489](https://github.com/chaos-mesh/chaos-mesh/pull/3489)
+- Fix the blank screen after creating chaos experiment with "By YAML" [#3489](https://github.com/chaos-mesh/chaos-mesh/pull/3489)
 
 ### Security
 

--- a/ui/app/src/components/FormField/AutocompleteField.tsx
+++ b/ui/app/src/components/FormField/AutocompleteField.tsx
@@ -27,7 +27,7 @@ export interface AutocompleteFieldProps extends MuiExtendsAutocompleteFieldProps
 
 const AutocompleteField: React.FC<AutocompleteFieldProps> = ({ name, multiple, options, ...props }) => {
   const { values, setFieldValue } = useFormikContext()
-  const value = getIn(values, name)
+  const value = getIn(values, name) || []
 
   const onChange = (_: any, newVal: string | string[] | null, reason: string) => {
     if (reason === 'clear') {


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

close https://github.com/chaos-mesh/chaos-mesh/issues/3416
<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- use empty array `[]` instead of `null` from `getIn()`

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [x] release-2.3
  - [x] release-2.2
  - [x] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
