### PR TITLE
fix: chaos controller can't find daemonIP over 1000 nodes using endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Enable prometheus directive within CoreDNS [#4321](https://github.com/chaos-mesh/chaos-mesh/pull/4321)
 - Fix TTL configuration from environment variables [#4338](https://github.com/chaos-mesh/chaos-mesh/pull/4338)
 - Fix dashboard panic while replacing query namespace with targetNamespace in namespace scoped mode [#4409](https://github.com/chaos-mesh/chaos-mesh/issues/4409)
-- fix chaos controller can't find daemonIP over 1000 node using endpoints [#4421](https://github.com/chaos-mesh/chaos-mesh/pull/4421)
+- Fix chaos controller can't find daemonIP over 1000 nodes using endpoints [#4421](https://github.com/chaos-mesh/chaos-mesh/pull/4421)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Enable prometheus directive within CoreDNS [#4321](https://github.com/chaos-mesh/chaos-mesh/pull/4321)
 - Fix TTL configuration from environment variables [#4338](https://github.com/chaos-mesh/chaos-mesh/pull/4338)
 - Fix dashboard panic while replacing query namespace with targetNamespace in namespace scoped mode [#4409](https://github.com/chaos-mesh/chaos-mesh/issues/4409)
+- fix chaos controller can't find daemonIP over 1000 node using endpoints [#4421](https://github.com/chaos-mesh/chaos-mesh/pull/4421)
 
 ### Security
 

--- a/controllers/utils/chaosdaemon/chaosdaemon.go
+++ b/controllers/utils/chaosdaemon/chaosdaemon.go
@@ -17,10 +17,12 @@ package chaosdaemon
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
+	dis_v1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,15 +35,17 @@ import (
 
 var log = ctrl.Log.WithName("controller-chaos-daemon-client-utils")
 
-func findIPOnEndpoints(e *v1.Endpoints, nodeName string) string {
-	for _, subset := range e.Subsets {
-		for _, addr := range subset.Addresses {
-			if addr.NodeName != nil && *addr.NodeName == nodeName {
-				return addr.IP
+func findIPOnEndpointSlice(e *dis_v1.EndpointSliceList, nodeName string) string {
+	for _, endpointSlice := range e.Items {
+		// only get the endpoint slice of the current chaos-daemon pod
+		if strings.HasPrefix(endpointSlice.ObjectMeta.Name, "chaos-daemon-") {
+			for _, ep := range endpointSlice.Endpoints {
+				if ep.NodeName != nil && *ep.NodeName == nodeName {
+					return ep.Addresses[0]
+				}
 			}
 		}
 	}
-
 	return ""
 }
 
@@ -54,18 +58,15 @@ func (b *ChaosDaemonClientBuilder) FindDaemonIP(ctx context.Context, pod *v1.Pod
 	log.Info("Creating client to chaos-daemon", "node", nodeName)
 
 	ns := config.ControllerCfg.Namespace
-	var endpoints v1.Endpoints
-	err := b.Reader.Get(ctx, types.NamespacedName{
-		Namespace: ns,
-		Name:      "chaos-daemon",
-	}, &endpoints)
+	var endpointSliceList dis_v1.EndpointSliceList
+	err := b.Reader.List(ctx, &endpointSliceList, client.InNamespace(ns))
 	if err != nil {
 		return "", err
 	}
 
-	daemonIP := findIPOnEndpoints(&endpoints, nodeName)
+	daemonIP := findIPOnEndpointSlice(&endpointSliceList, nodeName)
 	if len(daemonIP) == 0 {
-		return "", errors.Errorf("cannot find daemonIP on node %s in related Endpoints %v", nodeName, endpoints)
+		return "", errors.Errorf("cannot find daemonIP on node %s in endpointSliceList %v", nodeName, endpointSliceList)
 	}
 
 	return daemonIP, nil

--- a/controllers/utils/chaosdaemon/chaosdaemon.go
+++ b/controllers/utils/chaosdaemon/chaosdaemon.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
-	dis_v1 "k8s.io/api/discovery/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,9 +35,9 @@ import (
 
 var log = ctrl.Log.WithName("controller-chaos-daemon-client-utils")
 
-func findIPOnEndpointSlice(e *dis_v1.EndpointSliceList, nodeName string) string {
+func findIPOnEndpointSlice(e *discoveryv1.EndpointSliceList, nodeName string) string {
 	for _, endpointSlice := range e.Items {
-		// only get the endpoint slice of the current chaos-daemon pod
+		// Only get the endpoint slice of the current chaos-daemon pod.
 		if strings.HasPrefix(endpointSlice.ObjectMeta.Name, "chaos-daemon-") {
 			for _, ep := range endpointSlice.Endpoints {
 				if ep.NodeName != nil && *ep.NodeName == nodeName {
@@ -46,6 +46,7 @@ func findIPOnEndpointSlice(e *dis_v1.EndpointSliceList, nodeName string) string 
 			}
 		}
 	}
+
 	return ""
 }
 
@@ -58,7 +59,7 @@ func (b *ChaosDaemonClientBuilder) FindDaemonIP(ctx context.Context, pod *v1.Pod
 	log.Info("Creating client to chaos-daemon", "node", nodeName)
 
 	ns := config.ControllerCfg.Namespace
-	var endpointSliceList dis_v1.EndpointSliceList
+	var endpointSliceList discoveryv1.EndpointSliceList
 	err := b.Reader.List(ctx, &endpointSliceList, client.InNamespace(ns))
 	if err != nil {
 		return "", err

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -91,7 +91,6 @@ rules:
       - subjectaccessreviews
     verbs: [ "create" ]
 
-
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -103,8 +102,11 @@ metadata:
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
-    resources: [ "services", "endpointslices", "secrets" ]
+    resources: [ "services", "secrets" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [ "authorization.k8s.io" ]
     resources:
       - subjectaccessreviews

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
-    resources: [ "services", "endpoints", "secrets" ]
+    resources: [ "services", "endpointslices", "secrets" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "authorization.k8s.io" ]
     resources:

--- a/install.sh
+++ b/install.sh
@@ -1313,7 +1313,7 @@ metadata:
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
-    resources: [ "services", "endpoints", "secrets" ]
+    resources: [ "services", "endpointslices", "secrets" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "authorization.k8s.io" ]
     resources:

--- a/install.sh
+++ b/install.sh
@@ -1313,8 +1313,11 @@ metadata:
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
-    resources: [ "services", "endpointslices", "secrets" ]
+    resources: [ "services", "secrets" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [ "authorization.k8s.io" ]
     resources:
       - subjectaccessreviews


### PR DESCRIPTION
<!--
Thank you for contributing to Chaos Mesh!

If you're unsure where to start, please refer to the contributing doc:

https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md

If you still have questions, please let us know via issues.

Please follow https://www.conventionalcommits.org/en/v1.0.0/ when you open a new PR:
-->

## What problem does this PR solve?

Close https://github.com/chaos-mesh/chaos-mesh/issues/4287

This PR fixes chaos controller can't find daemonIP over 1000 nodes using endpoints.

## What's changed and how it works?

use endpointslice instead of endpoint 

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
