### PR TITLE
perf: make the Scope render conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Refine logging in pkg/dashboard/apiserver/auth/gcp, moved package level variable log into struct Service as a field [#3527](https://github.com/chaos-mesh/chaos-mesh/pull/3527)
 - Change e2e config settings to append "pause image" args. [#3567](https://github.com/chaos-mesh/chaos-mesh/pull/3567)
 - Update display of disabled scope in UI [#3621](https://github.com/chaos-mesh/chaos-mesh/pull/3621)
+- Make the Scope render conditionally [#3622](https://github.com/chaos-mesh/chaos-mesh/pull/3622)
 
 ### Deprecated
 

--- a/ui/app/src/components/Scope/index.tsx
+++ b/ui/app/src/components/Scope/index.tsx
@@ -35,14 +35,13 @@ import Mode from './Mode'
 import ScopePodsTable from './ScopePodsTable'
 
 interface ScopeProps {
-  kind?: string
   namespaces: string[]
   scope?: string
   modeScope?: string
   podsPreviewTitle?: string | JSX.Element
 }
 
-const Scope: React.FC<ScopeProps> = ({ kind, namespaces, scope = 'selector', modeScope = '', podsPreviewTitle }) => {
+const Scope = ({ namespaces, scope = 'selector', modeScope = '', podsPreviewTitle }: ScopeProps) => {
   const { values, setFieldValue, errors, touched } = useFormikContext()
   const {
     namespaces: currentNamespaces,
@@ -56,7 +55,6 @@ const Scope: React.FC<ScopeProps> = ({ kind, namespaces, scope = 'selector', mod
   const isTargetField = scope.startsWith('target')
   const pods = !isTargetField ? state.experiments.pods : state.experiments.networkTargetPods
   const getPods = !isTargetField ? getCommonPods : getNetworkTargetPods
-  const disabled = kind === 'AWSChaos' || kind === 'GCPChaos'
   const dispatch = useStoreDispatch()
 
   const kvSeparator = ': '
@@ -99,12 +97,7 @@ const Scope: React.FC<ScopeProps> = ({ kind, namespaces, scope = 'selector', mod
     }
   }, [dispatch, getPods, currentNamespaces, currentLabels, currentAnnotations])
 
-  return disabled ? (
-    <Typography
-      variant="body2"
-      sx={{ color: 'text.disabled' }}
-    >{`${kind} does not need to define the scope.`}</Typography>
-  ) : (
+  return (
     <Space>
       <AutocompleteField
         freeSolo
@@ -175,4 +168,21 @@ const Scope: React.FC<ScopeProps> = ({ kind, namespaces, scope = 'selector', mod
   )
 }
 
-export default Scope
+interface ConditionalScopeProps extends ScopeProps {
+  kind?: string
+}
+
+const ConditionalScope = ({ kind, ...rest }: ConditionalScopeProps) => {
+  const disabled = kind === 'AWSChaos' || kind === 'GCPChaos'
+
+  return disabled ? (
+    <Typography
+      variant="body2"
+      sx={{ color: 'text.disabled' }}
+    >{`${kind} does not need to define the scope.`}</Typography>
+  ) : (
+    <Scope {...rest} />
+  )
+}
+
+export default ConditionalScope


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

An enhancement for #3621.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Use a parent component (wrapper) to control whether to render the real form in Scope to avoid unnecessary overhead.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.3
  - [ ] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [x] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
