### PR TITLE
Fix namespace to align with install docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ about: Something isn't working as expected
 <!-- You can run `kubectl version` -->
 
 **What version of Chaos Mesh are you using?**
-<!-- You can run `kubectl exec -n chaos-mesh {chaos-controller-manager-pod-name} -- /usr/local/bin/chaos-controller-manager -version` -->
+<!-- You can run `kubectl exec --namespace=chaos-testing {chaos-controller-manager-pod-name} -- /usr/local/bin/chaos-controller-manager -version` -->
 
 **What did you do?**
 <!-- If possible, provide a recipe for reproducing the error. How you installed chaos-mesh. -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ about: Something isn't working as expected
 <!-- You can run `kubectl version` -->
 
 **What version of Chaos Mesh are you using?**
-<!-- You can run `kubectl exec --namespace=chaos-testing {chaos-controller-manager-pod-name} -- /usr/local/bin/chaos-controller-manager -version` -->
+<!-- You can run `kubectl exec --namespace=chaos-testing deploy/chaos-controller-manager -- /usr/local/bin/chaos-controller-manager -version` -->
 
 **What did you do?**
 <!-- If possible, provide a recipe for reproducing the error. How you installed chaos-mesh. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Changed
 
 - Replace io/ioutil package with os package. [#3539](https://github.com/chaos-mesh/chaos-mesh/pull/3539)
+- Fixed kubectl namespace in GitHub bug reporting issue template [#3556](https://github.com/chaos-mesh/chaos-mesh/pull/3556)
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary

The Chaos Mesh installation documentation suggests installing to the Kubernetes namespace `chaos-testing`. The GitHub issue template has a `kubectl` command that does not align with the namespace used in the install docs. This PR fixes the inconsistency.

Signed-off-by: Trevor Sullivan <trevor@trevorsullivan.net>
