### PR TITLE
chore: upgrade runner to 22.04

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,8 @@
 
 > This PR should be cherry-picked to the following release branches:
 
+- [ ] release-2.7
 - [ ] release-2.6
-- [ ] release-2.5
 
 ## Checklist
 

--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   # JOB to run change detection
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Set job outputs to values from filter step
     outputs:
       go: ${{ steps.filter.outputs.go }}
@@ -54,7 +54,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-22.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   skip-changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       go: ${{ steps.filter.outputs.go }}
       ui: ${{ steps.filter.outputs.ui }}
@@ -39,7 +39,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - run: echo "Not required to run go jobs."
   ui:
@@ -48,9 +48,8 @@ jobs:
     strategy:
       matrix:
         job:
-          - verify
           - build
           - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - run: echo "Not required to run ui jobs."

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   changed-files:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       only_changed: ${{ steps.filter.outputs.only_changed }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   build-image:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
   build-e2e-binary:
     needs: changed-files
     if: needs.changed-files.outputs.only_changed == 'false'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
     needs:
       - build-image
       - build-e2e-binary
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -242,6 +242,6 @@ jobs:
     needs:
       - e2e-test-matrix
     name: E2E Test Passed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 E2E Test Passed!"

--- a/.github/workflows/e2e_test_upload_cache.yml
+++ b/.github/workflows/e2e_test_upload_cache.yml
@@ -30,7 +30,7 @@ permissions: read-all
 
 jobs:
   build-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           key: e2e-image-build-cache-${{ runner.os }}
 
   build-e2e-binary:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout codes
         uses: actions/checkout@v4

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-22.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   check-license:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Check License Header

--- a/.github/workflows/must_update_changelog.yml
+++ b/.github/workflows/must_update_changelog.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   must-update-changelog:
     name: "Must Update CHANGELOG"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       LABEL_EXISTS: ${{ contains(github.event.pull_request.labels.*.name, 'no-need-update-changelog') }}
     steps:

--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -75,7 +75,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: [dev, build]

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -22,7 +22,7 @@ jobs:
           [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-kernel, chaos-dlv]
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-22.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,7 +80,7 @@ jobs:
 
   upload-manifest:
     needs: build-specific-architecture
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
@@ -127,7 +127,7 @@ jobs:
       - build-specific-architecture
       - upload-manifest
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # Need to upload files to the related release.
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
@@ -168,7 +168,7 @@ jobs:
   sbom:
     needs: build-specific-architecture
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # Need to upload files to the related release.
     env:

--- a/.github/workflows/upload_image_pr.yml
+++ b/.github/workflows/upload_image_pr.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   build-for-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ github.event.issue.pull_request && startsWith( github.event.comment.body, '/build-image') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -18,7 +18,7 @@ jobs:
   run:
     if: github.repository_owner == 'chaos-mesh'
     name: Upload
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   run:
     name: Upload
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Must Triggered by Tag v<version>"
         run: |


### PR DESCRIPTION
## What's changed and how it works?

Since `22.04` is also an LTS version, we can upgrade all old `20.04` runners in the year 2024.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
