### PR TITLE
Ability to add annotations to the ServiceAccount for Chaos Dashboard

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -78,6 +78,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `dashboard.replicaCount` | Replicas of chaos-dashboard | `1` |
 | `dashboard.priorityClassName` | Custom priorityClassName for using pod priorities | `` |
 | `dashboard.serviceAccount` | The serviceAccount for chaos-dashboard  | `chaos-dashboard` |
+| `dashboard.serviceAccountAnnotations` | Annotations for serviceAccount for chaos-dashboard  | `{}` |
 | `dashboard.image.registry` | Override global registry, empty value means using the global images.registry | `` |
 | `dashboard.image.repository` | Repository part for image of chaos-dashboard | `chaos-mesh/chaos-dashboard` |
 | `dashboard.image.tag` | Override global tag, empty value means using the global images.tag | `` |

--- a/helm/chaos-mesh/templates/chaos-dashboard-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-rbac.yaml
@@ -22,6 +22,8 @@ metadata:
   labels:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-dashboard
+  annotations:
+    {{- include "chaos-mesh.annotations" . | nindent 4 }}
 
 ---
 # ClusterRole for chaos-dashboard at cluster scope

--- a/helm/chaos-mesh/templates/chaos-dashboard-rbac.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-rbac.yaml
@@ -23,7 +23,9 @@ metadata:
     {{- include "chaos-mesh.labels" . | nindent 4 }}
     app.kubernetes.io/component: chaos-dashboard
   annotations:
-    {{- include "chaos-mesh.annotations" . | nindent 4 }}
+    {{- with .Values.dashboard.serviceAccountAnnotations }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
 
 ---
 # ClusterRole for chaos-dashboard at cluster scope

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -240,6 +240,7 @@ dashboard:
   priorityClassName: ""
   # The serviceAccount for chaos-dashboard
   serviceAccount: chaos-dashboard
+  serviceAccountAnnotations: {}
   image:
     # override global registry, empty value means using the global images.registry
     registry: ""


### PR DESCRIPTION
helm: Ability to add annotations to the ServiceAccount for Chaos Dashboard

### What problem does this PR solve?

Unable to add annotations to the ServiceAccount for Chaos Dashboard.

### What's changed and how it works?

Users can specify annotations via the `dashboard.serviceAccountAnnotations` value.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.3
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
