### PR TITLE
fix(ci): restrict access to kubeconfig

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -198,8 +198,11 @@ jobs:
           minikube image load ./output/saved-images/chaos-mesh.tgz
           minikube image load ./output/saved-images/e2e-helper.tgz
 
-      - name: Setup helm
-        uses: azure/setup-helm@v2.1
+      - name: Restrict access to kubeconfig # https://github.com/helm/helm/issues/9115
+        run: chmod 600 ~/.kube/config
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
 
       - name: Install Chaos Mesh
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -47,8 +47,11 @@ jobs:
         with:
           kubectl_version: v1.23.1
 
+      - name: Restrict access to kubeconfig # https://github.com/helm/helm/issues/9115
+        run: chmod 600 ~/.kube/config
+
       - name: Setup Helm
-        uses: azure/setup-helm@v2.1
+        uses: azure/setup-helm@v3
 
       - name: Magic Kind DNS Fix
         if: ${{ matrix.arch == 'arm64' }}


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Remove warnings when running the `helm` command in CI:

> WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/runner/.kube/config
> WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/runner/.kube/config

A screenshot:

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/15034155/230531613-aa3330ea-c627-4f41-8efe-d58e7b34671d.png">

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
