### PR TITLE
fix: deprecated Stream method in `pkg/ctrl/server/exec.go`

### DIFF
--- a/pkg/ctrl/server/exec.go
+++ b/pkg/ctrl/server/exec.go
@@ -63,7 +63,7 @@ func exec(ctx context.Context, pod *v1.Pod, cmd string, c *kubernetes.Clientset)
 	if err != nil {
 		return "", errors.Wrapf(err, "error in creating NewSPDYExecutor for pod %s/%s", pod.GetNamespace(), pod.GetName())
 	}
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: &stdout,
 		Stderr: &stderr,


### PR DESCRIPTION
## What problem does this PR solve?
Fix unused code and clean method in `pkg/ctrl/server/exec.go`
![image](https://github.com/chaos-mesh/chaos-mesh/assets/161462588/802d2e43-c8ae-4e46-b97b-32b5f49eacc8)

![image](https://github.com/chaos-mesh/chaos-mesh/assets/161462588/9df737ba-72c7-4c2b-8338-c42a7ca4cf25)

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
