### PR TITLE
chore: slow down the latest releases

### DIFF
--- a/.github/checklink_config.json
+++ b/.github/checklink_config.json
@@ -7,12 +7,6 @@
       "pattern": "^https://github.com"
     },
     {
-      "pattern": "url"
-    },
-    {
-      "pattern": "^#"
-    },
-    {
       "pattern": "^https://www.microsoft.com"
     },
     {

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -29,6 +29,7 @@ jobs:
             **.md
             ui/**
             .github/workflows/checklink.yaml
+            .github/checklink_config.json
             .github/workflows/ci.yml
             .github/workflows/ci_skip.yml
             .github/workflows/codecov_unittest.yaml

--- a/.github/workflows/e2e_test_upload_cache.yml
+++ b/.github/workflows/e2e_test_upload_cache.yml
@@ -12,6 +12,7 @@ on:
       # Not available for frontend code for now.
       - "ui/**"
       - .github/workflows/checklink.yaml
+      - .github/checklink_config.json
       - .github/workflows/ci.yml
       - .github/workflows/ci_skip.yml
       - .github/workflows/codecov_unittest.yaml

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,6 +9,7 @@ on:
       # Not available for frontend code for now.
       - "ui/**"
       - .github/workflows/checklink.yaml
+      - .github/checklink_config.json
       - .github/workflows/ci.yml
       - .github/workflows/ci_skip.yml
       - .github/workflows/codecov_unittest.yaml

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -3,7 +3,7 @@ name: Upload Image
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 18 * * *"
+    - cron: "0 0 * * 0"
   release:
     types: [published]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade byteman-helper to v4.0.20 [#3863](https://github.com/chaos-mesh/chaos-mesh/pull/3863)
 - Helm: change default webhook port to [#10250](https://github.com/chaos-mesh/chaos-mesh/pull/3877)
 - Upgrade base image for chaos-mesh to alpine:3.17 [#3893](https://github.com/chaos-mesh/chaos-mesh/pull/3893)
+- Slow down releasing the latest version #[3900](https://github.com/chaos-mesh/chaos-mesh/pull/3900)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Please reach out for bugs, feature requests, and other issues via:
 
 ### Community blogs
 
-- Grant Tarrant-Fisher: [Integrate your Reliability Toolkit with Your World, Part 2](https://web.archive.org/web/20220223141503/https://blog.reliably.com/integrate-your-reliability-toolkit-with-your-world-part-2-e012f2c2a7f6)
+- Grant Tarrant-Fisher: [Integrate your Reliability Toolkit with Your World](https://medium.com/search?q=Integrate+your+Reliability+Toolkit+with+Your+World)
 - Yoshinori Teraoka: [Streake: Chaos Mesh によるカオスエンジニアリング](https://medium.com/sreake-jp/chaos-mesh-%E3%81%AB%E3%82%88%E3%82%8B%E3%82%AB%E3%82%AA%E3%82%B9%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%8B%E3%82%A2%E3%83%AA%E3%83%B3%E3%82%B0-46fa2897c742)
 - Sébastien Prud'homme: [Chaos Mesh : un générateur de chaos pour Kubernetes](https://www.cowboysysop.com/post/chaos-mesh-un-generateur-de-chaos-pour-kubernetes/)
 - Craig Morten


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

For our current development speed, updating the latest image daily is unnecessary (not to mention that we can use the `workflow_dispatch` event to trigger it).

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Update the schedule of releasing the latest image **from daily to weekly**.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
