### PR TITLE
fix: upgrade codecov

### DIFF
--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -12,7 +12,6 @@ permissions: read-all
 jobs:
   unitTestAndCodeCoverage:
     name: "Unit Test And Code Coverage"
-    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +19,7 @@ jobs:
         run: make test
 
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./cover.out
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         target: auto
-        # allow the coverage to drop by 5%, and still posting a success status
+        # Allow the coverage to drop by 5%, and still post a success status.
         threshold: 5%
 
 parsers:
@@ -22,6 +22,6 @@ parsers:
       macro: false
 
 comment:
-  layout: "reach,diff,flags,files,footer"
+  layout: "diff, flags, files, footer"
   behavior: default
   require_changes: false


### PR DESCRIPTION
## What's changed and how it works?

<!-- Uncomment this line if this PR is associated with a proposal -->
<!-- Proposal: [name](url) -->

Recently, the codecov workflows always failed. After investigating, I found that we need to set `CODECOV_TOKEN` due to workflows reported:

Please upload with the Codecov repository upload token to resolve issue.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below (Depends on the actual situations. For example, if the failed commit isn't the most recent) to fix it:

```shell
git commit --amend --signoff
git push --force
```
