### PR TITLE
ci: use the negative pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,13 @@ updates:
   - package-ecosystem: "github-actions"
     # For GitHub Actions, use the value /. Dependabot will search the /.github/workflows directory,
     # as well as the action.yml/action.yaml file from the root directory.
-    directories: "/"
+    directory: "/"
     schedule:
       interval: "monthly"
     commit-message:
       prefix: "github-actions"
+    labels:
+      - "no-need-update-changelog"
   - package-ecosystem: "gomod"
     directories:
       - "/"
@@ -19,3 +21,5 @@ updates:
       - dependency-type: all
     commit-message:
       prefix: "go"
+    labels:
+      - "no-need-update-changelog"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -27,22 +27,9 @@ jobs:
           files: |
             .gitignore
             **.md
-            .github/ISSUE_TEMPLATE/*
             ui/**
-            .github/workflows/checklink.yaml
-            .github/checklink_config.json
-            .github/workflows/ci.yml
-            .github/workflows/ci_skip.yml
-            .github/workflows/codecov_unittest.yaml
-            .github/workflows/integration_test.yml
-            .github/workflows/license_checker.yml
-            .github/workflows/must_update_changelog.yml
-            .github/workflows/release_helm_chart.yml
-            .github/workflows/upload_env_image.yml
-            .github/workflows/upload_image.yml
-            .github/workflows/upload_image_pr.yml
-            .github/workflows/upload_latest_files.yml
-            .github/workflows/upload_release_files.yml
+            .github/**
+            !.github/workflows/e2e_test.yml
             test/integration_test/**
       - name: Show outputs
         run: echo "${{ toJSON(steps.filter.outputs) }}"

--- a/.github/workflows/e2e_test_upload_cache.yml
+++ b/.github/workflows/e2e_test_upload_cache.yml
@@ -11,20 +11,8 @@ on:
       - "**.md"
       # Not available for frontend code for now.
       - "ui/**"
-      - .github/workflows/checklink.yaml
-      - .github/checklink_config.json
-      - .github/workflows/ci.yml
-      - .github/workflows/ci_skip.yml
-      - .github/workflows/codecov_unittest.yaml
-      - .github/workflows/integration_test.yml
-      - .github/workflows/license_checker.yml
-      - .github/workflows/must_update_changelog.yml
-      - .github/workflows/release_helm_chart.yml
-      - .github/workflows/upload_env_image.yml
-      - .github/workflows/upload_image.yml
-      - .github/workflows/upload_image_pr.yml
-      - .github/workflows/upload_latest_files.yml
-      - .github/workflows/upload_release_files.yml
+      - .github/workflows/**
+      - "!.github/workflows/e2e_test_upload_cache.yml"
 
 permissions: read-all
 
@@ -32,8 +20,7 @@ jobs:
   build-image:
     runs-on: ubuntu-20.04
     steps:
-      - name: checkout codes
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: build e2e images
         env:
           DOCKER_CACHE: 1
@@ -52,8 +39,7 @@ jobs:
   build-e2e-binary:
     runs-on: ubuntu-20.04
     steps:
-      - name: checkout codes
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: build e2e binary
         env:
           DOCKER_CACHE: 1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -7,25 +7,10 @@ on:
     paths-ignore:
       - .gitignore
       - "**.md"
-      - .github/ISSUE_TEMPLATE/*
-      - .github/pull_request_template.md
       # Not available for frontend code for now.
       - "ui/**"
-      - .github/workflows/checklink.yaml
-      - .github/checklink_config.json
-      - .github/workflows/ci.yml
-      - .github/workflows/ci_skip.yml
-      - .github/workflows/codecov_unittest.yaml
-      - .github/workflows/e2e_test.yml
-      - .github/workflows/e2e_test_upload_cache.yml
-      - .github/workflows/license_checker.yml
-      - .github/workflows/must_update_changelog.yml
-      - .github/workflows/release_helm_chart.yml
-      - .github/workflows/upload_env_image.yml
-      - .github/workflows/upload_image.yml
-      - .github/workflows/upload_image_pr.yml
-      - .github/workflows/upload_latest_files.yml
-      - .github/workflows/upload_release_files.yml
+      - .github/workflows/**
+      - "!.github/workflows/integration_test.yml"
 
 permissions: read-all
 


### PR DESCRIPTION
## What problem does this PR solve?

We can use the negative pattern for `paths` and `paths-ignore` in CI.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
