### PR TITLE
dashboard: remove limit action from BlockChaos and generate specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix recover bug when setting force recover to true [#3578](https://github.com/chaos-mesh/chaos-mesh/pull/3578)
 - Fix Integration test with bumping kubectl version. [#3589](https://github.com/chaos-mesh/chaos-mesh/pull/3589)
 - Fix generate token failed on chaos dashboard [#3595](https://github.com/chaos-mesh/chaos-mesh/pull/3595)
+- Remove `limit` action of `BlockChaos` in the dashboard [#3655](https://github.com/chaos-mesh/chaos-mesh/pull/3655)
 
 ### Security
 

--- a/ui/app/src/components/NewExperimentNext/data/types.ts
+++ b/ui/app/src/components/NewExperimentNext/data/types.ts
@@ -361,20 +361,6 @@ const data: Record<Kind, Definition> = {
           ...blockCommon,
         },
       },
-      {
-        name: 'Limit',
-        key: 'limit',
-        spec: {
-          action: 'limit' as any,
-          iops: {
-            field: 'number',
-            label: 'IOPS',
-            value: 0,
-            helperText: 'The maximum IOPS',
-          },
-          ...blockCommon,
-        },
-      },
     ],
   },
   // DNS Fault


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

This PR removes the limit action, and run codegen, though I don't know whether these codegen behaves well.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.4
  - [x] release-2.3
  - [ ] release-2.2
