### PR TITLE
Remove useless kubebuilder comment in webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Remove not needed file crd-v1beta1.yaml [#3807](https://github.com/chaos-mesh/chaos-mesh/pull/3807)
 
+- Remove useless kubebuilder comment in webhook [#3816](https://github.com/chaos-mesh/chaos-mesh/pull/3816)
+
 ### Fixed
 
 - Remove the explicit use of pingcap/log [#3674](https://github.com/chaos-mesh/chaos-mesh/pull/3674)

--- a/api/v1alpha1/schedule_webhook.go
+++ b/api/v1alpha1/schedule_webhook.go
@@ -28,8 +28,6 @@ import (
 // log is for logging in this package.
 var schedulelog = logf.Log.WithName("schedule-resource")
 
-// +kubebuilder:webhook:path=/mutate-chaos-mesh-org-v1alpha1-schedule,mutating=true,failurePolicy=fail,groups=chaos-mesh.org,resources=schedule,verbs=create;update,versions=v1alpha1,name=mschedule.kb.io
-
 var _ webhook.Defaulter = &Schedule{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
@@ -43,8 +41,6 @@ func (in *ConcurrencyPolicy) Default() {
 		*in = ForbidConcurrent
 	}
 }
-
-// +kubebuilder:webhook:verbs=create;update,path=/validate-chaos-mesh-org-v1alpha1-schedule,mutating=false,failurePolicy=fail,groups=chaos-mesh.org,resources=schedule,versions=v1alpha1,name=vschedule.kb.io
 
 var _ webhook.Validator = &Schedule{}
 


### PR DESCRIPTION
Signed-off-by: Ningxuan Wang <wanxfinger@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?
These comments lack  the argument `admisstionReviewVersion`, resulting in error when api is imported in other project. And chaos mesh has explicit statement of webhooks in `helm/chaos-emsh/templates/`, so we should delete them.

### What's changed and how it works?
Just delete these comments
<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
