### PR TITLE
fix: cross build on darwin

### DIFF
--- a/build/build_image.py
+++ b/build/build_image.py
@@ -128,7 +128,7 @@ def main():
                     "build",
                     "--load",
                     "--platform",
-                    os.getenv("TARGET_PLATFORM")]
+                    f"linux/{os.getenv('TARGET_PLATFORM')}"]
             else:
                 # This branch is split to avoid to use `buildx`, as `buildx` is
                 # not supported on some CI environment
@@ -139,7 +139,7 @@ def main():
             pass_env_to_build_arg(cmd, env_key)
 
         target_platform = utils.get_target_platform()
-        cmd += ["--build-arg", f"TARGET_PLATFORM={target_platform}"]
+        cmd += ["--build-arg", f"TARGET_PLATFORM={target_platform.platform}"]
         cmd += ["-t", image_full_name, args.path[0]]
     else:
         cmd = ["docker", "pull", image_full_name]

--- a/build/get_env_shell.py
+++ b/build/get_env_shell.py
@@ -81,16 +81,12 @@ def main():
     cmd += ["--user", f"{os.getuid()}:{os.getgid()}"]
 
     target_platform = utils.get_target_platform()
-    # if the environment variable is not set, don't pass `--platform` argument,
+    # If the environment variable is not set, don't pass `--platform` argument,
     # as it's not supported on some docker build environment.
-    if os.getenv("TARGET_PLATFORM") is not None and os.getenv(
-            "TARGET_PLATFORM") != "":
-        cmd += ["--platform", f"linux/{os.getenv('TARGET_PLATFORM')}"]
+    if target_platform.from_env:
+        cmd += ["--platform", f"linux/{target_platform.platform}"]
     else:
-        cmd += ["--env", f"TARGET_PLATFORM={target_platform}"]
-
-    if target_platform == "arm64":
-        cmd += ["--env", "ETCD_UNSUPPORTED_ARCH=arm64"]
+        cmd += ["--env", f"TARGET_PLATFORM={target_platform.platform}"]
 
     if os.getenv("GO_BUILD_CACHE") is not None and os.getenv(
             "GO_BUILD_CACHE") != "":

--- a/build/utils.py
+++ b/build/utils.py
@@ -19,6 +19,7 @@ functions used in multiple scripts
 
 import os
 import sys
+from collections import namedtuple
 
 
 def underscore_uppercase(name):
@@ -33,21 +34,22 @@ def get_target_platform():
     get the target platform according to the `TARGET_PLATFORM` variable or the
     `uname` syscall
     """
+    Platform = namedtuple('Platform', ['platform', 'from_env'])
 
     if os.getenv("TARGET_PLATFORM") is not None and os.getenv("TARGET_PLATFORM") != "":
-        return os.getenv("TARGET_PLATFORM")
+        return Platform(os.getenv("TARGET_PLATFORM"), True)
 
     machine = os.uname().machine
     if machine == "x86_64":
-        return "amd64"
+        return Platform("amd64", False)
 
     if machine == "amd64":
-        return "amd64"
+        return Platform("amd64", False)
 
     if machine == "arm64":
-        return "arm64"
+        return Platform("arm64", False)
 
     if machine == "aarch64":
-        return "arm64"
+        return Platform("arm64", False)
 
-    sys.exit("Please run this script on amd64 or arm64 machine")
+    sys.exit("Please run this script on amd64 or arm64 machines.")


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

If I want to make a cross-build on Darwin (macOS M1), I can't build an amd64 image because the `--platform` only passes an arch param (`amd64`) but does not specify os. Since the `build-env` image based on `alpine:3.17` does not exist as `darwin/amd64`, I think we should force mark the `linux` prefix before the `--platform` param?

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Add a `linux` prefix in `--platform`, like `f"linux/{os.getenv('TARGET_PLATFORM')}"`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
