### PR TITLE
fix: comments in pkg/chaosdaemon/util.GetChildProcesses

### DIFF
--- a/pkg/chaosdaemon/util/util.go
+++ b/pkg/chaosdaemon/util/util.go
@@ -46,11 +46,11 @@ func ReadCommName(pid int) (string, error) {
 }
 
 // GetChildProcesses will return all child processes's pid. Include all generations.
-// only return error when /proc/pid/tasks cannot be read
+// Only return error when `/proc` cannot be read.
 func GetChildProcesses(ppid uint32, logger logr.Logger) ([]uint32, error) {
 	procs, err := os.ReadDir(bpm.DefaultProcPrefix)
 	if err != nil {
-		return nil, errors.Wrapf(err, "read /proc/pid/tasks , ppid : %d", ppid)
+		return nil, errors.Wrapf(err, "read /proc")
 	}
 
 	type processPair struct {


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

Fix comments in `pkg/chaosdaemon/util.GetChildProcesses`.

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
