### PR TITLE
fix "sidecar config" e2e test cases run failed in some scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix IOChaos `containerNames` field in UI [#3533](https://github.com/chaos-mesh/chaos-mesh/pull/3533)
 - Fix BlockChaos can't show Chinese name.  [#3536](https://github.com/chaos-mesh/chaos-mesh/pull/3536)
 - Add `omitempty` JSON tag to optional fields of the CRD objects. [#3531](https://github.com/chaos-mesh/chaos-mesh/pull/3531)
+- Fix "sidecar config" e2e test cases run failed in some scenario.[#3564](https://github.com/chaos-mesh/chaos-mesh/pull/3564)
 
 ### Security
 

--- a/e2e-test/e2e/chaos/sidecar/injection_config.go
+++ b/e2e-test/e2e/chaos/sidecar/injection_config.go
@@ -61,7 +61,7 @@ selector:
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
-		if newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
+		if len(newPods.Items) > 0 && newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
 			return true, nil
 		}
 		return false, nil
@@ -114,7 +114,7 @@ selector:
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
-		if newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
+		if len(newPods.Items) > 0 && newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
 			return true, nil
 		}
 		return false, nil

--- a/e2e-test/e2e/chaos/sidecar/template_config.go
+++ b/e2e-test/e2e/chaos/sidecar/template_config.go
@@ -60,7 +60,7 @@ selector:
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
-		if newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
+		if len(newPods.Items) > 0 && newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
 			return true, nil
 		}
 		return false, nil
@@ -103,7 +103,7 @@ selector:
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
-		if newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
+		if len(newPods.Items) > 0 && newPods.Items[0].Status.ContainerStatuses[0].RestartCount > 0 {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
Signed-off-by: zhengbingxian <zhengbingxian@archeros.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?
https://github.com/chaos-mesh/chaos-mesh/issues/3563
<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

Add judgment to check newPod.items' length,  so that it will not cause "runtime error: index out of range [0] with length 0"
<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further upadtes to `chaos-mesh/website` (e.g. docs)
- [ ] This change also requires further updates to `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.3
  - [ ] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [x] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
