### PR TITLE
fix(ui): process no selector chaos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Return 404 when the archive schedule was not found [#4553](https://github.com/chaos-mesh/chaos-mesh/pull/4553)
 - Changed JVMParameter.ReturnValue json tag field name to `returnValue` [#4525](https://github.com/chaos-mesh/chaos-mesh/pull/4525)
 - Correct the parsing of the physical machines in the Dashboard UI [#4580](https://github.com/chaos-mesh/chaos-mesh/pull/4580)
+- Correct the processing of no-selector chaos experiments in the Dashboard UI
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Return 404 when the archive schedule was not found [#4553](https://github.com/chaos-mesh/chaos-mesh/pull/4553)
 - Changed JVMParameter.ReturnValue json tag field name to `returnValue` [#4525](https://github.com/chaos-mesh/chaos-mesh/pull/4525)
 - Correct the parsing of the physical machines in the Dashboard UI [#4580](https://github.com/chaos-mesh/chaos-mesh/pull/4580)
-- Correct the processing of no-selector chaos experiments in the Dashboard UI
+- Correct the processing of no-selector chaos experiments in the Dashboard UI [#4671](https://github.com/chaos-mesh/chaos-mesh/pull/4671)
 
 ### Security
 

--- a/ui/app/src/components/NewExperimentNext/Step3.tsx
+++ b/ui/app/src/components/NewExperimentNext/Step3.tsx
@@ -87,7 +87,18 @@ const Step3: React.FC<Step3Props> = ({ onSubmit, inSchedule }) => {
 
             navigate('/experiments')
           })
-          .catch(console.error)
+          .catch((error) => {
+            if (process.env.NODE_ENV === 'development') {
+              console.error('Error submitting experiment:', error.response)
+            }
+
+            dispatch(
+              setAlert({
+                type: 'error',
+                message: error.response.data.message,
+              })
+            )
+          })
       }
     }
   }

--- a/ui/app/src/components/ObjectConfiguration/index.tsx
+++ b/ui/app/src/components/ObjectConfiguration/index.tsx
@@ -46,11 +46,19 @@ const ObjectConfiguration: React.FC<ObjectConfigurationProps> = ({
   inArchive,
   vertical,
 }) => {
-  const { lang } = useStoreSelector((state) => state.settings)
+  const { lang, useNewPhysicalMachine } = useStoreSelector((state) => state.settings)
 
-  const spec: any = inNode ? config : config!.kube_object!.spec
+  const spec: any = inNode ? config : config.kube_object?.spec
   const experiment =
     inSchedule || inNode ? spec[templateTypeToFieldName(inSchedule ? spec.type : (config as any).templateType)] : spec
+
+  const hasAddress =
+    !useNewPhysicalMachine &&
+    (inNode
+      ? (config as any).templateType === 'PhysicalMachineChaos'
+      : inSchedule
+      ? spec.type === 'PhysicalMachineChaos'
+      : (config.kind as any) === 'PhysicalMachineChaos')
 
   return (
     <>
@@ -102,38 +110,32 @@ const ObjectConfiguration: React.FC<ObjectConfigurationProps> = ({
           </Grid>
         )}
 
-        <Grid item xs={vertical ? 12 : 3}>
-          <Typography variant="subtitle2" gutterBottom>
-            {i18n('newE.steps.scope')}
-          </Typography>
+        {(hasAddress || experiment.selector) && (
+          <Grid item xs={vertical ? 12 : 3}>
+            <Typography variant="subtitle2" gutterBottom>
+              {i18n('newE.steps.scope')}
+            </Typography>
 
-          {(inNode
-            ? (config as any).templateType !== 'PhysicalMachineChaos'
-            : inSchedule
-            ? spec.type !== 'PhysicalMachineChaos'
-            : (config.kind as any) !== 'PhysicalMachineChaos') && <Selector data={experiment.selector} />}
+            {experiment.selector && <Selector data={experiment.selector} />}
 
-          {(inNode
-            ? (config as any).templateType === 'PhysicalMachineChaos'
-            : inSchedule
-            ? spec.type === 'PhysicalMachineChaos'
-            : (config.kind as any) === 'PhysicalMachineChaos') && (
-            <Table>
-              <TableRow>
-                <TableCell>{i18n('physic.address')}</TableCell>
-                <TableCell>
-                  <Typography variant="body2" color="textSecondary">
-                    {inNode
-                      ? (config as any).physicalmachineChaos.address
-                      : inSchedule
-                      ? spec.physicalmachineChaos.address
-                      : spec.address}
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            </Table>
-          )}
-        </Grid>
+            {hasAddress && (
+              <Table>
+                <TableRow>
+                  <TableCell>{i18n('physic.address')}</TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="textSecondary">
+                      {inNode
+                        ? (config as any).physicalmachineChaos.address
+                        : inSchedule
+                        ? spec.physicalmachineChaos.address
+                        : spec.address}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              </Table>
+            )}
+          </Grid>
+        )}
 
         <Grid item xs={vertical ? 12 : 3}>
           <Typography variant="subtitle2" gutterBottom>

--- a/ui/app/src/i18n/en.json
+++ b/ui/app/src/i18n/en.json
@@ -200,10 +200,13 @@
     "basic": {
       "nameHelper": "The schedule name",
       "scheduleHelper": "The schedule is expressed in the form of CronJob. If you are not familiar with it, you can use {crontabguru} to help define it.",
+      "historyLimit": "History limit",
       "historyLimitHelper": "Maximum number of experiment records.",
+      "concurrencyPolicy": "Concurrency policy",
       "concurrencyPolicyHelper": "Whether to allow experiments to run at the same time.",
       "forbid": "Forbid",
       "allow": "Allow",
+      "startingDeadlineSeconds": "Deadline for delayed Job start",
       "startingDeadlineSecondsHelper": "Counts how many missed jobs occurred from the value of startingDeadlineSeconds until now."
     }
   },

--- a/ui/app/src/i18n/zh.json
+++ b/ui/app/src/i18n/zh.json
@@ -137,10 +137,13 @@
     "basic": {
       "nameHelper": "计划的名称",
       "scheduleHelper": "计划以 CronJob 的形式表示。如果你还不熟悉它，可以借助 {crontabguru} 来辅助制定计划。",
+      "historyLimit": "历史限制",
       "historyLimitHelper": "最大实验记录数。",
+      "concurrencyPolicy": "并发性规则",
       "concurrencyPolicyHelper": "是否允许实验同时运行。",
       "forbid": "禁止",
       "allow": "允许",
+      "startingDeadlineSeconds": "延迟开始的最后期限",
       "startingDeadlineSecondsHelper": "统计从 startingDeadlineSeconds 设置的值到现在错过了多少次 job。"
     }
   },


### PR DESCRIPTION
## What problem does this PR solve?

Close #4461

## What's changed and how it works?

Some types of chaos don't have `selectors`, like `AWSChaos`, `AzureChaos`, `GCPChaos`, so we need to process them separately.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
