### PR TITLE
replace io/ioutil package with os package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
-- Nothing
+- Replace io/ioutil package with os package. [#3539](https://github.com/chaos-mesh/chaos-mesh/pull/3539)
 
 ### Deprecated
 

--- a/pkg/ptrace/ptrace_linux.go
+++ b/pkg/ptrace/ptrace_linux.go
@@ -29,7 +29,7 @@ import (
 	"bytes"
 	"debug/elf"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -91,7 +91,7 @@ func Trace(pid int, logger logr.Logger) (*TracedProgram, error) {
 	// ...
 	// only the first way finally worked for every situations
 	for {
-		threads, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+		threads, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}


### PR DESCRIPTION
Signed-off-by: 0xff-dev <stevenshuang521@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?
Deprecated: As of Go 1.16, os.ReadDir is a more efficient and correct choice.
`chaos-mesh` is currently using go 1.18.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further upadtes to `chaos-mesh/website` (e.g. docs)
- [ ] This change also requires further updates to `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.3
  - [ ] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
