### PR TITLE
fix: TTL configuration from wrong environment variables (#4338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
-- Nothing
+- Fix TTL configuration from environment variables [#4338](https://github.com/chaos-mesh/chaos-mesh/pull/4338)
 
 ### Security
 

--- a/pkg/config/dashboard.go
+++ b/pkg/config/dashboard.go
@@ -91,8 +91,8 @@ type TTLConfigWithStringTime struct {
 
 	EventTTL      string `envconfig:"TTL_EVENT"         default:"168h"` // one week
 	ExperimentTTL string `envconfig:"TTL_EXPERIMENT"    default:"336h"` // two weeks
-	ScheduleTTL   string `envconfig:"TTL_EXPERIMENT"    default:"336h"`
-	WorkflowTTL   string `envconfig:"TTL_EXPERIMENT"    default:"336h"`
+	ScheduleTTL   string `envconfig:"TTL_SCHEDULE"      default:"336h"`
+	WorkflowTTL   string `envconfig:"TTL_WORKFLOW"      default:"336h"`
 }
 
 func (config *TTLConfigWithStringTime) Parse() (*TTLConfig, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
