### PR TITLE
fix: Omit optional fields explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix the blank screen after creating chaos experiment with "By YAML" [#3489](https://github.com/chaos-mesh/chaos-mesh/pull/3489)
 - Update hint text about the manual token generating process for Kubernetes 1.24+ [#3505](https://github.com/chaos-mesh/chaos-mesh/pull/3505)
 - Fix BlockChaos can't show Chinese name.  [#3536](https://github.com/chaos-mesh/chaos-mesh/pull/3536)
+- Add `omitempty` JSON tag to optional fields of the CRD objects. [#3531](https://github.com/chaos-mesh/chaos-mesh/pull/3531)
 
 ### Security
 

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -52,7 +52,7 @@ type ChaosCondition struct {
 	Type   ChaosConditionType     `json:"type"`
 	Status corev1.ConditionStatus `json:"status"`
 	// +optional
-	Reason string `json:"reason"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type DesiredPhase string

--- a/api/v1alpha1/dnschaos_type.go
+++ b/api/v1alpha1/dnschaos_type.go
@@ -51,7 +51,7 @@ type DNSChaos struct {
 
 	// +optional
 	// Most recently observed status of the chaos experiment about pods
-	Status DNSChaosStatus `json:"status"`
+	Status DNSChaosStatus `json:"status,omitempty"`
 }
 
 var _ InnerObjectWithSelector = (*DNSChaos)(nil)
@@ -78,7 +78,7 @@ type DNSChaosSpec struct {
 	// 		The value is ["google.com", "github.*", "chaos-mes?.org"],
 	// 		will take effect on "google.com", "github.com" and "chaos-mesh.org"
 	// +optional
-	DomainNamePatterns []string `json:"patterns"`
+	DomainNamePatterns []string `json:"patterns,omitempty"`
 }
 
 // DNSChaosStatus defines the observed state of DNSChaos

--- a/api/v1alpha1/networkchaos_types.go
+++ b/api/v1alpha1/networkchaos_types.go
@@ -37,7 +37,7 @@ type NetworkChaos struct {
 
 	// +optional
 	// Most recently observed status of the chaos experiment about pods
-	Status NetworkChaosStatus `json:"status"`
+	Status NetworkChaosStatus `json:"status,omitempty"`
 }
 
 var _ InnerObjectWithCustomStatus = (*NetworkChaos)(nil)

--- a/api/v1alpha1/physical_machine_chaos_types.go
+++ b/api/v1alpha1/physical_machine_chaos_types.go
@@ -83,7 +83,7 @@ type PhysicalMachineChaos struct {
 
 	// +optional
 	// Most recently observed status of the chaos experiment
-	Status PhysicalMachineChaosStatus `json:"status"`
+	Status PhysicalMachineChaosStatus `json:"status,omitempty"`
 }
 
 // PhysicalMachineChaosSpec defines the desired state of PhysicalMachineChaos
@@ -120,7 +120,7 @@ type PhysicalMachineSelector struct {
 
 	// Selector is used to select physical machines that are used to inject chaos action.
 	// +optional
-	Selector PhysicalMachineSelectorSpec `json:"selector"`
+	Selector PhysicalMachineSelectorSpec `json:"selector,omitempty"`
 
 	// Mode defines the mode to run chaos action.
 	// Supported mode: one / all / fixed / fixed-percent / random-max-percent

--- a/api/v1alpha1/podchaos_types.go
+++ b/api/v1alpha1/podchaos_types.go
@@ -33,7 +33,7 @@ type PodChaos struct {
 
 	// +optional
 	// Most recently observed status of the chaos experiment about pods
-	Status PodChaosStatus `json:"status"`
+	Status PodChaosStatus `json:"status,omitempty"`
 }
 
 var _ InnerObjectWithSelector = (*PodChaos)(nil)
@@ -75,7 +75,7 @@ type PodChaosSpec struct {
 	// Value must be non-negative integer. The default value is zero that indicates delete immediately.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	GracePeriod int64 `json:"gracePeriod"`
+	GracePeriod int64 `json:"gracePeriod,omitempty"`
 }
 
 // PodChaosStatus represents the current status of the chaos experiment about pods.

--- a/api/v1alpha1/podnetworkchaos_types.go
+++ b/api/v1alpha1/podnetworkchaos_types.go
@@ -37,7 +37,7 @@ type PodNetworkChaos struct {
 
 	// +optional
 	// Most recently observed status of the chaos experiment about pods
-	Status PodNetworkChaosStatus `json:"status"`
+	Status PodNetworkChaosStatus `json:"status,omitempty"`
 }
 
 // PodNetworkChaosSpec defines the desired state of PodNetworkChaos

--- a/api/v1alpha1/schedule_types.go
+++ b/api/v1alpha1/schedule_types.go
@@ -33,7 +33,7 @@ type Schedule struct {
 	Spec ScheduleSpec `json:"spec"`
 
 	// +optional
-	Status ScheduleStatus `json:"status"`
+	Status ScheduleStatus `json:"status,omitempty"`
 }
 
 type ConcurrencyPolicy string

--- a/api/v1alpha1/statuscheck_types.go
+++ b/api/v1alpha1/statuscheck_types.go
@@ -36,7 +36,7 @@ type StatusCheck struct {
 
 	// +optional
 	// Most recently observed status of status check
-	Status StatusCheckStatus `json:"status"`
+	Status StatusCheckStatus `json:"status,omitempty"`
 }
 
 type StatusCheckMode string

--- a/api/v1alpha1/stresschaos_types.go
+++ b/api/v1alpha1/stresschaos_types.go
@@ -37,7 +37,7 @@ type StressChaos struct {
 
 	// +optional
 	// Most recently observed status of the time chaos experiment
-	Status StressChaosStatus `json:"status"`
+	Status StressChaosStatus `json:"status,omitempty"`
 }
 
 var _ InnerObjectWithCustomStatus = (*StressChaos)(nil)
@@ -80,16 +80,16 @@ type StressChaosStatus struct {
 type StressInstance struct {
 	// UID is the stress-ng identifier
 	// +optional
-	UID string `json:"uid"`
+	UID string `json:"uid,omitempty"`
 	// MemoryUID is the memStress identifier
 	// +optional
-	MemoryUID string `json:"memoryUid"`
+	MemoryUID string `json:"memoryUid,omitempty"`
 	// StartTime specifies when the stress-ng starts
 	// +optional
-	StartTime *metav1.Time `json:"startTime"`
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// MemoryStartTime specifies when the memStress starts
 	// +optional
-	MemoryStartTime *metav1.Time `json:"memoryStartTime"`
+	MemoryStartTime *metav1.Time `json:"memoryStartTime,omitempty"`
 }
 
 // Stressors defines plenty of stressors supported to stress system components out.

--- a/api/v1alpha1/timechaos_types.go
+++ b/api/v1alpha1/timechaos_types.go
@@ -33,7 +33,7 @@ type TimeChaos struct {
 
 	// +optional
 	// Most recently observed status of the time chaos experiment
-	Status TimeChaosStatus `json:"status"`
+	Status TimeChaosStatus `json:"status,omitempty"`
 }
 
 var _ InnerObjectWithSelector = (*TimeChaos)(nil)

--- a/api/v1alpha1/workflownode_types.go
+++ b/api/v1alpha1/workflownode_types.go
@@ -41,7 +41,7 @@ type WorkflowNode struct {
 
 	// +optional
 	// Most recently observed status of the workflow node
-	Status WorkflowNodeStatus `json:"status"`
+	Status WorkflowNodeStatus `json:"status,omitempty"`
 }
 
 type WorkflowNodeSpec struct {


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow the Title Formats below when you open a new PR:

1. module[, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
close #3526 

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Add missing `omitempty` JSON tag to optional fields.

### Related changes

- [ ] Need to update `chaos-mesh/website`
- [ ] Need to update `Dashboard UI`
- Need to **cheery-pick to release branches**
  - [ ] release-2.3
  - [ ] release-2.2
  - [ ] release-2.1

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] Breaking backward compatibility

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
