### PR TITLE
fix reduce useless recursively expanded variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ BASIC_IMAGE_ENV=IMAGE_DEV_ENV_TAG=$(IMAGE_DEV_ENV_TAG) \
 	IMAGE_TAG=$(IMAGE_TAG) TARGET_PLATFORM=$(TARGET_PLATFORM) \
 	GO_BUILD_CACHE=$(GO_BUILD_CACHE)
 
-RUN_IN_DEV_SHELL=$(shell $(BASIC_IMAGE_ENV)\
+RUN_IN_DEV_SHELL:=$(shell $(BASIC_IMAGE_ENV)\
 	$(ROOT)/build/get_env_shell.py dev-env)
-RUN_IN_BUILD_SHELL=$(shell $(BASIC_IMAGE_ENV)\
+RUN_IN_BUILD_SHELL:=$(shell $(BASIC_IMAGE_ENV)\
 	$(ROOT)/build/get_env_shell.py build-env)
 
 # See https://github.com/chaos-mesh/chaos-mesh/pull/4004 for more details.


### PR DESCRIPTION
## What problem does this PR solve?
In the original Makefile, `RUN_IN_DEV_SHELL` and `RUN_IN_BUILD_SHELL` were defined using = (recursively expanded variables). This notation defers evaluation until the variable is actually used, which can be helpful if the values need to reflect changes in other variables over time. However, for the variables updated in this PR, we do not require lazy (deferred) evaluation. 

Therefore, switching to := (simply expanded variables) is more appropriate, as each variable is expanded once at the time of definition and remains consistent throughout the build. This can improve performance and clarity by avoiding unnecessary re-evaluation.

## What's changed and how it works?

This change prevents many repeated computations from being executed multiple times—a behavior that can be observed by setting SHELL := bash -x.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
