### PR TITLE
chore: added openshift-specific helm values

### DIFF
--- a/helm/chaos-mesh/templates/openshift-scc.yaml
+++ b/helm/chaos-mesh/templates/openshift-scc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.openshift }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount  
+    name: chaos-daemon  
+    namespace: {{ .Release.Namespace }}  
+  - kind: ServiceAccount  
+    name: chaos-dns-server  
+    namespace: {{ .Release.Namespace }}  
+{{- end }}

--- a/helm/chaos-mesh/values.schema.json
+++ b/helm/chaos-mesh/values.schema.json
@@ -154,6 +154,9 @@
         "clusterScoped": {
             "type": "boolean"
         },
+        "openshift": {
+            "type": "boolean"
+        },
         "controllerManager": {
             "type": "object",
             "properties": {

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -26,6 +26,9 @@ customLabels: {}
 # Also see rbac.create and controllerManager.serviceAccount
 clusterScoped: true
 
+# flag to enable openshift-specific configurations
+openshift: false
+
 # Creating rbac API Objects. Also see clusterScoped and controllerManager.serviceAccount
 rbac:
   create: true


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

Removes need for manual configuration in Openshift environments

## What's changed and how it works?

An additional RoleBinding is added to add the chaos-daemon and chaos-dns-server to the "privileged" openshift SCC

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
