### PR TITLE
Fix fmt type of %T to obj.

### DIFF
--- a/pkg/time/time_skew_linux.go
+++ b/pkg/time/time_skew_linux.go
@@ -117,15 +117,15 @@ func (c *Config) New(values interface{}) (tasks.Injectable, error) {
 func (c *Config) Assign(injectable tasks.Injectable) error {
 	podHandler, ok := injectable.(*tasks.PodHandler)
 	if !ok {
-		return errors.New(fmt.Sprintf("type %t is not *tasks.PodHandler", injectable))
+		return errors.New(fmt.Sprintf("type %T is not *tasks.PodHandler", injectable))
 	}
 	groupProcessHandler, ok := podHandler.SubProcess.(*tasks.ProcessGroupHandler)
 	if !ok {
-		return errors.New(fmt.Sprintf("type %t is not *tasks.ProcessGroupHandler", podHandler.SubProcess))
+		return errors.New(fmt.Sprintf("type %T is not *tasks.ProcessGroupHandler", podHandler.SubProcess))
 	}
 	I, ok := groupProcessHandler.LeaderProcess.(*Skew)
 	if !ok {
-		return errors.New(fmt.Sprintf("type %t is not *Skew", groupProcessHandler.LeaderProcess))
+		return errors.New(fmt.Sprintf("type %T is not *Skew", groupProcessHandler.LeaderProcess))
 	}
 
 	I.SkewConfig = *c


### PR DESCRIPTION

## What problem does this PR solve?
Fix fmt type of %T to obj.

```
%T: a Go-syntax representation of the type of the value
%t: the word true or false (for booleans)
```


<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
