### PR TITLE
Move @Gallardot to emeritus maintainers and move @fewdan @Colstuwjx @…

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,6 @@ The Maintainers of Chaos Mesh, along with their emails, are listed be
 | Cwen Yin ([cwen0](https://github.com/cwen0))               |  [cwen@pingcap.com](mailto:cwen@pingcap.com)            |  [PingCAP](https://www.pingcap.com/)       |
 | Keao Yang ([YangKeao](https://github.com/YangKeao))        |  [yangkeao@pingcap.com](mailto:yangkeao@pingcap.com)    |  [PingCAP](https://www.pingcap.com/)       |
 | Calvin Weng ([dcalvin](https://github.com/dcalvin))        |  [wenghao@pingcap.com](mailto:wenghao@pingcap.com)      |  [PingCAP](https://www.pingcap.com/)       |
-| Hengliang Tan ([Gallardot](https://github.com/Gallardot))  |  [tttick@gmail.com](mailto:tttick@gmail.com)            |  [Xpeng Motors](https://www.xiaopeng.com/) |
 | Zhiqiang Zhou ([STRRL](https://github.com/STRRL))          | [im@strrl.dev](mailto:im@strrl.dev)                     | Freelancer                                 |
 | Glen Yang ([g1eny0ung](https://github.com/g1eny0ung))      | [g1enyy0ung@gmail.com](mailto:g1enyy0ung@gmail.com)     | [EMQ](https://www.emqx.com/)          |
 
@@ -21,16 +20,9 @@ The Committers of Chaos Mesh, along with their emails, are listed below:
 
 | Name                                                             | Email                                                                         | Org                                   |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------- |
-| Yihao Fu ([fewdan](https://github.com/fewdan))                   | [fuyihao@pingcap.com](mailto:fuyihao@pingcap.com)                             | [PingCAP](https://www.pingcap.com/)   |
-| Jiaxing Wu ([Colstuwjx](https://github.com/Colstuwjx))           | [wjx_colstu@hotmail.com](mailto:wjx_colstu@hotmail.com)                       | [Kingnet](https://www.kingnet.com/)   |
-| Shuyang Wu ([Yiyiyimu](https://github.com/Yiyiyimu))             | [wosoyoung@gmail.com](mailto:wosoyoung@gmail.com)                             | [APISIX](https://apisix.apache.org/)  |
 | Shenan Zhang ([Andrewmatilde](https://github.com/Andrewmatilde)) | [zhangshenan@pingcap.com](mailto:zhangshenan@pingcap.com)                     | [PingCAP](https://www.pingcap.com/)   |
 | Xiang Wang ([WangXiangUSTC](https://github.com/WangXiangUSTC))   | [wangxiang@pingcap.com](mailto:wangxiang@pingcap.com)                         | [PingCAP](https://www.pingcap.com/)   |
-| Wenbo Zhang ([ethercflow](https://github.com/ethercflow))        | [zhangwenbo@pingcap.com](mailto:zhangwenbo@pingcap.com)                       | [PingCAP](https://www.pingcap.com/)   |
-| Shivansh Saini ([shivanshs9](https://github.com/shivanshs9))     | [shivansh.saini.cse17@iitbhu.ac.in](mailto:shivansh.saini.cse17@iitbhu.ac.in) | [Headout](https://github.com/headout) |
-| Siyu Chen ([iguoyr](https://github.com/iguoyr))                  | [chensiyu@pingcap.com](mailto:chensiyu@pingcap.com)                           | [PingCAP](https://www.pingcap.com/)   |
 | Xianglin Gao ([xlgao-zju](https://github.com/xlgao-zju))         | [xlgao@zju.edu.cn](mailto:xlgao@zju.edu.cn)                                   | [Tencent](https://tencent.com/)       |
-| Chenxi Li ([Hexilee](https://github.com/Hexilee))                | [lichenxi@pingcap.com](mailto:lichenxi@pingcap.com)                           | [PingCAP](https://pingcap.com/)       |
 
 ## Emeritus Maintainers
 
@@ -42,3 +34,18 @@ The Emeritus Maintainers of Chaos Mesh, along with their emails, are listed belo
 | Qiang Zhou ([zhouqiang-cl](https://github.com/zhouqiang-cl))  |  [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com)  |  [PingCAP](https://www.pingcap.com/) |
 | Song Gao ([Yisaer](https://github.com/Yisaer))                |  [gaosong@pingcap.com](mailto:gaosong@pingcap.com)      |  [PingCAP](https://www.pingcap.com/) |
 | Ben Ye ([yeya24](https://github.com/yeya24))                  |  [yb532204897@gmail.com](mailto:yb532204897@gmail.com)  |  [AWS](https://aws.amazon.com/)      |
+| Hengliang Tan ([Gallardot](https://github.com/Gallardot))     |  [gallardot@apache.org](mailto:gallardot@apache.org)    |  [Xpeng Motors](https://www.xiaopeng.com/) |
+
+## Emeritus Committers
+
+The Emeritus Committers of Chaos Mesh, along with their emails, are listed below:
+
+| Name                                                             | Email                                                                         | Org                                   |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------- |
+| Yihao Fu ([fewdan](https://github.com/fewdan))                   | [fuyihao@pingcap.com](mailto:fuyihao@pingcap.com)                             | [PingCAP](https://www.pingcap.com/)   |
+| Jiaxing Wu ([Colstuwjx](https://github.com/Colstuwjx))           | [wjx_colstu@hotmail.com](mailto:wjx_colstu@hotmail.com)                       | [Kingnet](https://www.kingnet.com/)   |
+| Shuyang Wu ([Yiyiyimu](https://github.com/Yiyiyimu))             | [wosoyoung@gmail.com](mailto:wosoyoung@gmail.com)                             | [APISIX](https://apisix.apache.org/)  |
+| Wenbo Zhang ([ethercflow](https://github.com/ethercflow))        | [zhangwenbo@pingcap.com](mailto:zhangwenbo@pingcap.com)                       | [PingCAP](https://www.pingcap.com/)   |
+| Shivansh Saini ([shivanshs9](https://github.com/shivanshs9))     | [shivansh.saini.cse17@iitbhu.ac.in](mailto:shivansh.saini.cse17@iitbhu.ac.in) | [Headout](https://github.com/headout) |
+| Siyu Chen ([iguoyr](https://github.com/iguoyr))                  | [chensiyu@pingcap.com](mailto:chensiyu@pingcap.com)                           | [PingCAP](https://www.pingcap.com/)   |
+| Chenxi Li ([Hexilee](https://github.com/Hexilee))                | [lichenxi@pingcap.com](mailto:lichenxi@pingcap.com)                           | [PingCAP](https://pingcap.com/)       |

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,17 +3,9 @@ aliases:
     - cwen0
     - YangKeao
     - dcalvin
-    - Gallardot
     - STRRL
     - g1eny0ung
   chaos-mesh-committers:
-    - fewdan
-    - Colstuwjx
-    - Yiyiyimu
     - Andrewmatilde
     - WangXiangUSTC
-    - ethercflow
-    - shivanshs9
-    - iguoyr
     - xlgao-zju
-    - Hexilee


### PR DESCRIPTION
As per the [governance doc](https://github.com/chaos-mesh/chaos-mesh/blob/master/GOVERNANCE.md#maintainer), I create this PR on behalf of Chaos Mesh maintainers to move @Gallardot to emeritus maintainers and move @fewdan @Colstuwjx @ethercflow @shivanshs9 @iguoyr @Hexilee to emeritus committers as they haven't been able to stay active in the project for a while due to shift of focus.  

Thanks for their awesome work on Chaos Mesh! We very much appreciate their contributions but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly and sustained project.

/cc @chaos-mesh/maintainers 