### PR TITLE
fix: remove the duplicate pkg import

### DIFF
--- a/controllers/test/types.go
+++ b/controllers/test/types.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/client"
-	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	chaosdaemon "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
 )
@@ -106,10 +105,10 @@ func (c *MockChaosDaemonClient) UninstallJVMRules(ctx context.Context, in *chaos
 	return nil, mockError("UninstallJVMRules")
 }
 
-func (c *MockChaosDaemonClient) ApplyBlockChaos(ctx context.Context, req *pb.ApplyBlockChaosRequest, opts ...grpc.CallOption) (*pb.ApplyBlockChaosResponse, error) {
+func (c *MockChaosDaemonClient) ApplyBlockChaos(ctx context.Context, req *chaosdaemon.ApplyBlockChaosRequest, opts ...grpc.CallOption) (*chaosdaemon.ApplyBlockChaosResponse, error) {
 	return nil, mockError("ApplyBlockChaosRequest")
 }
 
-func (c *MockChaosDaemonClient) RecoverBlockChaos(ctx context.Context, req *pb.RecoverBlockChaosRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (c *MockChaosDaemonClient) RecoverBlockChaos(ctx context.Context, req *chaosdaemon.RecoverBlockChaosRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
