### PR TITLE
ci: use ebtables-legacy for test to adopte the new version of debian

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":["self-hosted", "Linux", "ARM64"]}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":"github-arm64-2c-8gb"]}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -30,8 +30,10 @@ ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
 RUN apt update && \
-    apt install unzip git build-essential curl musl musl-dev -y && \
+    apt install unzip git build-essential curl musl musl-dev ebtables -y && \
     rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 
 # The `TARGET_PLATFORM` would be `amd64` or `arm64`
 ARG TARGET_PLATFORM=amd64


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

There are some compatibility problems in CI on arm ubuntu 24.04,I am trying to fix it.

> [!TIP]
> Please replace this with a brief description of the problem this PR solves.
> You can also close #issue_number if this PR solves the issue.

## What's changed and how it works?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
