### PR TITLE
fix(test): docker command not found

### DIFF
--- a/hack/env-image-tag.sh
+++ b/hack/env-image-tag.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# This script would report the tag of build-env and dev-env to use based on configuartion file env-images.yaml.
+# This script would report the tag of build-env and dev-env to use based on configuration file env-images.yaml.
 #
 # Usage:
 # On master branch:
@@ -29,9 +29,9 @@ set -euo pipefail
 DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 PROJECT_DIR="$(dirname "$DIR")"
 
-if [ "$#" -eq  "0" ]; then
-  echo "Usage: $0 <env-image-name>"
-  exit 1
+if [[ "$#" == "0" ]]; then
+  echo "Usage: $0 <env-image-name: dev-env|build-env>"
+  exit 0
 fi
 
 if [[ "$1" == "dev-env" || "$1" == "build-env"  ]]; then


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

In https://github.com/chaos-mesh/chaos-mesh/actions/runs/6851229373/job/18627073546?pr=4246, I found that the `make test` will report `./hack/env-image-tag.sh: line 38: docker: command not found` errors.

<img width="931" alt="image" src="https://github.com/chaos-mesh/chaos-mesh/assets/15034155/d79d1aa6-c952-461e-87f2-b51f592e2405">

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

After investigating the Makefile, the `test` target will recursively call `make failpoint-*` targets, which will call `docker` in the container, this is the reason for errors.

So I created a recipe to encapsulate the `failpoint-ctl` command, although we've done a refactoring before to avoid macros, I don't think this recipe is too complicated, so it's not a big problem.

```makefile
define failpoint-ctl
	find $(ROOT)/* -type d | grep -vE "(\.git|bin|\.cache|ui)" | xargs failpoint-ctl $1
endef
```

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
