### PR TITLE
chore: update templates to fit v2.6

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new
 - [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
 - [ ] This change also requires further updates to the `UI interface`
 
-## Cherry-pick to release branches (Optional)
+## Cherry-pick to release branches (optional)
 
 > This PR should be cherry-picked to the following release branches:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,34 +10,38 @@ If you still have questions, please let us know via issues.
 Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
 -->
 
-### What problem does this PR solve?
+## What problem does this PR solve?
 
 <!-- Uncomment this line if some issues to close -->
 <!-- Close #<issue number> -->
 
-### What's changed and how it works?
+## What's changed and how it works?
 
 <!-- Uncomment this line if this PR is associated with a proposal -->
 <!-- Proposal: [name](url) -->
 
-### Related changes
+## Related changes
 
 - [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
 - [ ] This change also requires further updates to the `UI interface`
-- Need to **cheery-pick to release branches**
-  - [ ] release-2.6
-  - [ ] release-2.5
 
-### Checklist
+## Cherry-pick to release branches (Optional)
 
-CHANGELOG
+> This PR should be cherry-picked to the following release branches:
+
+- [ ] release-2.6
+- [ ] release-2.5
+
+## Checklist
+
+### CHANGELOG
 
 > Must include at least one of them.
 
 - [ ] I have updated the `CHANGELOG.md`
 - [ ] I have labeled this PR with "no-need-update-changelog"
 
-Tests
+### Tests
 
 > Must include at least one of them.
 
@@ -45,11 +49,11 @@ Tests
 - [ ] E2E test
 - [ ] Manual test
 
-Side effects
+### Side effects
 
 - [ ] **Breaking backward compatibility**
 
-### DCO
+## DCO
 
 If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,28 +25,25 @@ Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new
 - [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
 - [ ] This change also requires further updates to the `UI interface`
 - Need to **cheery-pick to release branches**
+  - [ ] release-2.6
   - [ ] release-2.5
-  - [ ] release-2.4
 
 ### Checklist
 
 CHANGELOG
 
-<!-- Must include at least one of them. -->
+> Must include at least one of them.
 
 - [ ] I have updated the `CHANGELOG.md`
 - [ ] I have labeled this PR with "no-need-update-changelog"
 
 Tests
 
-<!-- Must include at least one of them. -->
+> Must include at least one of them.
 
 - [ ] Unit test
 - [ ] E2E test
-- [ ] No code
-- [ ] Manual test (add steps below)
-
-<!-- > steps: -->
+- [ ] Manual test
 
 Side effects
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,32 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
-- Bump go to v1.19.3 [#3770](https://github.com/chaos-mesh/chaos-mesh/pull/3770)
-- Update k8s.io dependencies to v0.26.1 [#3902](https://github.com/chaos-mesh/chaos-mesh/pull/3902)
-- Update sigs.k8s.io/controller-runtime to v0.14.1 and sigs.k8s.io/controller-tools to v0.11.1 [#3902](https://github.com/chaos-mesh/chaos-mesh/pull/3902)
+- Nothing
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- Nothing
+
+### Security
+
+- Nothing
+
+## [2.6.0] - 2023-05-30
+
+### Added
+
 - Install offline Helm Chart for a multi-cluster [#3897](https://github.com/chaos-mesh/chaos-mesh/pull/3897)
 
 ### Changed
@@ -23,9 +46,11 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Switch views between k8s and hosts nodes [#3830](https://github.com/chaos-mesh/chaos-mesh/pull/3830)
 - New CI for finding merge conflicts [#3850](https://github.com/chaos-mesh/chaos-mesh/pull/3850)
 - Upgrade byteman-helper to v4.0.20 [#3863](https://github.com/chaos-mesh/chaos-mesh/pull/3863)
-- Helm: change default webhook port to [#10250](https://github.com/chaos-mesh/chaos-mesh/pull/3877)
+- Helm: change default webhook port to 10250 [#3877](https://github.com/chaos-mesh/chaos-mesh/pull/3877)
 - Upgrade base image for chaos-mesh to alpine:3.17 [#3893](https://github.com/chaos-mesh/chaos-mesh/pull/3893)
 - Slow down releasing the latest version [#3900](https://github.com/chaos-mesh/chaos-mesh/pull/3900)
+- Update k8s.io dependencies to v0.26.1 [#3902](https://github.com/chaos-mesh/chaos-mesh/pull/3902)
+- Update sigs.k8s.io/controller-runtime to v0.14.1 and sigs.k8s.io/controller-tools to v0.11.1 [#3902](https://github.com/chaos-mesh/chaos-mesh/pull/3902)
 - Change the package manager from `yarn` to `pnpm`. [#3965](https://github.com/chaos-mesh/chaos-mesh/pull/3965)
 - Upgrade DNS CoreDNS image url to ghcr.io [#3488](https://github.com/chaos-mesh/chaos-mesh/pull/3488)
 - Upgrade OS image for chaos-daemon container image [#3905](https://github.com/chaos-mesh/chaos-mesh/pull/3905)
@@ -40,6 +65,10 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade fx event logger [#4036](https://github.com/chaos-mesh/chaos-mesh/pull/4036)
 - Refine logging in `pkg/selector/physicalmachine` [#4037](https://github.com/chaos-mesh/chaos-mesh/pull/4037)
 - Setup OWNERS and OWNERS_ALIASES [#4039](https://github.com/chaos-mesh/chaos-mesh/pull/4039)
+
+### Deprecated
+
+- Nothing
 
 ### Removed
 


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Some templates are outdated.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Update the changelog and the pr template to fit `v2.6`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
