### PR TITLE
fix: upgrade all base images to bookworm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Security
 
-- Nothing
+- Upgrade all bullseye-slim to bookworm-slim
 
 ## [2.7.0] - 2024-09-20
 

--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -35,7 +35,7 @@ RUN case "$TARGET_PLATFORM" in \
 
 
 # ---
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
@@ -9,7 +9,7 @@ ENV https_proxy $HTTPS_PROXY
 ARG UI
 ARG SWAGGER
 
-RUN apt-get update && \ 
+RUN apt-get update && \
     echo "deb http://security.debian.org/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
     apt --allow-releaseinfo-change update && apt upgrade  -y && \

--- a/images/chaos-dlv/Dockerfile
+++ b/images/chaos-dlv/Dockerfile
@@ -3,7 +3,7 @@
 FROM golang:1.22-bookworm AS build-env
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 
-FROM debian:bookworm
+FROM debian:bookworm-slim
 
 RUN apt update && \
     apt install procps -y && \

--- a/images/chaos-mesh/Dockerfile
+++ b/images/chaos-mesh/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.21
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY


### PR DESCRIPTION
## What problem does this PR solve?

Close #4669.

## What's changed and how it works?

This PR upgrades all bullseye base images to bookworm, to fix all potential CVE problems.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [x] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
