### PR TITLE
fix: validate DNS server IP in SetDNSServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix remote cluster cannot upgrade helm release [#4075](https://github.com/chaos-mesh/chaos-mesh/pull/4075)
 - Fix goroutine leak [#4229](https://github.com/chaos-mesh/chaos-mesh/pull/4229)
 - Remove the duplicate `make test` [#4234](https://github.com/chaos-mesh/chaos-mesh/pull/4234)
+- Fix daemon-server `SetDNSServer` endpoint to validate provided server address [#4246](https://github.com/chaos-mesh/chaos-mesh/pull/4246)
 
 ### Security
 

--- a/pkg/chaosdaemon/dns_server.go
+++ b/pkg/chaosdaemon/dns_server.go
@@ -33,13 +33,11 @@ const (
 	DNSServerConfFile = "/etc/resolv.conf"
 )
 
+var ErrInvalidDNSServer = errors.New("invalid DNS server address")
+
 func (s *DaemonServer) SetDNSServer(ctx context.Context,
 	req *pb.SetDNSServerRequest) (*empty.Empty, error) {
 	log := s.getLoggerFromContext(ctx)
-
-	if net.ParseIP(req.DnsServer) == nil {
-		return nil, fmt.Errorf("invalid DNS server address")
-	}
 
 	log.Info("SetDNSServer", "request", req)
 	pid, err := s.crClient.GetPidFromContainerID(ctx, req.ContainerId)
@@ -51,8 +49,8 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 	if req.Enable {
 		// set dns server to the chaos dns server's address
 
-		if len(req.DnsServer) == 0 {
-			return &empty.Empty{}, errors.Errorf("invalid set dns server request %v", req)
+		if net.ParseIP(req.DnsServer) == nil {
+			return nil, ErrInvalidDNSServer
 		}
 
 		// backup the /etc/resolv.conf

--- a/pkg/chaosdaemon/dns_server.go
+++ b/pkg/chaosdaemon/dns_server.go
@@ -18,6 +18,7 @@ package chaosdaemon
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -35,6 +36,10 @@ const (
 func (s *DaemonServer) SetDNSServer(ctx context.Context,
 	req *pb.SetDNSServerRequest) (*empty.Empty, error) {
 	log := s.getLoggerFromContext(ctx)
+
+	if net.ParseIP(req.DnsServer) == nil {
+		return nil, fmt.Errorf("invalid DNS server address")
+	}
 
 	log.Info("SetDNSServer", "request", req)
 	pid, err := s.crClient.GetPidFromContainerID(ctx, req.ContainerId)

--- a/pkg/chaosdaemon/dns_server_test.go
+++ b/pkg/chaosdaemon/dns_server_test.go
@@ -1,0 +1,137 @@
+// Copyright 2023 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chaosdaemon_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
+	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+)
+
+func Test_SetDNSServer_Enable(t *testing.T) {
+	g := NewWithT(t)
+
+	type mockCmd struct {
+		cmd  string
+		args []string
+	}
+	var executedCommands []mockCmd
+
+	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+		executedCommands = append(executedCommands, mockCmd{cmd, args})
+		return exec.Command("echo", "mock command")
+	})
+
+	mock.With("MockContainerdClient", &test.MockClient{})
+
+	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	server := chaosdaemon.NewDaemonServerWithCRClient(crc, nil, logr.Discard())
+
+	res, err := server.SetDNSServer(context.TODO(), &pb.SetDNSServerRequest{
+		ContainerId: "containerd://foo",
+		DnsServer:   "8.6.4.2",
+		Enable:      true,
+		EnterNS:     false,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).NotTo(BeNil())
+
+	g.Expect(executedCommands).To(Equal([]mockCmd{
+		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak || cp /etc/resolv.conf /etc/resolv.conf.chaos.bak"}},
+		{cmd: "sh", args: []string{"-c", "cp /etc/resolv.conf /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver 8.6.4.2/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > /etc/resolv.conf && rm /etc/resolv_conf_dnschaos_temp"}},
+	}))
+}
+
+func Test_SetDNSServer_Enable_InvalidIP(t *testing.T) {
+	g := NewWithT(t)
+
+	cases := []string{"", "127.0.0.b", " 127.0.0.1", "127.0.0.1 ", ":g:1", "127.0.0.1;"}
+
+	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+		g.Fail("no process should be executed")
+		return exec.Command("echo", "mock command")
+	})
+
+	mock.With("MockContainerdClient", &test.MockClient{})
+
+	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	server := chaosdaemon.NewDaemonServerWithCRClient(crc, nil, logr.Discard())
+
+	for _, tc := range cases {
+		res, err := server.SetDNSServer(context.TODO(), &pb.SetDNSServerRequest{
+			ContainerId: "containerd://foo",
+			DnsServer:   tc,
+			Enable:      true,
+			EnterNS:     false,
+		})
+		g.Expect(err).To(Equal(chaosdaemon.ErrInvalidDNSServer))
+		g.Expect(res).To(BeNil())
+	}
+}
+
+func Test_SetDNSServer_Disable(t *testing.T) {
+	g := NewWithT(t)
+
+	type mockCmd struct {
+		cmd  string
+		args []string
+	}
+	var executedCommands []mockCmd
+
+	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+		executedCommands = append(executedCommands, mockCmd{cmd, args})
+		return exec.Command("echo", "mock command")
+	})
+
+	mock.With("MockContainerdClient", &test.MockClient{})
+
+	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	server := chaosdaemon.NewDaemonServerWithCRClient(crc, nil, logr.Discard())
+
+	res, err := server.SetDNSServer(context.TODO(), &pb.SetDNSServerRequest{
+		ContainerId: "containerd://foo",
+		DnsServer:   "",
+		Enable:      false,
+		EnterNS:     false,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).NotTo(BeNil())
+
+	g.Expect(executedCommands).To(Equal([]mockCmd{
+		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak && cat /etc/resolv.conf.chaos.bak > /etc/resolv.conf || true"}},
+	}))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

Ensures that the IP address set as the `nameserver` in `/etc/resolv.conf` is a valid IP address.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

The `chaos-daemon` gRPC endpoint `SetDNSServer` now validates that `req.DNSServer` before using that value.

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
