### PR TITLE
ci: use kubectl cluster-info dump to enhance e2e profiling

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -218,13 +218,10 @@ jobs:
         env:
           PROFILE_DIRECTORY: ./output/chaos-mesh-profile
         run: |
-          mkdir -p $PROFILE_DIRECTORY/logs
-          mkdir -p $PROFILE_DIRECTORY/manifests/pods
-          mkdir -p $PROFILE_DIRECTORY/manifests/services
-          for item in $(kubectl -n chaos-mesh get pods --no-headers | awk '{print $1}'); do kubectl -n chaos-mesh logs $item > $PROFILE_DIRECTORY/logs/$item.log; done;
-          for item in $(kubectl -n chaos-mesh get pods --no-headers | awk '{print $1}'); do kubectl -n chaos-mesh get pod $item -oyaml > $PROFILE_DIRECTORY/manifests/pods/pod-$item.yaml; done;
-          for item in $(kubectl -n chaos-mesh get services --no-headers | awk '{print $1}'); do kubectl -n chaos-mesh get services $item -oyaml > $PROFILE_DIRECTORY/manifests/services/service-$item.yaml; done;
-          for item in $(kubectl -n chaos-mesh get endpoints --no-headers | awk '{print $1}'); do kubectl -n chaos-mesh get endpoints $item -oyaml > $PROFILE_DIRECTORY/manifests/services/endpoint-$item.yaml; done;
+          kubectl cluster-info dump --all-namespaces --output-directory $PROFILE_DIRECTORY/manifests -o yaml
+          kubectl get endpoints -A -o yaml > $PROFILE_DIRECTORY/manifests/endpoints.yaml
+          kubectl get secrets -A -o yaml > $PROFILE_DIRECTORY/manifests/secrets.yaml
+          kubectl get configmaps -A -o yaml > $PROFILE_DIRECTORY/manifests/configmaps.yaml
       - name: post run - upload Chaos Mesh profile info
         if: always()
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Refine TTL config of Chaos dashboard [#4008](https://github.com/chaos-mesh/chaos-mesh/pull/4008)
 - `pause` would return non zero exit code when the subcommand failed [#4018](https://github.com/chaos-mesh/chaos-mesh/pull/4018)
+- Use kubectl cluster-info dump to enhance e2e profiling [#3759](https://github.com/chaos-mesh/chaos-mesh/pull/3759)
 
 ### Deprecated
 


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Cherry-pick #3759.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

### Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [ ] Manual test (add steps below)

<!-- > steps: -->

Side effects

- [ ] **Breaking backward compatibility**

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
