### PR TITLE
fix: bullseye to bookworm

### DIFF
--- a/.github/workflows/upload_image_pr.yml
+++ b/.github/workflows/upload_image_pr.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install jq
         run: |
-          sudo apt-get install jq -y
+          sudo apt install jq -y
 
       - name: Cache docker image and go
         uses: actions/cache@v4

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -43,12 +43,10 @@ ARG HTTP_PROXY
 ENV http_proxy $HTTP_PROXY
 ENV https_proxy $HTTPS_PROXY
 
-RUN mkdir -p /usr/share/man/man1 /usr/share/man/man2
-
 RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
     apt update --allow-releaseinfo-change && apt upgrade -y && \
-    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
+    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-17-jre && \
     rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
@@ -57,7 +55,7 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
 ENV RUST_BACKTRACE 1
 ENV BYTEMAN_HOME /usr/local/byteman
 ENV PATH $PATH:/usr/local/byteman/bin
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH $PATH:/usr/local/bin
 
 COPY bin/chaos-daemon /usr/local/bin/chaos-daemon

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -45,11 +45,10 @@ ENV https_proxy $HTTPS_PROXY
 
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man2
 
-RUN apt-get update && \
-    echo "deb http://security.debian.org/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
     apt --allow-releaseinfo-change update && apt upgrade -y && \
-    apt-get install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
+    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
     rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man2
 
 RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt --allow-releaseinfo-change update && apt upgrade -y && \
+    apt update --allow-releaseinfo-change && apt upgrade -y && \
     apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-11-jre && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -9,11 +9,10 @@ ENV https_proxy $HTTPS_PROXY
 ARG UI
 ARG SWAGGER
 
-RUN apt-get update && \
-    echo "deb http://security.debian.org/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt --allow-releaseinfo-change update && apt upgrade  -y && \
-    apt-get install tzdata ca-certificates -y && \
+RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
+    apt --allow-releaseinfo-change update && apt upgrade -y && \
+    apt install tzdata ca-certificates -y && \
     rm -rf /var/lib/apt/lists/*
 
 ENV http_proxy=

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -11,7 +11,7 @@ ARG SWAGGER
 
 RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt --allow-releaseinfo-change update && apt upgrade -y && \
+    apt update --allow-releaseinfo-change && apt upgrade -y && \
     apt install tzdata ca-certificates -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/chaos-kernel/Dockerfile
+++ b/images/chaos-kernel/Dockerfile
@@ -5,7 +5,7 @@ ARG HTTP_PROXY
 ARG MAKE_JOBS=4
 ARG MIRROR=http://archive.ubuntu.com/ubuntu
 
-RUN apt-get update && apt-get install -y ca-certificates gnupg2 wget
+RUN apt update && apt install -y ca-certificates gnupg2 wget
 
 RUN if [ ! -z "$MIRROR" ]; then sed -i "s|http://archive.ubuntu.com/ubuntu|$MIRROR|g" /etc/apt/sources.list; fi
 
@@ -14,7 +14,7 @@ RUN echo "deb https://apt.kitware.com/ubuntu/ bionic main" >> /etc/apt/sources.l
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 
-RUN ulimit -n 1024 && apt-get update &&  apt-get install -y gcc-8 g++-8 bison build-essential \
+RUN ulimit -n 1024 && apt update && apt install -y gcc-8 g++-8 bison build-essential \
     flex git libedit-dev libllvm6.0 llvm-6.0-dev libclang-6.0-dev python python-pip \
     zlib1g-dev libelf-dev libssl-dev
 RUN apt install -y cmake


### PR DESCRIPTION
## What problem does this PR solve?

In [#4676](https://github.com/chaos-mesh/chaos-mesh/pull/4676), I forgot to update `bullseye-security` and `bullseye-proposed-updates` to `bookworm-security` and `bookworm-proposed-updates`.


## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
