### PR TITLE
Dashboard rwo pvc restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Fixed
 
 - Fix version comparison in install.sh [#3901](https://github.com/chaos-mesh/chaos-mesh/pull/3901)
+- Fix stuck dashboard updates when using ReadWriteOnce PVCs [#3876](https://github.com/chaos-mesh/chaos-mesh/issues/3876)
 
 ### Security
 
@@ -201,7 +202,6 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Security
 
 - Nothing
-
 
 ## [2.3.2] - 2022-09-20
 

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -24,6 +24,15 @@ metadata:
     app.kubernetes.io/component: chaos-dashboard
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
+  strategy:
+    {{- if .Values.dashboard.persistentVolume.enabled }}
+    type: Recreate
+    {{- else }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- end }}
   selector:
     matchLabels:
       {{- include "chaos-mesh.selectors" . | nindent 6 }}

--- a/install.sh
+++ b/install.sh
@@ -1684,6 +1684,11 @@ metadata:
     app.kubernetes.io/component: chaos-dashboard
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: chaos-mesh


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
Close #3876

### What's changed and how it works?

I have changed the dashboards `updateStrategy`. The PersistentVolumeClaim for the dashboard is created with the accessMode `ReadWriteOnce`, which does not allow the dashboard to do a rolling restart because the blue version of the dashboard won't be shutdown until the green version is up and running.

This lead to problems when doing a `kubectl rollout-restart deployment chaos-dashboard` because the new dashboard Pod could not mount the PVC.

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

steps:

- Install the ChaosMesh + dashboard using a `helm install` command
  - configure the dashboard to be enabled and use a PersistentVolumeClaim of arbitrary size
- Change the update strategy as mentioned in this PR
- Watch the dashboard rollout-restart instead of being stuck

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
