### PR TITLE
fix: add codecov token to action

### DIFF
--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   unitTestAndCodeCoverage:
     runs-on: ubuntu-latest
-    name: "Unit Test And Code Coverage"
+    name: Unit Test And Code Coverage
     steps:
       - uses: actions/checkout@v4
 
@@ -22,6 +22,7 @@ jobs:
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cover.out
           verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
## What's changed and how it works?

Add token to codecov action.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
