### PR TITLE
fix: parse physical machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Wrong references of helm values in the prometheus template [#4543](https://github.com/chaos-mesh/chaos-mesh/pull/4543)
 - Return 404 when the archive schedule was not found [#4553](https://github.com/chaos-mesh/chaos-mesh/pull/4553)
 - Changed JVMParameter.ReturnValue json tag field name to `returnValue` [#4525](https://github.com/chaos-mesh/chaos-mesh/pull/4525)
+- Correct the parsing of the physical machines in the Dashboard UI
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Wrong references of helm values in the prometheus template [#4543](https://github.com/chaos-mesh/chaos-mesh/pull/4543)
 - Return 404 when the archive schedule was not found [#4553](https://github.com/chaos-mesh/chaos-mesh/pull/4553)
 - Changed JVMParameter.ReturnValue json tag field name to `returnValue` [#4525](https://github.com/chaos-mesh/chaos-mesh/pull/4525)
-- Correct the parsing of the physical machines in the Dashboard UI
+- Correct the parsing of the physical machines in the Dashboard UI [#4580](https://github.com/chaos-mesh/chaos-mesh/pull/4580)
 
 ### Security
 

--- a/ui/app/src/components/NewExperimentNext/Step3.tsx
+++ b/ui/app/src/components/NewExperimentNext/Step3.tsx
@@ -65,7 +65,7 @@ const Step3: React.FC<Step3Props> = ({ onSubmit, inSchedule }) => {
     )
 
     if (process.env.NODE_ENV === 'development' || debugMode) {
-      console.debug('Debug parsedValues:', parsedValues)
+      console.debug('Here is the experiment you are going to submit:', JSON.stringify(parsedValues, null, 2))
     }
 
     if (!debugMode) {

--- a/ui/app/src/components/NewWorkflowNext/utils/convert.ts
+++ b/ui/app/src/components/NewWorkflowNext/utils/convert.ts
@@ -23,6 +23,7 @@ import type { NodeExperiment } from 'slices/workflows'
 
 import { Schedule, scheduleInitialValues } from 'components/AutoForm/data'
 
+import { parsePodsOrPhysicalMachines } from 'lib/formikhelpers'
 import { arrToObjBySep, isDeepEmpty, objToArrBySep } from 'lib/utils'
 
 export enum ExperimentKind {
@@ -206,7 +207,11 @@ export function flowToWorkflow(nodes: Node[], edges: Edge[], storeTemplates: Rec
 
         // Parse labels, annotations, labelSelectors, and annotationSelectors to object.
         if (['labels', 'annotations', 'labelSelectors', 'annotationSelectors'].includes(key)) {
-          return arrToObjBySep(value, ': ')
+          return arrToObjBySep(value, ':', { removeAllSpaces: true })
+        }
+
+        if (key === 'physicalMachines') {
+          return parsePodsOrPhysicalMachines(value)
         }
 
         return value

--- a/ui/app/src/components/Scope/TargetsTable/index.tsx
+++ b/ui/app/src/components/Scope/TargetsTable/index.tsx
@@ -41,11 +41,12 @@ const TargetsTable = ({ env, scope = 'scope', data }: TargetsTableProps) => {
   const targetsCount = originalTargets.length
 
   const { values, setFieldValue } = useFormikContext()
-  const formikTargets: string[] = getIn(values, `${scope}.pods`)
+  const formikTargets: string[] = getIn(values, `${scope}.${env === 'k8s' ? 'pods' : 'physicalMachines'}`) || []
 
   const selected = formikTargets.length > 0 ? formikTargets : originalTargets
   const isSelected = (name: string) => selected.indexOf(name) !== -1
-  const setSelected = (newVal: string[]) => setFieldValue(`${scope}.pods`, newVal)
+  const setSelected = (newVal: string[]) =>
+    setFieldValue(`${scope}.${env === 'k8s' ? 'pods' : 'physicalMachines'}`, newVal)
 
   const dispatch = useStoreDispatch()
 
@@ -67,7 +68,7 @@ const TargetsTable = ({ env, scope = 'scope', data }: TargetsTableProps) => {
       dispatch(
         setAlert({
           type: 'warning',
-          message: 'Please select at least one pod.',
+          message: 'Please select at least one target.',
         })
       )
 

--- a/ui/app/src/lib/formikhelpers.ts
+++ b/ui/app/src/lib/formikhelpers.ts
@@ -29,6 +29,20 @@ import { ScheduleSpecific } from 'components/Schedule/types'
 
 import { arrToObjBySep, sanitize } from './utils'
 
+export function parsePodsOrPhysicalMachines(data: string[]) {
+  return data.reduce((acc, d) => {
+    const [namespace, name] = d.split(':')
+
+    if (acc.hasOwnProperty(namespace)) {
+      acc[namespace].push(name)
+    } else {
+      acc[namespace] = [name]
+    }
+
+    return acc
+  }, {} as Record<string, string[]>)
+}
+
 export function parseSubmit<K extends ExperimentKind>(
   env: Env,
   _kind: K,
@@ -70,20 +84,6 @@ export function parseSubmit<K extends ExperimentKind>(
       scope.annotationSelectors = arrToObjBySep(scope.annotationSelectors, ':', { removeAllSpaces: true }) as any
     } else {
       delete scope.annotationSelectors
-    }
-
-    function parsePodsOrPhysicalMachines(data: string[]) {
-      return data.reduce((acc, d) => {
-        const [namespace, name] = d.split(':')
-
-        if (acc.hasOwnProperty(namespace)) {
-          acc[namespace].push(name)
-        } else {
-          acc[namespace] = [name]
-        }
-
-        return acc
-      }, {} as Record<string, string[]>)
     }
 
     // Parse pods if exists.


### PR DESCRIPTION
## What problem does this PR solve?

Close #4566

## What's changed and how it works?

We haven't handled the parsing of physical machines correctly. In the frontend code, all physical machines are originally recorded with this format:

```
namespace:machine-name
```

So we need to parse them into the below format:

```yaml
namespace:
  - machine1
  - machine2
```

This PR fixes all the places where this problem occurs.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
