### PR TITLE
Changed CoreDNS listen port from 53 to 5353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
+- Change CoreDNS listen port from 53 to 5353 [#4022](https://github.com/chaos-mesh/chaos-mesh/pull/4022)
 - Bump go to v1.19.3 [#3770](https://github.com/chaos-mesh/chaos-mesh/pull/3770)
 - Change ubuntu version from latest to 20.04 [#3817](https://github.com/chaos-mesh/chaos-mesh/pull/3817)
 - Switch views between k8s and hosts nodes [#3830](https://github.com/chaos-mesh/chaos-mesh/pull/3830)

--- a/helm/chaos-mesh/templates/dns-configmap.yaml
+++ b/helm/chaos-mesh/templates/dns-configmap.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/component: chaos-dns-server
 data:
   Corefile: |
-    .:53 {
+    .:5353 {
         errors
         health {
             lameduck 5s

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -77,10 +77,10 @@ spec:
           mountPath: /etc/chaos-dns
           readOnly: true
         ports:
-        - containerPort: 53
+        - containerPort: 5353
           name: dns
           protocol: UDP
-        - containerPort: 53
+        - containerPort: 5353
           name: dns-tcp
           protocol: TCP
         - containerPort: 9153

--- a/helm/chaos-mesh/templates/dns-service.yaml
+++ b/helm/chaos-mesh/templates/dns-service.yaml
@@ -31,9 +31,11 @@ spec:
   ports:
   - name: dns
     port: 53
+    targetPort: 5353
     protocol: UDP
   - name: dns-tcp
     port: 53
+    targetPort: 5353
     protocol: TCP
   - name: metrics
     port: 9153

--- a/install.sh
+++ b/install.sh
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: chaos-dns-server
 data:
   Corefile: |
-    .:53 {
+    .:5353 {
         errors
         health {
             lameduck 5s
@@ -1553,9 +1553,11 @@ spec:
   ports:
   - name: dns
     port: 53
+    targetPort: 5353
     protocol: UDP
   - name: dns-tcp
     port: 53
+    targetPort: 5353
     protocol: TCP
   - name: metrics
     port: 9153
@@ -1985,10 +1987,10 @@ spec:
           mountPath: /etc/chaos-dns
           readOnly: true
         ports:
-        - containerPort: 53
+        - containerPort: 5353
           name: dns
           protocol: UDP
-        - containerPort: 53
+        - containerPort: 5353
           name: dns-tcp
           protocol: TCP
         - containerPort: 9153


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

Fixes `Listen: listen tcp :53: bind: permission denied` in chaos-dns-server pod deployed on OpenShift 4.11.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

### What's changed and how it works?
Changed CoreDNS listen port from 53 to 5353 to obtain Chaos DNS Server compability with OpenShift.
Files:
- dns-service.yaml
- dns-deployment.yaml
- dns-configmap.yaml

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [x] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

 steps:
Manual deployment on OpenShift 4.11.

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
