### PR TITLE
refactor: fmt = goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ check: generate manifests/crd.yaml vet lint fmt tidy install.sh helm-values-sche
 
 fmt: SHELL:=$(RUN_IN_DEV_SHELL)
 fmt: images/dev-env/.dockerbuilt ## Reformat go files with goimports
-  find . -type f -name '*.go' -not -path '**/zz_generated.*.go' -not -path './.cache/**' \
-    -exec goimports -w -l -local github.com/chaos-mesh/chaos-mesh {} +
+	find . -type f -name '*.go' -not -path '**/zz_generated.*.go' -not -path './.cache/**' \
+		-exec goimports -w -l -local github.com/chaos-mesh/chaos-mesh {} +
 
 gosec-scan: SHELL:=$(RUN_IN_DEV_SHELL)
 gosec-scan: images/dev-env/.dockerbuilt

--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,13 @@ swagger_spec: images/dev-env/.dockerbuilt ## Generate OpenAPI/Swagger spec for f
 check: generate manifests/crd.yaml vet lint fmt tidy install.sh helm-values-schema ## Run prerequisite checks for PR
 
 fmt: SHELL:=$(RUN_IN_DEV_SHELL)
-fmt: groupimports images/dev-env/.dockerbuilt ## Reformat go files with gofmt and goimports
-	$(CGO) fmt $$($(PACKAGE_LIST))
+fmt: images/dev-env/.dockerbuilt ## Reformat go files with goimports
+  find . -type f -name '*.go' -not -path '**/zz_generated.*.go' -not -path './.cache/**' \
+    -exec goimports -w -l -local github.com/chaos-mesh/chaos-mesh {} +
 
 gosec-scan: SHELL:=$(RUN_IN_DEV_SHELL)
 gosec-scan: images/dev-env/.dockerbuilt
 	gosec ./api/... ./controllers/... ./pkg/... || echo "*** sec-scan failed: known-issues ***"
-
-groupimports: SHELL:=$(RUN_IN_DEV_SHELL)
-groupimports: images/dev-env/.dockerbuilt ## Reformat go files with goimports
-	find . -type f -name '*.go' -not -path '**/zz_generated.*.go' -not -path './.cache/**' | xargs \
-		-d $$'\n' -n 10 goimports -w -l -local github.com/chaos-mesh/chaos-mesh
 
 lint: SHELL:=$(RUN_IN_DEV_SHELL)
 lint: images/dev-env/.dockerbuilt ## Lint go files with revive
@@ -310,7 +306,7 @@ bin/chaos-builder: images/dev-env/.dockerbuilt
 	$(CGOENV) go build -ldflags '$(LDFLAGS)' -buildvcs=false -o bin/chaos-builder ./cmd/chaos-builder/...
 
 .PHONY: all image clean test manifests manifests/crd.yaml \
-	boilerplate tidy groupimports fmt vet lint install.sh schedule-migration \
+	boilerplate tidy fmt vet lint install.sh schedule-migration \
 	config proto \
 	generate generate-deepcopy swagger_spec bin/chaos-builder \
 	gosec-scan \

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.22 AS go_install
 ENV GOPATH /go
 ENV CGO_ENABLED 0
 
-RUN go install golang.org/x/tools/cmd/goimports@v0.33.0
+RUN go install golang.org/x/tools/cmd/goimports@v0.30.0
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 RUN go install github.com/mgechev/revive@v1.2.4
 RUN go install github.com/pingcap/failpoint/failpoint-ctl@v0.0.0-20200210140405-f8f9fb234798

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.22 AS go_install
 ENV GOPATH /go
 ENV CGO_ENABLED 0
 
-RUN go install golang.org/x/tools/cmd/goimports@v0.13.0
+RUN go install golang.org/x/tools/cmd/goimports@v0.33.0
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 RUN go install github.com/mgechev/revive@v1.2.4
 RUN go install github.com/pingcap/failpoint/failpoint-ctl@v0.0.0-20200210140405-f8f9fb234798


### PR DESCRIPTION
## What problem does this PR solve?

As https://pkg.go.dev/golang.org/x/tools/cmd/goimports says:

> In addition to fixing imports, goimports also formats your code in the same style as gofmt so it can be used as a replacement for your editor's gofmt-on-save hook.

## What's changed and how it works?

Remove the extra format operation.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
