### PR TITLE
refactor(ci): release helm chart

### DIFF
--- a/.github/workflows/release_helm_chart.yml
+++ b/.github/workflows/release_helm_chart.yml
@@ -9,38 +9,17 @@ permissions: read-all
 
 jobs:
   release-chart:
-    runs-on: ubuntu-20.04
     steps:
-      - name: "Must Triggered by Tag chart-<version>"
-        run: |
-          # GITHUB_REF_TYPE MUST equals to "tag"
-          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
-            echo "This workflow must be triggered by tag"
-            echo "GITHUB_REF_TYPE: ${GITHUB_REF_TYPE}"
-            echo "GITHUB_REF: ${GITHUB_REF}"
-            exit 1
-          fi
-
-          # The tag MUST start with "chart-"
-          GIT_TAG=${GITHUB_REF##*/}
-          if [[ "${GIT_TAG}" == "chart-"* ]]; then
-            exit 0
-          fi
-
-          echo "The tag must start with 'chart-'"
-          echo "GITHUB_REF: ${GITHUB_REF}"
-          exit 1
       - uses: actions/checkout@v4
-      - name: "Extract Version"
+      - name: Extract version
         id: extract_version
         run: |
-          GIT_TAG=${GITHUB_REF##*/}
-          VERSION=${GIT_TAG##chart-}
-          echo "::set-output name=version::$(echo $VERSION)"
+          VERSION=${GITHUB_REF_NAME##chart-}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@master
         with:
-          token: ${{ secrets.CR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: helm
           charts_url: https://charts.chaos-mesh.org
           owner: chaos-mesh


### PR DESCRIPTION
## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Refactor the workflow of release Helm chart with `GITHUB_REF_NAME`. Also, this PR deprecates the old `CR_TOKEN`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
