### PR TITLE
Change ubuntu version from latest to 20.04

### DIFF
--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   # JOB to run change detection
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Set job outputs to values from filter step
     outputs:
       go: ${{ steps.filter.outputs.go }}
@@ -54,7 +54,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v2
 
@@ -110,7 +110,7 @@ jobs:
           - build
           - test
         # node-version: ["14"] # TODO: add nodejs-16?
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   skip-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       go: ${{ steps.filter.outputs.go }}
       ui: ${{ steps.filter.outputs.ui }}
@@ -39,7 +39,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: echo "Not required to run go jobs."
   ui:
@@ -51,6 +51,6 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: echo "Not required to run ui jobs."

--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   unitTestAndCodeCoverage:
     name: "Unit Test And Code Coverage"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       only_changed: ${{ steps.filter.outputs.only_changed }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   build-image:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
   build-e2e-binary:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -142,7 +142,7 @@ jobs:
     needs:
       - build-image
       - build-e2e-binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -241,6 +241,6 @@ jobs:
     needs:
       - e2e-test-matrix
     name: E2E Test Passed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: echo "🎉 E2E Test Passed!"

--- a/.github/workflows/e2e_test_upload_cache.yml
+++ b/.github/workflows/e2e_test_upload_cache.yml
@@ -30,7 +30,7 @@ permissions: read-all
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
           key: e2e-image-build-cache-${{ runner.os }}
 
   build-e2e-binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v2

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   check-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Check License Header

--- a/.github/workflows/must_update_changelog.yml
+++ b/.github/workflows/must_update_changelog.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   must-update-changelog:
     name: "Must Update CHANGELOG"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     env:
       LABEL_EXISTS: ${{ contains(github.event.pull_request.labels.*.name, 'no-need-update-changelog') }}
     steps:

--- a/.github/workflows/release_helm_chart.yml
+++ b/.github/workflows/release_helm_chart.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   release-chart:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: "Must Triggered by Tag chart-<version>"
         run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/stale@v3
         with:

--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -77,7 +77,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         image: [dev, build]

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -21,7 +21,7 @@ jobs:
           [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-kernel, chaos-dlv]
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-latest", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -83,7 +83,7 @@ jobs:
 
   upload-manifest:
     needs: build-specific-architecture
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
@@ -130,7 +130,7 @@ jobs:
       - build-specific-architecture
       - upload-manifest
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write # Need to upload files to the related release.
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
@@ -171,7 +171,7 @@ jobs:
   sbom:
     needs: build-specific-architecture
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write # Need to upload files to the related release.
     env:

--- a/.github/workflows/upload_image_pr.yml
+++ b/.github/workflows/upload_image_pr.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   build-for-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.issue.pull_request && startsWith( github.event.comment.body, '/build-image') }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -18,7 +18,7 @@ jobs:
   run:
     if: github.repository_owner == 'chaos-mesh'
     name: Upload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   run:
     name: Upload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: "Must Triggered by Tag v<version>"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Use the next generation `New Workflow` UI by default [#3718](https://github.com/chaos-mesh/chaos-mesh/pull/3718)
 - StressChaos: Support cgroup v2 for docker and crio [#3698](https://github.com/chaos-mesh/chaos-mesh/pull/3698)
 - Bump go to v1.19.3 [#3770](https://github.com/chaos-mesh/chaos-mesh/pull/3770)
+- Change ubuntu version from latest to 20.04 [#3817](https://github.com/chaos-mesh/chaos-mesh/pull/3817)
 
 ### Deprecated
 


### PR DESCRIPTION
Signed-off-by: Ningxuan Wang <wanxfinger@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

Since Github action has migrated ubuntu-latest from 20.04 to 22.04, our minikube install action which requires ubuntu version to be 18 or 20 will not work. And I think other actions also should use a certain version rather than latest.

### What's changed and how it works?
Change the version of ubuntu
<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.4
  - [ ] release-2.3

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
