### PR TITLE
[release-2.6] fix: add codecov token to action

### DIFF
--- a/.github/workflows/codecov_unittest.yaml
+++ b/.github/workflows/codecov_unittest.yaml
@@ -11,8 +11,8 @@ permissions: read-all
 
 jobs:
   unitTestAndCodeCoverage:
-    name: "Unit Test And Code Coverage"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    name: Unit Test And Code Coverage
     steps:
       - uses: actions/checkout@v4
 
@@ -20,8 +20,9 @@ jobs:
         run: make test
 
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cover.out
           verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

> [!TIP]
> Please replace this with a brief description of the problem this PR solves.
> You can also close #issue_number if this PR solves the issue.

## What's changed and how it works?

Cherry-pick #4513 to `release-2.6`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.6
- [ ] release-2.5

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
