### PR TITLE
feat: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # For GitHub Actions, use the value /. Dependabot will search the /.github/workflows directory,
+    # as well as the action.yml/action.yaml file from the root directory.
+    directories: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/api"
+      - "/e2e-test"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: all

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directories: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "github-actions"
   - package-ecosystem: "gomod"
     directories:
       - "/"
@@ -15,3 +17,5 @@ updates:
       interval: "monthly"
     allow:
       - dependency-type: all
+    commit-message:
+      prefix: "go"


### PR DESCRIPTION
## What problem does this PR solve?

Currently, it doesn't make sense to have our dependencies updated by dependabot, because we have a CI check to check all `go.mod` and `go.sum` files to see if they have been updated at the same time.

For example, you may see PRs like these:

- #4502
- #4562
- ...

So I searched dependabot's docs and created a `dependabot.yml` to update our dependencies every once in a while. In this configuration, I specified all manifest locations to make sure all related dependencies will be modified in one PR:

```yaml
directories:
  - "/"
  - "/api"
  - "/e2e-test"
```

But I'm not sure this will work, I need to see how it actually runs subsequently.

At the same time, I also enabled **Grouped security updates** to optimize the performance of CI tests:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/1e9f18b2-20fd-4aac-8eb2-72e075d38319" />

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
