### PR TITLE
chore: update image tag to 2.4.0, update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 For more information and how-to, see [RFC: Keep A Changelog](https://github.com/chaos-mesh/rfcs/blob/main/text/2022-01-17-keep-a-changelog.md).
-
 ## [Unreleased]
+
+### Added
+
+- Nothing
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- Nothing
+
+### Security
+
+- Nothing
+
+## [2.4.0] - 2022-09-23
 
 ### Added
 

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -48,7 +48,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "latest"
+  tag: "2.4.0"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Ready for release 2.4.0.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

- Update image tag in helm charts
- update CHANGELOG 

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3
  - [ ] release-2.2

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
