### PR TITLE
Publish a generated extension using jbang and jitpack

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,0 +1,3 @@
+src
+target
+chaos-mesh.java

--- a/java/chaos-mesh.java.template
+++ b/java/chaos-mesh.java.template
@@ -1,0 +1,3 @@
+//DEPS io.fabric8:kubernetes-client:$FABRIC8_VERSION
+//DEPS io.fabric8:generator-annotations:$FABRIC8_VERSION
+//SOURCES src/**.java

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,15 @@
+# From: https://www.jbang.dev/documentation/guide/latest/exporting.html
+before_install:
+  - sdk install java 11.0.15-tem
+  - sdk use java 11.0.15-tem
+  - curl -Ls https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-`uname -s`-`uname -m` -o envsubst && chmod +x envsubst
+  - curl -Ls https://sh.jbang.dev | bash -s - app setup
+  - curl -Ls https://github.com/codacy/git-version/releases/download/2.8.0/git-version -o git-version && chmod a+x git-version
+install:
+  - ./envsubst < java/chaos-mesh.java.template > java/chaos-mesh.java
+  - ~/.jbang/bin/jbang io.fabric8:java-generator-cli:${FABRIC8_VERSION} --source config/crd/bases --target ./java/src
+  - ~/.jbang/bin/jbang export mavenrepo --force -O target --group=org.chaos_mesh --artifact=chaos-mesh --version=$(./git-version) java/chaos-mesh.java
+  - mkdir -p ~/.m2/repository
+  - cp -rv target/* ~/.m2/repository/
+env:
+  FABRIC8_VERSION: "6.7.2"


### PR DESCRIPTION
Hi all 👋  and thanks for the amazing and widely used project!

For some time we are delivering a [java-generator from CRD](https://github.com/fabric8io/kubernetes-client/blob/master/doc/java-generation-from-CRD.md) as part of the fabric8 kubernetes-client project.
We are dissatisfied with the [current "extensions" mechanism](https://github.com/fabric8io/kubernetes-client/tree/master/extensions/chaosmesh) and, sometimes, we struggle to keep it up to date and maintained.

Here I'm proposing a possible implementation of the automation needed in this repository to publish a package functionally equivalent to the current extension but with close to zero maintenance involved.

You can check the resulting artifacts built from my fork: https://jitpack.io/#andreaTP/chaos-mesh/3.0.1-SNAPSHOT

I'm happy to receive feedback on all the pieces, the automation(jbang and jitpack), the generated code, where to publish etc.

For reference, this is the same process we went through for the Camel-K extension: https://github.com/apache/camel-k/pull/3994
