### PR TITLE
chore: update .licenseyc.yaml for consistent style

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -66,7 +66,7 @@ header:
     - 'ui/packages/mui-extends/.storybook/**'
     - 'ui/packages/mui-extends/stories/**'
     - 'ui/packages/mui-extends/test/storyshots.test.js'
+    - 'ui/yarn.lock'
     # codecov configuration file
-    - codecov.yml
-    - .gitkeep
-    - yarn.lock
+    - 'codecov.yml'
+    - '.gitkeep'


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

keep consistent style in `.licenserc.yaml` with https://github.com/chaos-mesh/chaos-mesh/pull/3756

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
