### PR TITLE
ci: fix integration test, update kuebctl version

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,7 +22,7 @@ jobs:
         # released version of kind-action doesn't support arm64
         uses: helm/kind-action@4c7909140acfc81a05fc96fed8fea6673ba8ce80
         with:
-          kubectl_version: v1.23.1
+          kubectl_version: v1.25.0
 
       - name: Setup Helm
         uses: azure/setup-helm@v2.1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,13 +22,10 @@ jobs:
         # released version of kind-action doesn't support arm64
         uses: helm/kind-action@4c7909140acfc81a05fc96fed8fea6673ba8ce80
         with:
-          kubectl_version: v1.25.0
+          kubectl_version: v1.23.1
 
       - name: Setup Helm
         uses: azure/setup-helm@v2.1
-
-      - name: Setup Kubectl
-        uses: azure/setup-kubectl@v2.0
 
       - name: Magic Kind DNS Fix
         if: ${{ matrix.arch == 'arm64' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix BlockChaos can't show Chinese name.  [#3536](https://github.com/chaos-mesh/chaos-mesh/pull/3536)
 - Add `omitempty` JSON tag to optional fields of the CRD objects. [#3531](https://github.com/chaos-mesh/chaos-mesh/pull/3531)
 - Fix "sidecar config" e2e test cases run failed in some scenario.[#3564](https://github.com/chaos-mesh/chaos-mesh/pull/3564)
+- Fix Integration test with bumping kubectl version. [#3589](https://github.com/chaos-mesh/chaos-mesh/pull/3589)
 
 ### Security
 


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

fix https://github.com/chaos-mesh/chaos-mesh/issues/3587

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

- update the kubectl version when setting up kubernetes

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.3
  - [x] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
