### PR TITLE
fix: replace actions/checkout from master to v3

### DIFF
--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -14,7 +14,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build Chaos Mesh Build Env
         if: ${{ github.event.pull_request }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -20,7 +20,7 @@ jobs:
         arch: [amd64, arm64]
     runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           # Must use at least depth 2!
           fetch-depth: 2

--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Extract Image Tag
         shell: bash

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -23,7 +23,7 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
     runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           # It requires all the tags and branches to generate the correct GitVersion with `hack/version.sh`.
           fetch-depth: 0

--- a/.github/workflows/upload_image_pr.yml
+++ b/.github/workflows/upload_image_pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && startsWith( github.event.comment.body, '/build-image') }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Install jq
         run: |

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -20,7 +20,7 @@ jobs:
     name: Upload
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           # Must use at least depth 2!
           fetch-depth: 2

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -31,7 +31,7 @@ jobs:
           echo "The tag must start with 'v'"
           echo "GITHUB_REF: ${GITHUB_REF}"
           exit 1
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           # Must use at least depth 2!
           fetch-depth: 2


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Using the master version maybe cause potential problems in the future, so I pin all the master versions to `v3`. The existing `v2` versions have not changed.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
