### PR TITLE
fix: use the correct error variable

### DIFF
--- a/pkg/workflow/controllers/parallel_node_reconciler.go
+++ b/pkg/workflow/controllers/parallel_node_reconciler.go
@@ -128,7 +128,7 @@ func (it *ParallelNodeReconciler) Reconcile(ctx context.Context, request reconci
 	})
 
 	if updateError != nil {
-		it.logger.Error(err, "failed to update the status of node", "node", request)
+		it.logger.Error(updateError, "failed to update the status of node", "node", request)
 		return reconcile.Result{}, updateError
 	}
 

--- a/pkg/workflow/controllers/serial_node_reconciler.go
+++ b/pkg/workflow/controllers/serial_node_reconciler.go
@@ -148,7 +148,7 @@ func (it *SerialNodeReconciler) Reconcile(ctx context.Context, request reconcile
 	})
 
 	if updateError != nil {
-		it.logger.Error(err, "failed to update the status of node", "node", request)
+		it.logger.Error(updateError, "failed to update the status of node", "node", request)
 		return reconcile.Result{}, updateError
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

should use `updateErr`

## What's changed and how it works?

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
