### PR TITLE
ci: add more ignore domain for check markdown link

### DIFF
--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -14,6 +14,15 @@
     },
     {
       "pattern": "^https://www.microsoft.com"
+    },
+    {
+      "pattern": "^http://techgenix.com"
+    },
+    {
+      "pattern": "^https://en.pingcap.com"
+    },
+    {
+      "pattern": "^https://www.tencent.com"
     }
   ],
   "aliveStatusCodes": [200, 403, 500, 502, 503]


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

close https://github.com/chaos-mesh/chaos-mesh/issues/3615

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

append more domain into ignore patterns

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.3
  - [ ] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
