### PR TITLE
fix: enable mode when creating PhysicalMachineChaos with addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix timechaos not injected into the child process [#3725](https://github.com/chaos-mesh/chaos-mesh/pull/3725)
 - Ignore `ScheduleSkipRemoveHistory` events to fix the memory of controller-manager keep increasing [#3761](https://github.com/chaos-mesh/chaos-mesh/issues/3761)
 - Update `is mandatory` to true in a swagger comment [#3743](https://github.com/chaos-mesh/chaos-mesh/pull/3743)
+- Enable mode when creating PhysicalMachineChaos with addresses in UI [#3797](https://github.com/chaos-mesh/chaos-mesh/pull/3797)
 
 ### Security
 

--- a/ui/app/src/components/AutoForm/data.ts
+++ b/ui/app/src/components/AutoForm/data.ts
@@ -19,7 +19,7 @@ import _ from 'lodash'
 export const podPhases = ['Pending', 'Running', 'Succeeded', 'Failed', 'Unknown']
 
 export const scopeInitialValues = ({ hasSelector }: { hasSelector: boolean }) => ({
-  ...(!hasSelector && {
+  ...(hasSelector && {
     selector: {
       namespaces: [],
       labelSelectors: [],

--- a/ui/app/src/components/AutoForm/data.ts
+++ b/ui/app/src/components/AutoForm/data.ts
@@ -18,18 +18,20 @@ import _ from 'lodash'
 
 export const podPhases = ['Pending', 'Running', 'Succeeded', 'Failed', 'Unknown']
 
-export const scopeInitialValues = {
-  selector: {
-    namespaces: [],
-    labelSelectors: [],
-    annotationSelectors: [],
-    podPhaseSelectors: [],
-    pods: [],
-    physicalMachines: [],
-  },
+export const scopeInitialValues = ({ hasSelector }: { hasSelector: boolean }) => ({
+  ...(!hasSelector && {
+    selector: {
+      namespaces: [],
+      labelSelectors: [],
+      annotationSelectors: [],
+      podPhaseSelectors: [],
+      pods: [],
+      physicalMachines: [],
+    },
+  }),
   mode: 'all',
   value: undefined,
-}
+})
 
 export interface Schedule {
   schedule: string

--- a/ui/app/src/components/AutoForm/index.tsx
+++ b/ui/app/src/components/AutoForm/index.tsx
@@ -81,6 +81,7 @@ const AutoForm: React.FC<AutoFormProps> = ({ belong = Belong.Experiment, id, kin
       scopeInitialValues({ hasSelector: kind === 'PhysicalMachineChaos' && !useNewPhysicalMachine ? false : true })),
     ...(belong === Belong.Workflow && { ...workflowNodeInfoInitialValues, templateType: kind }),
   })
+  const hasSelector = !!initialValues.selector
   const [form, setForm] = useState<AtomFormData[]>([])
   const [scheduled, setScheduled] = useState(false)
 
@@ -342,7 +343,7 @@ const AutoForm: React.FC<AutoFormProps> = ({ belong = Belong.Experiment, id, kin
                   <Typography variant="h6">
                     <T id="newE.steps.scope" />
                   </Typography>
-                  {useNewPhysicalMachine ? (
+                  {hasSelector ? (
                     <Scope
                       env={kind === 'PhysicalMachineChaos' ? 'physic' : 'k8s'}
                       kind={kind}

--- a/ui/app/src/components/AutoForm/index.tsx
+++ b/ui/app/src/components/AutoForm/index.tsx
@@ -30,6 +30,7 @@ import { useStoreSelector } from 'store'
 import { AutocompleteField, SelectField, Submit, TextField, TextTextField } from 'components/FormField'
 import { SpecialTemplateType } from 'components/NewWorkflowNext/utils/convert'
 import Scope from 'components/Scope'
+import Mode from 'components/Scope/Mode'
 import { T } from 'components/T'
 
 import { concatKindAction } from 'lib/utils'
@@ -69,17 +70,15 @@ const AutoForm: React.FC<AutoFormProps> = ({ belong = Belong.Experiment, id, kin
 
   const { useNewPhysicalMachine } = useStoreSelector((state) => state.settings)
   const noScope =
-    kind === SpecialTemplateType.Suspend ||
-    kind === SpecialTemplateType.Serial ||
-    kind === SpecialTemplateType.Parallel ||
-    (kind === 'PhysicalMachineChaos' && !useNewPhysicalMachine)
+    kind === SpecialTemplateType.Suspend || kind === SpecialTemplateType.Serial || kind === SpecialTemplateType.Parallel
 
   const [initialValues, setInitialValues] = useState<FormikValues>({
     id,
     kind,
     action,
-    ...(kind === 'NetworkChaos' && { target: scopeInitialValues }),
-    ...(!noScope && scopeInitialValues),
+    ...(kind === 'NetworkChaos' && { target: scopeInitialValues({ hasSelector: true }) }),
+    ...(!noScope &&
+      scopeInitialValues({ hasSelector: kind === 'PhysicalMachineChaos' && !useNewPhysicalMachine ? false : true })),
     ...(belong === Belong.Workflow && { ...workflowNodeInfoInitialValues, templateType: kind }),
   })
   const [form, setForm] = useState<AtomFormData[]>([])
@@ -343,12 +342,14 @@ const AutoForm: React.FC<AutoFormProps> = ({ belong = Belong.Experiment, id, kin
                   <Typography variant="h6">
                     <T id="newE.steps.scope" />
                   </Typography>
-                  {useNewPhysicalMachine && (
+                  {useNewPhysicalMachine ? (
                     <Scope
                       env={kind === 'PhysicalMachineChaos' ? 'physic' : 'k8s'}
                       kind={kind}
                       namespaces={namespaces}
                     />
+                  ) : (
+                    <Mode scope="selector" modeScope="" />
                   )}
                   <Divider />
                   <Box>

--- a/ui/app/src/lib/localStorage.ts
+++ b/ui/app/src/lib/localStorage.ts
@@ -21,22 +21,22 @@ export default class LocalStorage {
   static ls = window.localStorage
 
   static get(key: string) {
-    return LocalStorage.ls.getItem(PREFIX + key)
+    return this.ls.getItem(PREFIX + key)
   }
 
   static getObj(key: string) {
-    return JSON.parse(LocalStorage.get(key) ?? '{}')
+    return JSON.parse(this.get(key) ?? '{}')
   }
 
   static set(key: string, val: string) {
-    LocalStorage.ls.setItem(PREFIX + key, val)
+    this.ls.setItem(PREFIX + key, val)
   }
 
   static setObj(key: string, obj: any) {
-    LocalStorage.set(key, JSON.stringify(obj))
+    this.set(key, JSON.stringify(obj))
   }
 
   static remove(key: string) {
-    LocalStorage.ls.removeItem(PREFIX + key)
+    this.ls.removeItem(PREFIX + key)
   }
 }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #3747

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

This PR enables mode when creating PhysicalMachineChaos with addresses.

#### Misc

This PR also fixes little problems in `localStorage.ts`.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
