### PR TITLE
Allow chaos-dns-server affinity to be set in helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Support for deploying chaos-dashboard with sidecar containers in helm chart [#4164](https://github.com/chaos-mesh/chaos-mesh/pull/4164)
 - Add `values.schema.json` [#4205](https://github.com/chaos-mesh/chaos-mesh/pull/4205)
 - Add [`GreptimeDB`](https://greptime.com) to ADOPTERS.md [#4245](https://github.com/chaos-mesh/chaos-mesh/pull/4245)
+- Support configurable chaos-dns-server pod affinities[#4260](https://github.com/chaos-mesh/chaos-mesh/pull/4260)
 
 ### Changed
 

--- a/helm/chaos-mesh/templates/dns-deployment.yaml
+++ b/helm/chaos-mesh/templates/dns-deployment.yaml
@@ -42,17 +42,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: {{ .Values.dnsServer.serviceAccount }}
+      {{- with .Values.dnsServer.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: k8s-app
-                    operator: In
-                    values: ["chaos-dns"]
-              topologyKey: kubernetes.io/hostname
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- with .Values.dnsServer.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -452,6 +452,18 @@ dnsServer:
     LISTEN_HOST: "0.0.0.0"
     # The port of chaos-dns-server listen on
     LISTEN_PORT: 53
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - chaos-dns-server
+            topologyKey: kubernetes.io/hostname
+          weight: 100
 
 prometheus:
   # Enable prometheus

--- a/install.sh
+++ b/install.sh
@@ -1963,14 +1963,15 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
+          - podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                  - key: k8s-app
-                    operator: In
-                    values: ["chaos-dns"]
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - chaos-dns-server
               topologyKey: kubernetes.io/hostname
+            weight: 100
       priorityClassName: 
       containers:
       - name: chaos-dns-server


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve? 
The current chaos-dns-server affinity is not applicable because the `k8s-app: chaos-dns` label is not created on chaos-dns-server pods. This PR allows that affinity to be defined by the end user.
Close #4259 

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works? 
chaos-dns-server affinity is defined using the `dnsServer.affinity` key value from the helm chart values file.

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [X] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [X] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
