### PR TITLE
ci: use current branch Chaos Mesh version in e2e tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -163,19 +163,18 @@ jobs:
           - "[Basic] [DNSChaos]"
           - "[Basic] [StressChaos]"
     steps:
-      - name: checkout codes
-        uses: actions/checkout@v4
-      - name: download saved images
+      - uses: actions/checkout@v4
+      - name: Download saved images
         uses: actions/download-artifact@v2
         with:
           name: saved-images
           path: ./output/saved-images
-      - name: download e2e binary
+      - name: Download e2e binary
         uses: actions/download-artifact@v2
         with:
           name: e2e-binary
           path: ./output/e2e-binary
-      - name: move e2e binary
+      - name: Move e2e binary
         run: |
           mkdir -p ./e2e-test/image/e2e/bin
           mv ./output/e2e-binary/ginkgo ./e2e-test/image/e2e/bin/ginkgo
@@ -204,10 +203,14 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v3
 
+      - name: Choose Chaos Mesh version
+        id: chaos-mesh-version
+        run: echo "version=$(yq '.images.tag' helm/chaos-mesh/values.yaml)" >> "$GITHUB_OUTPUT"
+
       - name: Install Chaos Mesh
         # Set DOCKER_API_VERSION to 1.41 to bypass https://github.com/chaos-mesh/chaos-mesh/pull/4154#issuecomment-1704442551.
         run: |
-          helm install --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-mesh --set images.tag=latest --set chaosDaemon.env.DOCKER_API_VERSION=1.41
+          helm install --wait --create-namespace chaos-mesh helm/chaos-mesh -n=chaos-mesh --set images.tag=${{ steps.chaos-mesh-version.outputs.version }},chaosDaemon.env.DOCKER_API_VERSION=1.41
       - name: e2e tests
         env:
           FOCUS: ${{ matrix.focus }}

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       {{- end }}
       containers:
         - name: chaos-daemon
-          image: {{template "chaos-daemon.image" . }}
+          image: {{ template "chaos-daemon.image" . }}
           imagePullPolicy: {{ .Values.chaosDaemon.imagePullPolicy | default "IfNotPresent" }}
           {{- if .Values.chaosDaemon.resources }}
           resources:
@@ -176,7 +176,7 @@ spec:
         {{- end }}
       volumes:
         - name: socket-path
-          hostPath: 
+          hostPath:
             path: {{template "chaos-daemon.socket-path" . }}
         - name: sys-path
           hostPath:


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

@STRRL Should we run e2e tests based on the current branch version of Chaos Mesh? For this I've updated the e2e workflow, and I think it's a reasonable change.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Choose a Chaos Mesh version before installing:

```yaml
- name: Choose Chaos Mesh version
  id: chaos-mesh-version
  run: echo "version=$(yq '.images.tag' helm/chaos-mesh/values.yaml)" >> "$GITHUB_OUTPUT"
```

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
