### PR TITLE
Set the database column type to text for 'Workflow/Experiment/Schedule'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Change `awschaos/*/impl.go` to use `aws_session_token` with static credentials provider so that users can perform awschaos using [temporary AWS credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) [#4066](https://github.com/chaos-mesh/chaos-mesh/pull/4066)
 - Enable consistency for ghcr.io registry [#4091](https://github.com/chaos-mesh/chaos-mesh/pull/4091) [#4134](https://github.com/chaos-mesh/chaos-mesh/pull/4134)
 - Prevent mousewheel scroll from changing numeric input values. [#4133](https://github.com/chaos-mesh/chaos-mesh/pull/4133)
+- Set the database column type to text for 'Workflow/Experiment/Schedule' [#4151](https://github.com/chaos-mesh/chaos-mesh/pull/4151)
 
 ### Deprecated
 
@@ -45,7 +46,6 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
-- Set the database column type to text for 'Workflow/Experiment/Schedule' [#4151](https://github.com/chaos-mesh/chaos-mesh/pull/4151)
 - Change CoreDNS listen port from 53 to 5353 [#4022](https://github.com/chaos-mesh/chaos-mesh/pull/4022)
 - Bump go to v1.19.3 [#3770](https://github.com/chaos-mesh/chaos-mesh/pull/3770)
 - Change ubuntu version from latest to 20.04 [#3817](https://github.com/chaos-mesh/chaos-mesh/pull/3817)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
+- Set the database column type to text for 'Workflow/Experiment/Schedule' [#4151](https://github.com/chaos-mesh/chaos-mesh/pull/4151)
 - Change CoreDNS listen port from 53 to 5353 [#4022](https://github.com/chaos-mesh/chaos-mesh/pull/4022)
 - Bump go to v1.19.3 [#3770](https://github.com/chaos-mesh/chaos-mesh/pull/3770)
 - Change ubuntu version from latest to 20.04 [#3817](https://github.com/chaos-mesh/chaos-mesh/pull/3817)

--- a/pkg/dashboard/core/event.go
+++ b/pkg/dashboard/core/event.go
@@ -64,5 +64,5 @@ type Event struct {
 	Kind      string    `json:"kind"`
 	Type      string    `json:"type"`
 	Reason    string    `json:"reason"`
-	Message   string    `json:"message"`
+	Message   string    `gorm:"type:text;size:32768" json:"message"`
 }

--- a/pkg/dashboard/core/experiment.go
+++ b/pkg/dashboard/core/experiment.go
@@ -61,7 +61,7 @@ type ExperimentStore interface {
 // Experiment represents an experiment instance. Use in db.
 type Experiment struct {
 	ExperimentMeta
-	Experiment string `gorm:"size:4096"` // JSON string
+	Experiment string `gorm:"type:text;size:32768"` // JSON string
 }
 
 // ExperimentMeta defines the metadata of an experiment. Use in db.

--- a/pkg/dashboard/core/schedule.go
+++ b/pkg/dashboard/core/schedule.go
@@ -58,7 +58,7 @@ type ScheduleStore interface {
 // Schedule represents a schedule instance. Use in db.
 type Schedule struct {
 	ScheduleMeta
-	Schedule string `gorm:"size:4096"` // JSON string
+	Schedule string `gorm:"type:text;size:32768"` // JSON string
 }
 
 // ScheduleMeta defines the metadata of a schedule instance. Use in db.


### PR DESCRIPTION
## What problem does this PR solve?

The DB of chaos dashboard restricts the length of these three fields to normal varchar. This can easily lead to storage failure due to data being too long, logs show:

```text
2023-08-09T07:59:54.584Z	ERROR	collector.NetworkChaos	collector/collector.go:114	failed to update experiment	{"archive": {"ID":16,"CreatedAt":"2023-08-05T11:15:45Z","UpdatedAt":"2023-08-09T07:59:54.583499664Z","DeletedAt":null,"uid":"d97a7ec5-8b9d-4acf-8ee4-a997b42648fb","kind":"NetworkChaos","name":"net-loss-100","namespace":"default","action":"loss","start_time":"2023-08-05T11:15:44Z","finish_time":null,"archived":false,"Experiment":"{\"kind\":\"NetworkChaos\",\"apiVersion\":\"chaos-mesh.org/v1alpha1\",\"metadata\":{\"name\":\"net-loss-100\",\"namespace\":\"default\",\"uid\":\"d97a7ec5-8b9d-4acf-8ee4-a997b42648fb\",\"resourceVersion\":\"4947395\",\"generation\":31,\"creationTimestamp\":\"2023-08-05T11:15:44Z\",\"annotations\":{\"experiment.chaos-mesh.org/pause\":\"true\"},\"finalizers\":[\"chaos-mesh/records\"],\"managedFields\":[{\"manager\":\"chaos-dashboard\",\"operation\":\"Update\",\"apiVersion\":\"chaos-mesh.org/v1alpha1\",\"time\":\"2023-08-05T11:17:51Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:experiment.chaos-mesh.org/pause\":{}}},\"f:spec\":{\".\":{},\"f:action\":{},\"f:direction\":{},\"f:loss\":{\".\":{},\"f:loss\":{}},\"f:mode\":{},\"f:selector\":{\".\":{},\"f:labelSelectors\":{\".\":{},\"f:app\":{}},\"f:namespaces\":{}}},\"f:status\":{\".\":{},\"f:experiment\":{}}}},{\"manager\":\"chaos-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"chaos-mesh.org/v1alpha1\",\"time\":\"2023-08-05T11:22:47Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:finalizers\":{\".\":{},\"v:\\\"chaos-mesh/records\\\"\":{}}},\"f:status\":{\"f:conditions\":{},\"f:experiment\":{\"f:containerRecords\":{},\"f:desiredPhase\":{}},\"f:instances\":{\".\":{},\"f:default/chaos-hello-web-block-5cff846575-7c7cf\":{}}}}}]},\"spec\":{\"selector\":{\"namespaces\":[\"default\"],\"labelSelectors\":{\"app\":\"chaos-hello-web-block\"}},\"mode\":\"all\",\"action\":\"loss\",\"loss\":{\"loss\":\"100\",\"correlation\":\"0\"},\"direction\":\"to\"},\"status\":{\"conditions\":[{\"type\":\"Selected\",\"status\":\"True\"},{\"type\":\"AllInjected\",\"status\":\"False\"},{\"type\":\"AllRecovered\",\"status\":\"True\"},{\"type\":\"Paused\",\"status\":\"True\"}],\"experiment\":{\"desiredPhase\":\"Stop\",\"containerRecords\":[{\"id\":\"default/chaos-hello-web-block-5cff846575-7c7cf\",\"selectorKey\":\".\",\"phase\":\"Not Injected\",\"injectedCount\":1,\"recoveredCount\":1,\"events\":[{\"type\":\"Succeeded\",\"operation\":\"Apply\",\"timestamp\":\"2023-08-05T11:15:44Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:51Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:52Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:53Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:53Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:54Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:54Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:59Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:17:59Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:18:20Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:18:20Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:19:42Z\"},{\"type\":\"Failed\",\"operation\":\"Recover\",\"message\":\"failed to apply for pod default/chaos-hello-web-block-5cff846575-7c7cf: unable to flush ip sets for pod chaos-hello-web-block-5cff846575-7c7cf\",\"timestamp\":\"2023-08-05T11:19:42Z\"},{\"type\":\"Succeeded\",\"operation\":\"Recover\",\"timestamp\":\"2023-08-05T11:22:47Z\"}]}]},\"instances\":{\"default/chaos-hello-web-block-5cff846575-7c7cf\":2}}}"}, "error": "Error 1406: Data too long for column 'experiment' at row 1"}
```

```text
2023-08-09T08:04:21.815Z	ERROR	collector.event-collector.Event	collector/event_collector.go:105	failed to save event	{"event": {"id":0,"object_id":"4c5e13f1-e59b-48bc-afe0-e4061aefa16d","created_at":"2023-08-09T08:04:21Z","namespace":"default","name":"kill-tomcat-6","kind":"PodChaos","type":"Warning","reason":"Failed","message":"Failed to update records: Internal error occurred: failed calling webhook \"mpodchaos.kb.io\": failed to call webhook: Post \"https://chaos-mesh-controller-manager.chaos-mesh.svc:443/mutate-chaos-mesh-org-v1alpha1-podchaos?timeout=5s\": context deadline exceeded"}, "error": "Error 1406: Data too long for column 'message' at row 1"}
```

notes: no `Schedule Data too long` log, I haven't used Schedule heavily yet, but according to the storage structure, I predict we will encounter the same problem in the future.

## What's changed and how it works?

Set the database column type to text for 'Workflow/Experiment/Schedule'

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
