### PR TITLE
fix KernelChaos: select container and inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
-- Nothing
+- Fix using ContainerSelector in kernel chaos [#4050](https://github.com/chaos-mesh/chaos-mesh/pull/4050)
 
 ### Security
 

--- a/api/v1alpha1/kernelchaos_types.go
+++ b/api/v1alpha1/kernelchaos_types.go
@@ -120,6 +120,6 @@ type KernelChaosStatus struct {
 
 func (obj *KernelChaos) GetSelectorSpecs() map[string]interface{} {
 	return map[string]interface{}{
-		".": &obj.Spec.PodSelector,
+		".": &obj.Spec.ContainerSelector,
 	}
 }

--- a/controllers/chaosimpl/kernelchaos/types.go
+++ b/controllers/chaosimpl/kernelchaos/types.go
@@ -17,23 +17,19 @@ package kernelchaos
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
-	k8sError "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	impltypes "github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/types"
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"
 	"github.com/chaos-mesh/chaos-mesh/controllers/config"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"
-	"github.com/chaos-mesh/chaos-mesh/controllers/utils/controller"
+	chaosdaemonclient "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/client"
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	pb_kernel "github.com/chaos-mesh/chaos-mesh/pkg/chaoskernel/pb"
 	grpcUtils "github.com/chaos-mesh/chaos-mesh/pkg/grpc"
@@ -45,34 +41,45 @@ type Impl struct {
 	client.Client
 	Log logr.Logger
 
-	chaosDaemonClientBuilder *chaosdaemon.ChaosDaemonClientBuilder
+	decoder *utils.ContainerRecordDecoder
 }
 
 // Apply applies KernelChaos
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
+	impl.Log.Info("kernelchaos apply", "record", records[index])
+
+	decodedContainer, err := impl.decoder.DecodeContainerRecord(ctx, records[index], obj)
+	pbClient := decodedContainer.PbClient
+	if pbClient != nil {
+		defer pbClient.Close()
+	}
+	if err != nil {
+		return v1alpha1.NotInjected, err
+	}
+	pod := decodedContainer.Pod
+	containerId := decodedContainer.ContainerId
+
+	impl.Log.Info("Try to apply KernelChaos", "namespace", pod.Namespace, "pod", pod, "containerName", decodedContainer.ContainerName)
+	conn, pid, err := impl.prepareBPFKI(ctx, pbClient, pod, containerId)
+	if err != nil {
+		return v1alpha1.NotInjected, err
+	}
+	defer conn.Close()
+
 	kernelChaos := obj.(*v1alpha1.KernelChaos)
-	record := records[index]
+	callchain := generateFailKernRequestFrame(kernelChaos.Spec.FailKernRequest.Callchain)
 
-	log := impl.Log.WithValues("chaos", kernelChaos, "record", record)
-	podId, containerID, err := controller.ParseNamespacedNameContainer(record.Id)
+	bpfClient := pb_kernel.NewBPFKIServiceClient(conn)
+	_, err = bpfClient.FailMMOrBIO(ctx, &pb_kernel.FailKernRequest{
+		Pid:         pid,
+		Ftype:       pb_kernel.FailKernRequest_FAILTYPE(kernelChaos.Spec.FailKernRequest.FailType),
+		Headers:     kernelChaos.Spec.FailKernRequest.Headers,
+		Callchain:   callchain,
+		Probability: float32(kernelChaos.Spec.FailKernRequest.Probability) / 100,
+		Times:       kernelChaos.Spec.FailKernRequest.Times,
+	})
 	if err != nil {
-		return v1alpha1.NotInjected, err
-	}
-	var pod v1.Pod
-	err = impl.Client.Get(ctx, podId, &pod)
-	if err != nil {
-		log.Error(err, "fail to get pod by record")
-		// TODO: handle this error
-		if k8sError.IsNotFound(err) {
-			return v1alpha1.NotInjected, nil
-		}
-		return v1alpha1.NotInjected, err
-	}
-
-	log = log.WithValues("pod", pod)
-
-	if err = impl.applyPod(ctx, &pod, kernelChaos, containerID); err != nil {
-		log.Error(err, "failed to apply chaos on pod")
+		err = errors.Wrapf(err, "Fail mm or bio error")
 		return v1alpha1.NotInjected, err
 	}
 
@@ -81,169 +88,88 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 
 // Recover means the reconciler recovers the chaos action
 func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
+	impl.Log.Info("kernelchaos recover", "record", records[index])
+
+	decodedContainer, err := impl.decoder.DecodeContainerRecord(ctx, records[index], obj)
+	pbClient := decodedContainer.PbClient
+	if pbClient != nil {
+		defer pbClient.Close()
+	}
+	if err != nil {
+		return v1alpha1.Injected, err
+	}
+	var pod = decodedContainer.Pod
+	containerId := decodedContainer.ContainerId
+
+	impl.Log.Info("Try to recover KernelChaos", "namespace", pod.Namespace, "pod", pod, "containerName", decodedContainer.ContainerName)
+	conn, pid, err := impl.prepareBPFKI(ctx, pbClient, pod, containerId)
+	if err != nil {
+		return v1alpha1.NotInjected, err
+	}
+	defer conn.Close()
+
 	kernelChaos := obj.(*v1alpha1.KernelChaos)
-	record := records[index]
+	callchain := generateFailKernRequestFrame(kernelChaos.Spec.FailKernRequest.Callchain)
 
-	log := impl.Log.WithValues("chaos", kernelChaos, "record", record)
-	podId, containerID, err := controller.ParseNamespacedNameContainer(record.Id)
+	bpfClient := pb_kernel.NewBPFKIServiceClient(conn)
+	_, err = bpfClient.RecoverMMOrBIO(ctx, &pb_kernel.FailKernRequest{
+		Pid:       pid,
+		Callchain: callchain,
+	})
 	if err != nil {
-		errorInfo := fmt.Sprintf("kernelChaos recover error, record ID is %s", record.Id)
-		log.Error(err, errorInfo)
-		// This error is not expected to exist
-		return v1alpha1.Injected, err
-	}
-	var pod v1.Pod
-	err = impl.Client.Get(ctx, podId, &pod)
-	if err != nil {
-		log.Error(err, "fail to get pod by record")
-		// TODO: handle this error
-		if k8sError.IsNotFound(err) {
-			return v1alpha1.NotInjected, nil
-		}
-		return v1alpha1.Injected, err
-	}
-
-	log = log.WithValues("pod", pod)
-
-	if err = impl.recoverPod(ctx, &pod, kernelChaos, containerID); err != nil {
-		log.Error(err, "failed to recover chaos on pod")
+		err = errors.Wrapf(err, "Recover mm or bio error")
 		return v1alpha1.Injected, err
 	}
 
 	return v1alpha1.NotInjected, nil
 }
 
-func (impl *Impl) recoverPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.KernelChaos, containerID string) error {
-	impl.Log.Info("try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
-
-	pbClient, err := impl.chaosDaemonClientBuilder.Build(ctx, pod, &types.NamespacedName{
-		Namespace: chaos.Namespace,
-		Name:      chaos.Name,
-	})
-	if err != nil {
-		return err
-	}
-	defer pbClient.Close()
-
-	if len(pod.Status.ContainerStatuses) == 0 {
-		err = errors.Wrapf(utils.ErrContainerNotFound, "pod %s/%s has empty container status", pod.Namespace, pod.Name)
-		return err
-	}
-
-	containerResponse, err := pbClient.ContainerGetPid(ctx, &pb.ContainerRequest{
-		Action: &pb.ContainerAction{
-			Action: pb.ContainerAction_GETPID,
-		},
-		ContainerId: containerID,
-	})
-
-	if err != nil {
-		impl.Log.Error(err, "Get container pid error", "namespace", pod.Namespace, "name", pod.Name)
-		return err
-	}
-
-	impl.Log.Info("Get container pid", "namespace", pod.Namespace, "name", pod.Name)
-	conn, err := impl.CreateBPFKIConnection(ctx, impl.Client, pod)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	var callchain []*pb_kernel.FailKernRequestFrame
-	for _, frame := range chaos.Spec.FailKernRequest.Callchain {
-		callchain = append(callchain, &pb_kernel.FailKernRequestFrame{
+func generateFailKernRequestFrame(callChain []v1alpha1.Frame) (requestFrame []*pb_kernel.FailKernRequestFrame) {
+	for _, frame := range callChain {
+		requestFrame = append(requestFrame, &pb_kernel.FailKernRequestFrame{
 			Funcname:   frame.Funcname,
 			Parameters: frame.Parameters,
 			Predicate:  frame.Predicate,
 		})
 	}
-
-	bpfClient := pb_kernel.NewBPFKIServiceClient(conn)
-	_, err = bpfClient.RecoverMMOrBIO(ctx, &pb_kernel.FailKernRequest{
-		Pid:       containerResponse.Pid,
-		Callchain: callchain,
-	})
-
-	return err
+	return
 }
 
-func (impl *Impl) applyPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.KernelChaos, containerID string) error {
-	impl.Log.Info("Try to inject kernel on pod", "namespace", pod.Namespace, "name", pod.Name)
-
-	pbClient, err := impl.chaosDaemonClientBuilder.Build(ctx, pod, &types.NamespacedName{
-		Namespace: chaos.Namespace,
-		Name:      chaos.Name,
-	})
-	if err != nil {
-		return err
-	}
-	defer pbClient.Close()
-
-	if len(pod.Status.ContainerStatuses) == 0 {
-		err = errors.Wrapf(utils.ErrContainerNotFound, "pod %s/%s has empty container status", pod.Namespace, pod.Name)
-		return err
-	}
-
+func (impl *Impl) prepareBPFKI(ctx context.Context, pbClient chaosdaemonclient.ChaosDaemonClientInterface, pod *v1.Pod, containerId string) (*grpc.ClientConn, uint32, error) {
 	containerResponse, err := pbClient.ContainerGetPid(ctx, &pb.ContainerRequest{
 		Action: &pb.ContainerAction{
 			Action: pb.ContainerAction_GETPID,
 		},
-		ContainerId: containerID,
+		ContainerId: containerId,
 	})
 	if err != nil {
-		impl.Log.Error(err, "Get container pid error", "namespace", pod.Namespace, "name", pod.Name)
-		return err
+		err = errors.Wrapf(err, "Get container %s/%s %s pid error", pod.Namespace, pod.Name, containerId)
+		return nil, 0, err
 	}
 
-	impl.Log.Info("Get container pid", "namespace", pod.Namespace, "name", pod.Name)
-	conn, err := impl.CreateBPFKIConnection(ctx, impl.Client, pod)
+	daemonIP, err := impl.decoder.FindDaemonIP(ctx, pod)
 	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	var callchain []*pb_kernel.FailKernRequestFrame
-	for _, frame := range chaos.Spec.FailKernRequest.Callchain {
-		callchain = append(callchain, &pb_kernel.FailKernRequestFrame{
-			Funcname:   frame.Funcname,
-			Parameters: frame.Parameters,
-			Predicate:  frame.Predicate,
-		})
-	}
-
-	bpfClient := pb_kernel.NewBPFKIServiceClient(conn)
-	_, err = bpfClient.FailMMOrBIO(ctx, &pb_kernel.FailKernRequest{
-		Pid:         containerResponse.Pid,
-		Ftype:       pb_kernel.FailKernRequest_FAILTYPE(chaos.Spec.FailKernRequest.FailType),
-		Headers:     chaos.Spec.FailKernRequest.Headers,
-		Callchain:   callchain,
-		Probability: float32(chaos.Spec.FailKernRequest.Probability) / 100,
-		Times:       chaos.Spec.FailKernRequest.Times,
-	})
-
-	return err
-}
-
-// CreateBPFKIConnection create a grpc connection with bpfki
-func (impl *Impl) CreateBPFKIConnection(ctx context.Context, c client.Client, pod *v1.Pod) (*grpc.ClientConn, error) {
-	daemonIP, err := impl.chaosDaemonClientBuilder.FindDaemonIP(ctx, pod)
-	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	builder := grpcUtils.Builder(daemonIP, config.ControllerCfg.BPFKIPort).
 		WithDefaultTimeout().
 		Insecure()
-	return builder.Build()
+	clientConn, err := builder.Build()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return clientConn, containerResponse.Pid, nil
 }
 
-func NewImpl(c client.Client, log logr.Logger, builder *chaosdaemon.ChaosDaemonClientBuilder) *impltypes.ChaosImplPair {
+func NewImpl(c client.Client, log logr.Logger, decoder *utils.ContainerRecordDecoder) *impltypes.ChaosImplPair {
 	return &impltypes.ChaosImplPair{
 		Name:   "kernelchaos",
 		Object: &v1alpha1.KernelChaos{},
 		Impl: &Impl{
-			Client:                   c,
-			Log:                      log.WithName("kernelchaos"),
-			chaosDaemonClientBuilder: builder,
+			Client:  c,
+			Log:     log.WithName("kernelchaos"),
+			decoder: decoder,
 		},
 		ObjectList: &v1alpha1.KernelChaosList{},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

### What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

The last update of KernelChaos changed the Pod selector to the container selector, but one thing was not updated and seems to have been missed.

It will be called through reflection and cause error in function 'ParseNamespacedNameContainer'. The error message is 'too few parts of namespacedname'.

The last update incorrectly used the container name as the container ID for selecting the container.

### What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

* Fix inconsistent last update of KernelChaos 
Update selector from PodSelector to ContainerSelector in file 'api/v1alpha1/kernelchaos_types.go'
* Select container by name
Users should obviously use the name of the container instead of the ID (e.g. containerd://7dc3e8617cd......) to select the target container.
* Use widely used ContainerRecordDecoder:
Use the ContainerRecordDecoder to parse the Pod and Container's Name and ID from record and build the ChaosDaemonClient.

### Related changes

- [x] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [x] This change also requires further updates to the `UI interface`
- Need to **cheery-pick to release branches**
  - [ ] release-2.5
  - [ ] release-2.4

### Checklist

CHANGELOG

<!-- Must include at least one of them. -->

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Tests

<!-- Must include at least one of them. -->

- [ ] Unit test
- [ ] E2E test
- [ ] No code
- [x] Manual test (add steps below)

<!-- > steps: -->

I create a demo Pod and KernelChaos with and without containerNames field to verify the fix in my single-node k8s cluster.

See:

https://github.com/YuSitong1999/chaos-mesh-verify

Side effects

- [ ] **Breaking backward compatibility**

It is the same as the last update which was fixed.
Because when the comtainerNames are not set, only the first container will be injected like before, the KernelChaos defined by yaml files are backward compatible.
The KernelChaos which is created and applied by Golang code may need a simple modification to use ContainerSelector instead 
 of PodSelector.

### DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
