### PR TITLE
chore: upgrade the base image of dev/build-env

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -86,7 +86,7 @@ jobs:
           # whose target is the branch)
           key: e2e-image-build-cache-${{ runner.os }}
 
-      - name: build e2e images
+      - name: Build e2e images
         env:
           DOCKER_CACHE: 1
           DOCKER_CACHE_DIR: ${{ github.workspace }}/cache

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Setup minikube
         uses: medyagh/setup-minikube@latest
         with:
-          minikube-version: v1.32.0
+          minikube-version: 1.32.0
           kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: load image into minikube

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     outputs:
       only_changed: ${{ steps.filter.outputs.only_changed }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   build-image:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
   build-e2e-binary:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
     needs:
       - build-image
       - build-e2e-binary
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -240,6 +240,6 @@ jobs:
     needs:
       - e2e-test-matrix
     name: E2E Test Passed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - run: echo "🎉 E2E Test Passed!"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       only_changed: ${{ steps.filter.outputs.only_changed }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   build-image:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
   build-e2e-binary:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
     needs:
       - build-image
       - build-e2e-binary
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -181,14 +181,12 @@ jobs:
           mv ./output/e2e-binary/e2e.test ./e2e-test/image/e2e/bin/e2e.test
           chmod +x ./e2e-test/image/e2e/bin/ginkgo
           chmod +x ./e2e-test/image/e2e/bin/e2e.test
+
       - name: Setup minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: medyagh/setup-minikube@latest
         with:
-          driver: docker
-          minikube version: v1.32.0
-          kubernetes version: ${{ matrix.kubernetes-version }}
-          start args: --cni calico
-          github token: ${{ secrets.GITHUB_TOKEN }}
+          minikube-version: v1.32.0
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: load image into minikube
         run: |
@@ -242,6 +240,6 @@ jobs:
     needs:
       - e2e-test-matrix
     name: E2E Test Passed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 E2E Test Passed!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Security
 
 - Remove `-k` from `curl` command lines in chaos-daemon Dockerfile [#4241](https://github.com/chaos-mesh/chaos-mesh/pull/4241)
-- Upgrade from debian buster to bookworm [#4388](https://github.com/chaos-mesh/chaos-mesh/pull/4388)
+- Upgrade the base image of dev/build-env [#4388](https://github.com/chaos-mesh/chaos-mesh/pull/4388)
 
 ## [2.6.0] - 2023-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Security
 
 - Remove `-k` from `curl` command lines in chaos-daemon Dockerfile [#4241](https://github.com/chaos-mesh/chaos-mesh/pull/4241)
+- Upgrade from debian buster to bookworm [#4388](https://github.com/chaos-mesh/chaos-mesh/pull/4388)
 
 ## [2.6.0] - 2023-05-30
 

--- a/e2e-test/e2e/chaos/stresschaos/misc.go
+++ b/e2e-test/e2e/chaos/stresschaos/misc.go
@@ -106,12 +106,13 @@ func getStressCondition(c http.Client, port uint16) (*StressCondition, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	out, err := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(out)
 
 	condition := &StressCondition{}
 	err = json.Unmarshal(out, condition)

--- a/e2e-test/e2e/chaos/stresschaos/misc.go
+++ b/e2e-test/e2e/chaos/stresschaos/misc.go
@@ -112,7 +112,6 @@ func getStressCondition(c http.Client, port uint16) (*StressCondition, error) {
 	if err != nil {
 		return nil, err
 	}
-	klog.Info("out", out)
 
 	condition := &StressCondition{}
 	err = json.Unmarshal(out, condition)

--- a/e2e-test/e2e/chaos/stresschaos/misc.go
+++ b/e2e-test/e2e/chaos/stresschaos/misc.go
@@ -112,7 +112,7 @@ func getStressCondition(c http.Client, port uint16) (*StressCondition, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(out)
+	klog.Info("out", out)
 
 	condition := &StressCondition{}
 	err = json.Unmarshal(out, condition)

--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -10,12 +10,12 @@ ARG HTTP_PROXY
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
-RUN apt-get update && \
-    apt-get install build-essential curl git pkg-config libfuse-dev fuse -y && \
+RUN apt update && \
+    apt install build-essential curl git pkg-config libfuse-dev fuse -y && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
+    apt install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 RUN npm install pnpm@8 -g
 

--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM debian:bookworm-slim
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man2
 RUN apt-get update && \
     echo "deb http://security.debian.org/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt --allow-releaseinfo-change update && apt upgrade  -y && \
+    apt --allow-releaseinfo-change update && apt upgrade -y && \
     apt-get install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -19,7 +19,7 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.8.7
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.12.0
 RUN go install github.com/apache/skywalking-eyes/cmd/license-eye@v0.2.0
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -29,8 +29,8 @@ ARG HTTP_PROXY
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
-RUN apt-get update && \
-    apt-get install unzip git build-essential curl python musl musl-dev python3 -y && \
+RUN apt update && \
+    apt install unzip git build-essential curl musl musl-dev -y && \
     rm -rf /var/lib/apt/lists/*
 
 # The `TARGET_PLATFORM` would be `amd64` or `arm64`


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

<!-- Uncomment this line if some issues to close -->
<!-- Close #<issue number> -->

The motivation for this PR comes from #4384.

## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Upgrade debian buster to bookwarm. I suppose that we can upgrade to the latest stable version.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
