### PR TITLE
StressChaos: removing StressngStressors field

### DIFF
--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -62,10 +62,9 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return v1alpha1.Injected, nil
 	}
 
-	stressors := stresschaos.Spec.StressngStressors
 	cpuStressors := ""
 	memoryStressors := ""
-	if len(stressors) == 0 {
+	if len(stresschaos.Spec.StressngStressors) == 0 {
 		cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
 		if err != nil {
 			impl.Log.Info("fail to ")

--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -64,13 +64,11 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 
 	cpuStressors := ""
 	memoryStressors := ""
-	if len(stresschaos.Spec.StressngStressors) == 0 {
-		cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
-		if err != nil {
-			impl.Log.Info("fail to ")
-			// TODO: add an event here
-			return v1alpha1.NotInjected, err
-		}
+	cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
+	if err != nil {
+		impl.Log.Info("fail to ")
+		// TODO: add an event here
+		return v1alpha1.NotInjected, err
 	}
 
 	req := pb.ExecStressRequest{


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

As mentioned by @g1eny0ung the `StressngStressors` is not being used Apply(), thus its not required.
Fixes #3783 

## What's changed and how it works?

Removed the use of `StressngStressors`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
