### PR TITLE
chore: ready for v2.6.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   # JOB to run change detection
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Set job outputs to values from filter step
     outputs:
       go: ${{ steps.filter.outputs.go }}
@@ -54,7 +54,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":"github-arm64-2c-8gb"}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-22.04", "arm64":"github-arm64-2c-8gb"}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   skip-changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       go: ${{ steps.filter.outputs.go }}
       ui: ${{ steps.filter.outputs.ui }}
@@ -39,7 +39,7 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "Not required to run go jobs."
   ui:
@@ -51,6 +51,6 @@ jobs:
           - verify
           - build
           - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "Not required to run ui jobs."

--- a/.github/workflows/must_update_changelog.yml
+++ b/.github/workflows/must_update_changelog.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   must-update-changelog:
     name: "Must Update CHANGELOG"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       LABEL_EXISTS: ${{ contains(github.event.pull_request.labels.*.name, 'no-need-update-changelog') }}
     steps:

--- a/.github/workflows/upload_env_image.yml
+++ b/.github/workflows/upload_env_image.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -75,7 +75,7 @@ jobs:
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: [dev, build]

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -21,7 +21,7 @@ jobs:
           [chaos-daemon, chaos-mesh, chaos-dashboard, chaos-kernel, chaos-dlv]
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
-    runs-on: ${{ fromJson('{"amd64":"ubuntu-20.04", "arm64":"github-arm64-2c-8gb"}')[matrix.arch] }}
+    runs-on: ${{ fromJson('{"amd64":"ubuntu-22.04", "arm64":"github-arm64-2c-8gb"}')[matrix.arch] }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -79,7 +79,7 @@ jobs:
 
   upload-manifest:
     needs: build-specific-architecture
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
       packages: write
@@ -126,7 +126,7 @@ jobs:
       - build-specific-architecture
       - upload-manifest
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # Need to upload files to the related release.
       # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github
@@ -167,7 +167,7 @@ jobs:
   sbom:
     needs: build-specific-architecture
     if: needs.build-specific-architecture.outputs.image_tag != 'latest'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # Need to upload files to the related release.
     env:

--- a/.github/workflows/upload_latest_files.yml
+++ b/.github/workflows/upload_latest_files.yml
@@ -18,7 +18,7 @@ jobs:
   run:
     if: github.repository_owner == 'chaos-mesh'
     name: Upload
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/upload_release_files.yml
+++ b/.github/workflows/upload_release_files.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   run:
     name: Upload
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Must Triggered by Tag v<version>"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,32 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Nothing
+
+### Security
+
+- Nothing
+
+## [2.6.7] - 2025-05-15
+
+### Added
+
+- Nothing
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
 - Correct the processing of no-selector chaos experiments in the Dashboard UI [#4671](https://github.com/chaos-mesh/chaos-mesh/pull/4671)
 
 ### Security

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -48,7 +48,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "v2.6.6"
+  tag: "v2.6.7"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
It's ready for the next patch version.

This patch version mainly resolves [CVEs](https://github.com/chaos-mesh/chaos-mesh/issues/4669) by upgrading base images.

And, if there are no serious CVEs to follow in the future, this will be the last version of `v2.6`.