### PR TITLE
fix dashboard panic when exec delete action by finish_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Set `replicas: 1` automatically when HA is not enabled [#4079](https://github.com/chaos-mesh/chaos-mesh/pull/4079)
 - Remove redundant where statements [#4084](https://github.com/chaos-mesh/chaos-mesh/pull/4084)
+- Fix dashboard panic when exec delete action by finish_time [#4100](https://github.com/chaos-mesh/chaos-mesh/pull/4100)
 
 ### Security
 

--- a/pkg/dashboard/store/experiment/experiment.go
+++ b/pkg/dashboard/store/experiment/experiment.go
@@ -141,6 +141,10 @@ func (e *experimentStore) DeleteByFinishTime(_ context.Context, ttl time.Duratio
 
 	nowTime := time.Now()
 	for _, exp := range experiments {
+		if exp.FinishTime == nil {
+			log.Error(nil, "finish time is nil when deleting archived experiment records, skip it", "experiment", exp)
+			continue
+		}
 		if exp.FinishTime.Add(ttl).Before(nowTime) {
 			if err := e.db.Table("experiments").Unscoped().Delete(*exp).Error; err != nil {
 				return err

--- a/pkg/dashboard/store/schedule/schedule.go
+++ b/pkg/dashboard/store/schedule/schedule.go
@@ -113,7 +113,7 @@ func (e *ScheduleStore) DeleteByFinishTime(_ context.Context, ttl time.Duration)
 	nowTime := time.Now()
 	for _, sch := range sches {
 		if sch.FinishTime == nil {
-			log.Error(nil, "finish time is nil when deleting schedule records, skip it", "schedule", sch)
+			log.Error(nil, "finish time is nil when deleting archived schedule records, skip it", "schedule", sch)
 			continue
 		}
 		if sch.FinishTime.Add(ttl).Before(nowTime) {

--- a/pkg/dashboard/store/schedule/schedule.go
+++ b/pkg/dashboard/store/schedule/schedule.go
@@ -112,6 +112,10 @@ func (e *ScheduleStore) DeleteByFinishTime(_ context.Context, ttl time.Duration)
 
 	nowTime := time.Now()
 	for _, sch := range sches {
+		if sch.FinishTime == nil {
+			log.Error(nil, "finish time is nil when deleting schedule records, skip it", "schedule", sch)
+			continue
+		}
 		if sch.FinishTime.Add(ttl).Before(nowTime) {
 			if err := e.db.Table("schedules").Unscoped().Delete(*sch).Error; err != nil {
 				return err

--- a/pkg/dashboard/store/workflow/workflow.go
+++ b/pkg/dashboard/store/workflow/workflow.go
@@ -119,7 +119,7 @@ func (it *WorkflowStore) DeleteByFinishTime(ctx context.Context, ttl time.Durati
 	nowTime := time.Now()
 	for _, wfl := range workflows {
 		if wfl.FinishTime == nil {
-			log.Error(nil, "workflow finish time is nil when deleting workflow reocrds, skip it", "workflow", wfl)
+			log.Error(nil, "workflow finish time is nil when deleting archived workflow reocrds, skip it", "workflow", wfl)
 			continue
 		}
 		if wfl.FinishTime.Add(ttl).Before(nowTime) {

--- a/pkg/dashboard/store/workflow/workflow.go
+++ b/pkg/dashboard/store/workflow/workflow.go
@@ -20,9 +20,12 @@ import (
 	"time"
 
 	"github.com/jinzhu/gorm"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/dashboard/core"
 )
+
+var log = ctrl.Log.WithName("store/workflow")
 
 type WorkflowStore struct {
 	db *gorm.DB
@@ -115,6 +118,10 @@ func (it *WorkflowStore) DeleteByFinishTime(ctx context.Context, ttl time.Durati
 
 	nowTime := time.Now()
 	for _, wfl := range workflows {
+		if wfl.FinishTime == nil {
+			log.Error(nil, "workflow finish time is nil when deleting workflow reocrds, skip it", "workflow", wfl)
+			continue
+		}
 		if wfl.FinishTime.Add(ttl).Before(nowTime) {
 			if err := it.db.Where("uid = ?", wfl.UID).Unscoped().Delete(*it).Error; err != nil {
 				return err
@@ -128,7 +135,7 @@ func (it *WorkflowStore) DeleteByFinishTime(ctx context.Context, ttl time.Durati
 func (it *WorkflowStore) MarkAsArchived(ctx context.Context, namespace, name string) error {
 	if err := it.db.Model(core.WorkflowEntity{}).
 		Where("namespace = ? AND name = ? AND archived = ?", namespace, name, false).
-		Updates(map[string]interface{}{"archived": true, "end_time": time.Now().Format(time.RFC3339)}).Error; err != nil && !gorm.IsRecordNotFoundError(err) {
+		Updates(map[string]interface{}{"archived": true, "finish_time": time.Now().Format(time.RFC3339)}).Error; err != nil && !gorm.IsRecordNotFoundError(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->  

Fix #4099 

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) --> 

* Set finish_time when to mark it archived.  In workflow definition, end_time represents the time when the workflow completed all steps and finish time represents the time when the workflow was deleted from Kubernetes. So we should set finish_time when to mark it archived instead of end_time. 
* Add nill check on `DeleteByFinishTime" function. 

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
