### PR TITLE
chore: deprecate set-output

### DIFF
--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -28,13 +28,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Extract Image Tag
+        id: image_tag
         shell: bash
         run: |
           # we assume that both image tags of build-env and dev-env are same during this workflow
           IMAGE_TAG=$(./hack/env-image-tag.sh build-env)
 
-          echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
-        id: image_tag
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -38,7 +38,7 @@ jobs:
             IMAGE_TAG=latest;
           fi
 
-          echo "::set-output name=image_tag::$(echo $IMAGE_TAG)"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
## What problem does this PR solve?

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## What's changed and how it works?

Update related commands.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
