### PR TITLE
fix(httpchaos): fetch secret with correct secret name

### DIFF
--- a/controllers/podhttpchaos/controller.go
+++ b/controllers/podhttpchaos/controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -155,13 +154,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	inputTLS := []byte("")
 	if obj.Spec.TLS != nil {
 		tlsKeys := obj.Spec.TLS
-		secret := v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tlsKeys.SecretName,
-				Namespace: tlsKeys.SecretNamespace,
-			},
-		}
-		if err := r.Client.Get(context.TODO(), req.NamespacedName, &secret); err != nil {
+		secret := v1.Secret{}
+		if err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      tlsKeys.SecretName,
+			Namespace: tlsKeys.SecretNamespace,
+		}, &secret); err != nil {
 			r.Log.Error(err, "unable to get secret")
 			return ctrl.Result{}, nil
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

fix: https://github.com/chaos-mesh/chaos-mesh/issues/3957

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [x] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
