### PR TITLE
chore: check links only in modified files

### DIFF
--- a/.github/checklink_config.json
+++ b/.github/checklink_config.json
@@ -2,24 +2,6 @@
   "ignorePatterns": [
     {
       "pattern": "^http://localhost"
-    },
-    {
-      "pattern": "^https://github.com"
-    },
-    {
-      "pattern": "^https://www.microsoft.com"
-    },
-    {
-      "pattern": "^http://techgenix.com"
-    },
-    {
-      "pattern": "^https://en.pingcap.com"
-    },
-    {
-      "pattern": "^https://www.tencent.com"
-    },
-    {
-      "pattern": "^https://twitter.com"
     }
   ],
   "aliveStatusCodes": [200, 403, 500, 502, 503]

--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -18,4 +18,5 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
+          check-modified-files-only: 'yes'
           config-file: ".github/checklink_config.json"


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Ref: https://github.com/chaos-mesh/website/pull/394.

> Over time, some of the links in our blogs (mostly blogs, but also documents) have broken (another reason is some domains are blocked by GitHub, like Twitter). This causes some contributors to open a PR every time and find this check failed, and then they get stuck in a dead-end loop of fixing the CI.

> So I update the action to check only the modified files by setting `check-modified-files-only` to `yes`. This avoids checking all the legacy files.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
