### PR TITLE
chore: bump ginkgo version in dev-env to v2

### DIFF
--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -21,7 +21,7 @@ RUN go install github.com/axw/gocov/gocov@v1.0.0
 RUN go install github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 RUN go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
 RUN go install github.com/swaggo/swag/cmd/swag@v1.8.3
-RUN go install github.com/onsi/ginkgo/ginkgo@v2.8.0
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 RUN go install github.com/apache/skywalking-eyes/cmd/license-eye@v0.2.0
 
 FROM debian:buster-slim


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

Resolve `dev-env` building failure after https://github.com/chaos-mesh/chaos-mesh/pull/3902.


<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?

- `github.com/onsi/ginkgo/ginkgo` -> `github.com/onsi/ginkgo/v2/ginkgo`

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [x] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
