### PR TITLE
feat: export container metrics in Chaos Daemon for containerd runtime

### DIFF
--- a/pkg/chaosdaemon/crclients/client.go
+++ b/pkg/chaosdaemon/crclients/client.go
@@ -17,6 +17,7 @@ package crclients
 
 import (
 	"context"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/utils"
 
 	"github.com/pkg/errors"
 
@@ -44,6 +45,8 @@ type CrClientConfig struct {
 	ContainerdNS string
 }
 
+type ContainerStats = utils.ContainerStats
+
 // ContainerRuntimeInfoClient represents a struct which can give you information about container runtime
 type ContainerRuntimeInfoClient interface {
 	GetPidFromContainerID(ctx context.Context, containerID string) (uint32, error)
@@ -51,6 +54,7 @@ type ContainerRuntimeInfoClient interface {
 	FormatContainerID(ctx context.Context, containerID string) (string, error)
 	ListContainerIDs(ctx context.Context) ([]string, error)
 	GetLabelsFromContainerID(ctx context.Context, containerID string) (map[string]string, error)
+	StatsByContainerID(ctx context.Context, containerID string) (*ContainerStats, error)
 }
 
 // CreateContainerRuntimeInfoClient creates a container runtime information client.

--- a/pkg/chaosdaemon/crclients/containerd/client.go
+++ b/pkg/chaosdaemon/crclients/containerd/client.go
@@ -18,6 +18,9 @@ package containerd
 import (
 	"context"
 	"fmt"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/utils"
+	"google.golang.org/grpc"
+	runtimev1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"syscall"
 
 	"github.com/containerd/containerd"
@@ -41,9 +44,15 @@ type ContainerdClientInterface interface {
 	Containers(ctx context.Context, filters ...string) ([]containerd.Container, error)
 }
 
+// ContainerdRuntimeServiceInterface represents the runtimev1.RuntimeServiceClient, it's used to simply unit test
+type ContainerdRuntimeServiceInterface interface {
+	ContainerStats(ctx context.Context, in *runtimev1.ContainerStatsRequest, opts ...grpc.CallOption) (*runtimev1.ContainerStatsResponse, error)
+}
+
 // ContainerdClient can get information from containerd
 type ContainerdClient struct {
-	client ContainerdClientInterface
+	client        ContainerdClientInterface
+	runtimeClient ContainerdRuntimeServiceInterface
 }
 
 // FormatContainerID strips protocol prefix from the container ID
@@ -133,6 +142,23 @@ func (c ContainerdClient) GetLabelsFromContainerID(ctx context.Context, containe
 	return labels, nil
 }
 
+// StatsByContainerID returns the stats according to container ID
+func (c ContainerdClient) StatsByContainerID(ctx context.Context, containerID string) (*utils.ContainerStats, error) {
+	id, err := c.FormatContainerID(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	req := &runtimev1.ContainerStatsRequest{
+		ContainerId: id,
+	}
+	resp, err := c.runtimeClient.ContainerStats(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.BuildContainerStatsFromCRIResponse(resp), nil
+}
+
 func New(address string, opts ...containerd.ClientOpt) (*ContainerdClient, error) {
 	// Mock point to return error in unit test
 	if err := mock.On("NewContainerdClientError"); err != nil {
@@ -141,6 +167,7 @@ func New(address string, opts ...containerd.ClientOpt) (*ContainerdClient, error
 	if client := mock.On("MockContainerdClient"); client != nil {
 		return &ContainerdClient{
 			client.(ContainerdClientInterface),
+			client.(ContainerdRuntimeServiceInterface),
 		}, nil
 	}
 
@@ -148,9 +175,14 @@ func New(address string, opts ...containerd.ClientOpt) (*ContainerdClient, error
 	if err != nil {
 		return nil, err
 	}
+	runtimeClient, err := utils.BuildRuntimeServiceClient(address)
+	if err != nil {
+		return nil, err
+	}
 	// The real logic
 	return &ContainerdClient{
-		client: c,
+		client:        c,
+		runtimeClient: runtimeClient,
 	}, nil
 }
 

--- a/pkg/chaosdaemon/crclients/crio/client.go
+++ b/pkg/chaosdaemon/crclients/crio/client.go
@@ -19,13 +19,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/utils"
 	"net"
 	"net/http"
 	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -126,15 +126,10 @@ func (c CrioClient) GetLabelsFromContainerID(ctx context.Context, containerID st
 	return container.Status.Labels, nil
 }
 
-func buildRuntimeServiceClient(endpoint string) (v1.RuntimeServiceClient, error) {
-	addr := fmt.Sprintf("unix://%s", endpoint)
-	conn, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithInsecure())
-	if err != nil {
-		return nil, err
-	}
-
-	client := v1.NewRuntimeServiceClient(conn)
-	return client, err
+// StatsByContainerID returns the stats according to container ID
+func (c CrioClient) StatsByContainerID(ctx context.Context, containerID string) (*utils.ContainerStats, error) {
+	// TODO: implement StatsByContainerID
+	return nil, errors.New("not implemented")
 }
 
 func New(socketPath string) (*CrioClient, error) {
@@ -146,7 +141,7 @@ func New(socketPath string) (*CrioClient, error) {
 		Transport: tr,
 	}
 
-	runtimeClient, err := buildRuntimeServiceClient(socketPath)
+	runtimeClient, err := utils.BuildRuntimeServiceClient(socketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chaosdaemon/crclients/docker/client.go
+++ b/pkg/chaosdaemon/crclients/docker/client.go
@@ -18,6 +18,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/utils"
 	"net/http"
 
 	"github.com/docker/docker/api/types"
@@ -120,6 +121,12 @@ func (c DockerClient) GetLabelsFromContainerID(ctx context.Context, containerID 
 	}
 
 	return container.Config.Labels, nil
+}
+
+// StatsByContainerID returns the stats according to container ID
+func (c DockerClient) StatsByContainerID(ctx context.Context, containerID string) (*utils.ContainerStats, error) {
+	// TODO: implement StatsByContainerID
+	return nil, errors.New("not implemented")
 }
 
 func New(host string, version string, client *http.Client, httpHeaders map[string]string) (*DockerClient, error) {

--- a/pkg/chaosdaemon/crclients/utils/cri.go
+++ b/pkg/chaosdaemon/crclients/utils/cri.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"fmt"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"strings"
+)
+
+// BuildRuntimeServiceClient creates a new RuntimeServiceClient from the given endpoint
+func BuildRuntimeServiceClient(endpoint string) (v1.RuntimeServiceClient, error) {
+	addr := endpoint
+	if !strings.HasPrefix(addr, "unix://") {
+		addr = fmt.Sprintf("unix://%s", addr)
+	}
+	conn, err := grpc.Dial(addr,
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+
+	client := v1.NewRuntimeServiceClient(conn)
+	return client, err
+}
+
+// BuildContainerStatsFromCRIResponse creates a new ContainerStats from the response of runtimeClient.ContainerStats
+func BuildContainerStatsFromCRIResponse(resp *v1.ContainerStatsResponse) *ContainerStats {
+	result := &ContainerStats{}
+
+	stats := resp.Stats
+	if stats == nil {
+		return result
+	}
+
+	cpu := stats.Cpu
+	if cpu != nil {
+		result.Cpu.UsageCoreNanoSeconds = cpu.UsageCoreNanoSeconds.GetValue()
+	}
+
+	memory := stats.Memory
+	if memory != nil {
+		result.Memory.WorkingSetBytes = memory.WorkingSetBytes.GetValue()
+		result.Memory.AvailableBytes = memory.AvailableBytes.GetValue()
+		result.Memory.UsageBytes = memory.UsageBytes.GetValue()
+		result.Memory.RssBytes = memory.RssBytes.GetValue()
+		result.Memory.PageFaults = memory.PageFaults.GetValue()
+		result.Memory.MajorPageFaults = memory.MajorPageFaults.GetValue()
+	}
+
+	swap := stats.Swap
+	if swap != nil {
+		result.Swap.AvailableBytes = swap.SwapAvailableBytes.GetValue()
+		result.Swap.UsageBytes = swap.SwapUsageBytes.GetValue()
+	}
+
+	return result
+}

--- a/pkg/chaosdaemon/crclients/utils/types.go
+++ b/pkg/chaosdaemon/crclients/utils/types.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+// ContainerStats represents the stats of a container
+type ContainerStats struct {
+	Cpu struct {
+		UsageCoreNanoSeconds uint64
+	}
+	Memory struct {
+		WorkingSetBytes uint64
+		AvailableBytes  uint64
+		UsageBytes      uint64
+		RssBytes        uint64
+		PageFaults      uint64
+		MajorPageFaults uint64
+	}
+	Swap struct {
+		AvailableBytes uint64
+		UsageBytes     uint64
+	}
+}

--- a/pkg/metrics/chaos-daemon.go
+++ b/pkg/metrics/chaos-daemon.go
@@ -57,6 +57,13 @@ type ChaosDaemonMetricsCollector struct {
 	iptablesPacketBytes *prometheus.GaugeVec
 	ipsetMembers        *prometheus.GaugeVec
 	tcRules             *prometheus.GaugeVec
+	containerMetrics    []containerMetric
+}
+
+type containerMetric struct {
+	desc      *prometheus.Desc
+	valueType prometheus.ValueType
+	mapValue  func(stats *crclients.ContainerStats) float64
 }
 
 // NewChaosDaemonMetricsCollector initializes metrics for each chaos daemon
@@ -79,6 +86,107 @@ func NewChaosDaemonMetricsCollector(logger logr.Logger) *ChaosDaemonMetricsColle
 			Name: "chaos_daemon_tcs",
 			Help: "Total number of tc rules",
 		}, []string{"namespace", "pod", "container"}),
+		containerMetrics: []containerMetric{
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_cpu_usage_seconds_total",
+					"Total CPU usage in seconds of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.CounterValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Cpu.UsageCoreNanoSeconds) / 1e9
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_working_set_bytes",
+					"The amount of working set memory in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.WorkingSetBytes)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_available_bytes",
+					"The available memory in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.AvailableBytes)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_usage_bytes",
+					"The memory usage in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.UsageBytes)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_rss_bytes",
+					"The amount of RSS memory in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.RssBytes)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_page_faults_total",
+					"Total number of page faults of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.CounterValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.PageFaults)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_major_page_faults_total",
+					"Total number of major page faults of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.CounterValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Memory.MajorPageFaults)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_swap_available_bytes",
+					"The available swap memory in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Swap.AvailableBytes)
+				},
+			},
+			{
+				desc: prometheus.NewDesc(
+					"chaos_daemon_container_memory_swap_usage_bytes",
+					"The swap usage in bytes of the container",
+					[]string{"namespace", "pod", "container"},
+					nil),
+				valueType: prometheus.GaugeValue,
+				mapValue: func(stats *crclients.ContainerStats) float64 {
+					return float64(stats.Swap.UsageBytes)
+				},
+			},
+		},
 	}
 }
 
@@ -87,6 +195,9 @@ func (collector *ChaosDaemonMetricsCollector) Describe(ch chan<- *prometheus.Des
 	collector.iptablesPacketBytes.Describe(ch)
 	collector.ipsetMembers.Describe(ch)
 	collector.tcRules.Describe(ch)
+	for _, m := range collector.containerMetrics {
+		ch <- m.desc
+	}
 }
 
 func (collector *ChaosDaemonMetricsCollector) Collect(ch chan<- prometheus.Metric) {
@@ -95,6 +206,7 @@ func (collector *ChaosDaemonMetricsCollector) Collect(ch chan<- prometheus.Metri
 	collector.iptablesPacketBytes.Collect(ch)
 	collector.ipsetMembers.Collect(ch)
 	collector.tcRules.Collect(ch)
+	collector.collectContainerStatsMetrics(ch)
 }
 
 func (collector *ChaosDaemonMetricsCollector) InjectCrClient(client crclients.ContainerRuntimeInfoClient) *ChaosDaemonMetricsCollector {
@@ -167,5 +279,49 @@ func (collector *ChaosDaemonMetricsCollector) collectNetworkMetrics() {
 			log.Error(err, "fail to collect tc rules metric")
 		}
 		collector.tcRules.WithLabelValues(labelValues...).Set(float64(tcRules))
+	}
+}
+
+func (collector *ChaosDaemonMetricsCollector) collectContainerStatsMetrics(ch chan<- prometheus.Metric) {
+	containerIDs, err := collector.crClient.ListContainerIDs(context.Background())
+	if err != nil {
+		collector.logger.Error(err, "fail to list all container process IDs")
+		return
+	}
+
+	for _, containerID := range containerIDs {
+		labels, err := collector.crClient.GetLabelsFromContainerID(context.Background(), containerID)
+		if err != nil {
+			collector.logger.Error(err, "fail to get container labels", "containerID", containerID)
+			continue
+		}
+
+		namespace, podName, containerName := labels[kubernetesPodNamespaceLabel],
+			labels[kubernetesPodNameLabel], labels[kubernetesContainerNameLabel]
+
+		labelValues := []string{namespace, podName, containerName}
+		log := collector.logger.WithValues(
+			"namespace", namespace,
+			"podName", podName,
+			"containerName", containerName,
+			"containerID", containerID,
+		)
+
+		stats, err := collector.crClient.StatsByContainerID(context.Background(), containerID)
+		if err != nil {
+			log.Error(err, "fail to get container stats")
+		}
+		if stats == nil {
+			continue
+		}
+
+		for _, m := range collector.containerMetrics {
+			ch <- prometheus.MustNewConstMetric(
+				m.desc,
+				m.valueType,
+				m.mapValue(stats),
+				labelValues...,
+			)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

RFC: chaos-mesh/rfcs#47

This PR implements the feature of exporting statistical metrics in RFC. Statistical metrics are the metrics that describe the statistical information of the container. These metrics are exported by Chaos Daemon. We plan to export the following metrics:

| Metric Name                                             | Description                                                 |
| ------------------------------------------------------- | ----------------------------------------------------------- |
| `chaos_daemon_container_cpu_usage_seconds_total`        | Total CPU usage in seconds of the container.                |
| `chaos_daemon_container_memory_working_set_bytes`       | The amount of working set memory in bytes of the container. |
| `chaos_daemon_container_memory_available_bytes`         | The available memory in bytes of the container.             |
| `chaos_daemon_container_memory_usage_bytes`             | The memory usage in bytes of the container.                 |
| `chaos_daemon_container_memory_rss_bytes`               | The amount of RSS memory in bytes of the container.         |
| `chaos_daemon_container_memory_page_faults_total`       | Total number of page faults of the container.               |
| `chaos_daemon_container_memory_major_page_faults_total` | Total number of major page faults of the container.         |
| `chaos_daemon_container_memory_swap_available_bytes`    | The available swap in bytes of the container.               |
| `chaos_daemon_container_memory_swap_usage_bytes`        | The swap usage in bytes of the container.                   |

Statistical metrics are exported with the following labels:

| Label Name  | Description                     |
| ----------- | ------------------------------- |
| `namespace` | The namespace of the container. |
| `pod`       | The pod name of the container.  |
| `container` | The container name.             |

## What's changed and how it works?

Proposal: chaos-mesh/rfcs#47

This PR modifies Chaos Daemon.

This PR retrieves statistical information about the container from the CRI interface. To achieve this, the interface `ContainerRuntimeInfoClient` has been expanded to include a new method `StatsByContainerID`. This method is used to obtain statistical information about the container from Controller Runtime based on Container ID. Essentially, this method is for decoupling with the CRI API and its functionality is almost identical to that of `runtimev1.RuntimeServiceClient`'s `ContainerStats` method.

Afterwards, this PR will expose the collected statistical information to the `/metric` endpoint. To achieve this, this PR has expanded `ChaosDaemonMetricsCollector`. Since some `counter` type metrics (such as CPU Usage Seconds) are already increasing when collected, `prometheus.MustNewConstMetric` is used to export them ([a related discussion](https://github.com/prometheus-net/prometheus-net/issues/32)).

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
