### PR TITLE
ci: remove the duplicate `make test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,18 @@ jobs:
           elif [[ "$job" == "build" ]]; then
             make image
           elif [[ "$job" == "test" ]]; then
-            ROOT=$(pwd)
-            KUBEBUILDER_ASSETS=${ROOT}/output/bin/kubebuilder/bin make test
+            make test
           else
             make $job
           fi
+
+      - name: Upload Code Coverage
+        uses: codecov/codecov-action@v3
+        if: matrix.job == 'test'
+        with:
+          files: ./cover.out
+          verbose: true
+          fail_ci_if_error: true
   ui:
     needs: changes
     if: ${{ needs.changes.outputs.ui == 'true' }}

--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -1,12 +1,6 @@
 name: Unit Test And Code Coverage
 
-# this workflow would work on all the prs
 on:
-  pull_request:
-    paths:
-      - Makefile
-      - go.*
-      - "**.go"
   push:
     paths:
       - Makefile
@@ -20,40 +14,13 @@ jobs:
     name: "Unit Test And Code Coverage"
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Build Chaos Mesh Build Env
-        if: ${{ github.event.pull_request }}
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-
-          make image-build-env
-
-      - name: Build Chaos Mesh Dev Env
-        if: ${{ github.event.pull_request }}
-        env:
-          IMAGE_DEV_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-dev-env-image') }}
-        run: |
-          if [ "${IMAGE_DEV_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_DEV_ENV_BUILD=1;
-          else
-            export IMAGE_DEV_ENV_BUILD=0;
-          fi
-
-          make image-dev-env
+      - uses: actions/checkout@v4
 
       - name: Unit Test
-        run: |
-          make test
+        run: make test
+
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./cover.out
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix dashboard panic when exec delete action by finish_time [#4100](https://github.com/chaos-mesh/chaos-mesh/pull/4100)
 - Fix remote cluster cannot upgrade helm release [#4075](https://github.com/chaos-mesh/chaos-mesh/pull/4075)
 - Fix goroutine leak [#4229](https://github.com/chaos-mesh/chaos-mesh/pull/4229)
+- Remove the duplicate `make test` [#4227](https://github.com/chaos-mesh/chaos-mesh/pull/4227)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix dashboard panic when exec delete action by finish_time [#4100](https://github.com/chaos-mesh/chaos-mesh/pull/4100)
 - Fix remote cluster cannot upgrade helm release [#4075](https://github.com/chaos-mesh/chaos-mesh/pull/4075)
 - Fix goroutine leak [#4229](https://github.com/chaos-mesh/chaos-mesh/pull/4229)
-- Remove the duplicate `make test` [#4227](https://github.com/chaos-mesh/chaos-mesh/pull/4227)
+- Remove the duplicate `make test` [#4234](https://github.com/chaos-mesh/chaos-mesh/pull/4234)
 
 ### Security
 


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

Currently, we run two unit tests (`make test`) when we open a PR.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Let `codecov_unittest.yaml` only run on `push` and append code coverage action in `ci.yml`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
