### PR TITLE
Remove yeya24 as current maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,6 @@ The Maintainers of Chaos Mesh, along with their emails, are listed be
 | Cwen Yin ([cwen0](https://github.com/cwen0))               |  [cwen@pingcap.com](mailto:cwen@pingcap.com)            |  [PingCAP](https://www.pingcap.com/)       |
 | Keao Yang ([YangKeao](https://github.com/YangKeao))        |  [yangkeao@pingcap.com](mailto:yangkeao@pingcap.com)    |  [PingCAP](https://www.pingcap.com/)       |
 | Calvin Weng ([dcalvin](https://github.com/dcalvin))        |  [wenghao@pingcap.com](mailto:wenghao@pingcap.com)      |  [PingCAP](https://www.pingcap.com/)       |
-| Ben Ye ([yeya24](https://github.com/yeya24))               |  [yb532204897@gmail.com](mailto:yb532204897@gmail.com)  |  [ByteDance](https://www.bytedance.com/)   |
 | Hengliang Tan ([Gallardot](https://github.com/Gallardot))  |  [tttick@gmail.com](mailto:tttick@gmail.com)            |  [Xpeng Motors](https://www.xiaopeng.com/) |
 | Zhiqiang Zhou ([STRRL](https://github.com/STRRL))          | [im@strrl.dev](mailto:im@strrl.dev)                     | Freelancer                                 |
 | Glen Yang ([g1eny0ung](https://github.com/g1eny0ung))      | [g1enyy0ung@gmail.com](mailto:g1enyy0ung@gmail.com)     | [EMQ](https://www.emqx.com/)          |
@@ -42,3 +41,4 @@ The Emeritus Maintainers of Chaos Mesh, along with their emails, are listed belo
 | Siddon Tang ([siddontang](https://github.com/siddontang))     |  [tl@pingcap.com](mailto:tl@pingcap.com)                |  [PingCAP](https://www.pingcap.com/) |
 | Qiang Zhou ([zhouqiang-cl](https://github.com/zhouqiang-cl))  |  [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com)  |  [PingCAP](https://www.pingcap.com/) |
 | Song Gao ([Yisaer](https://github.com/Yisaer))                |  [gaosong@pingcap.com](mailto:gaosong@pingcap.com)      |  [PingCAP](https://www.pingcap.com/) |
+| Ben Ye ([yeya24](https://github.com/yeya24))                  |  [yb532204897@gmail.com](mailto:yb532204897@gmail.com)  |  [AWS](https://aws.amazon.com/)      |


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

I have been inactive on the project for 2 years since I left PingCAP. I have other things to focus now and it is hard for me to focus back to the project.
Since we have more and more active maintainers now I feel it is better to move myself to emeritus maintainer state.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
