### PR TITLE
fix: set default of ChaosControllerConfig.DNSServicePort to 53

### DIFF
--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -93,7 +93,7 @@ type ChaosControllerConfig struct {
 
 	// DNSServiceName is the name of DNS service, which is used for DNS chaos
 	DNSServiceName string `envconfig:"CHAOS_DNS_SERVICE_NAME" default:""`
-	DNSServicePort int    `envconfig:"CHAOS_DNS_SERVICE_PORT" default:""`
+	DNSServicePort int    `envconfig:"CHAOS_DNS_SERVICE_PORT" default:"53"`
 
 	// SecurityMode is used for enable authority validation in admission webhook
 	SecurityMode bool `envconfig:"SECURITY_MODE" default:"true" json:"security_mode"`


### PR DESCRIPTION
Fix #4217 by setting ChaosControllerConfig.DNSServicePort default value to 53

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [X] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [X] Manual test

### Side effects

- [ ] **Breaking backward compatibility**
