### PR TITLE
upgrade go version to v1.19.7 in CI environment

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.7"
       - name: Build Chaos Mesh Build Env
         if: ${{ github.event.pull_request }}
         env:

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.7"
 
       - name: Install bom
         run: go install sigs.k8s.io/bom/cmd/bom@latest

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.7"
       - name: Configure awscli
         run: |
           pip3 install awscli

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.7"
       - name: Configure awscli
         run: |
           pip3 install awscli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Security
 
-- Bump go to v1.19.7 to fix CVE-2022-41723 [#3978](https://github.com/chaos-mesh/chaos-mesh/pull/3978)
+- Bump go to v1.19.7 to fix CVE-2022-41723 [#3978](https://github.com/chaos-mesh/chaos-mesh/pull/3978) [#3981](https://github.com/chaos-mesh/chaos-mesh/pull/3981)
 
 - Nothing
 


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->
 
This pr is a part of https://github.com/chaos-mesh/chaos-mesh/pull/3978. In this pr, we upgrade go version in CI environment. 

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
