### PR TITLE
fix: deprecate @loadable/component

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.3.0",
-    "@loadable/component": "^5.14.1",
     "@mui/base": "5.0.0-alpha.120",
     "@mui/icons-material": "^5.10.16",
     "@mui/lab": "5.0.0-alpha.122",

--- a/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
+++ b/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
@@ -17,12 +17,11 @@
 import Paper from '@/mui-extends/Paper'
 import Space from '@/mui-extends/Space'
 import { useStoreDispatch } from '@/store'
-import loadable from '@loadable/component'
 import PublishIcon from '@mui/icons-material/Publish'
 import { Button, Typography } from '@mui/material'
 import { Ace } from 'ace-builds'
 import yaml from 'js-yaml'
-import { useState } from 'react'
+import { lazy, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { setAlert } from '@/slices/globalStatus'
@@ -30,7 +29,7 @@ import { setAlert } from '@/slices/globalStatus'
 import i18n from '@/components/T'
 import YAML from '@/components/YAML'
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 interface ByYAMLProps {
   callback?: (data: any) => void

--- a/ui/app/src/components/NewWorkflow/index.tsx
+++ b/ui/app/src/components/NewWorkflow/index.tsx
@@ -20,7 +20,6 @@ import Paper from '@/mui-extends/Paper'
 import Space from '@/mui-extends/Space'
 import { useGetCommonChaosAvailableNamespaces, usePostWorkflows } from '@/openapi'
 import { useStoreDispatch, useStoreSelector } from '@/store'
-import loadable from '@loadable/component'
 import CheckIcon from '@mui/icons-material/Check'
 import PublishIcon from '@mui/icons-material/Publish'
 import RemoveIcon from '@mui/icons-material/Remove'
@@ -43,7 +42,7 @@ import { Ace } from 'ace-builds'
 import { Form, Formik } from 'formik'
 import yaml from 'js-yaml'
 import _ from 'lodash'
-import { useEffect, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router'
 
@@ -89,7 +88,7 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
   },
 }))
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 type IStep = Template
 

--- a/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
+++ b/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
@@ -20,11 +20,10 @@ import Paper from '@/mui-extends/Paper'
 import Space from '@/mui-extends/Space'
 import { useGetCommonChaosAvailableNamespaces, usePostWorkflows } from '@/openapi'
 import { useStoreDispatch, useStoreSelector } from '@/store'
-import loadable from '@loadable/component'
 import { Box, Divider, MenuItem, Typography } from '@mui/material'
 import { Form, Formik } from 'formik'
 import yaml from 'js-yaml'
-import { useEffect, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import * as Yup from 'yup'
 
@@ -34,7 +33,7 @@ import { SelectField, Submit, TextField } from '@/components/FormField'
 import FormikEffect from '@/components/FormikEffect'
 import { T } from '@/components/T'
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 const validationSchema = Yup.object({
   name: Yup.string().trim().required(),

--- a/ui/app/src/components/TopContainer/index.tsx
+++ b/ui/app/src/components/TopContainer/index.tsx
@@ -20,7 +20,6 @@ import ConfirmDialog from '@/mui-extends/ConfirmDialog'
 import Loading from '@/mui-extends/Loading'
 import { useGetCommonConfig } from '@/openapi'
 import { useStoreDispatch, useStoreSelector } from '@/store'
-import loadable from '@loadable/component'
 import {
   Alert,
   Box,
@@ -35,7 +34,7 @@ import {
 } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import Cookies from 'js-cookie'
-import { useEffect, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 import { Outlet } from 'react-router'
 
 import { setAlertOpen, setAuthOpen, setConfirmOpen, setNameSpace, setTokenName, setTokens } from '@/slices/globalStatus'
@@ -49,7 +48,7 @@ import Navbar from './Navbar'
 import { closedWidth, openedWidth } from './Sidebar'
 import Sidebar from './Sidebar'
 
-const Auth = loadable(() => import('./Auth'))
+const Auth = lazy(() => import('./Auth'))
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'open',

--- a/ui/app/src/pages/Archives/Single.tsx
+++ b/ui/app/src/pages/Archives/Single.tsx
@@ -19,9 +19,9 @@ import Paper from '@/mui-extends/Paper'
 import PaperTop from '@/mui-extends/PaperTop'
 import Space from '@/mui-extends/Space'
 import { useGetArchivesSchedulesUid, useGetArchivesUid, useGetArchivesWorkflowsUid, useGetEvents } from '@/openapi'
-import loadable from '@loadable/component'
 import { Box, Grid, Grow } from '@mui/material'
 import yaml from 'js-yaml'
+import { lazy } from 'react'
 import { useParams } from 'react-router'
 
 import EventsTimeline from '@/components/EventsTimeline'
@@ -30,7 +30,7 @@ import i18n from '@/components/T'
 
 import { useQuery } from '@/lib/hooks'
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 const Single = () => {
   const { uuid } = useParams()

--- a/ui/app/src/pages/Dashboard/Predefined.tsx
+++ b/ui/app/src/pages/Dashboard/Predefined.tsx
@@ -19,13 +19,12 @@ import PaperTop from '@/mui-extends/PaperTop'
 import Space from '@/mui-extends/Space'
 import { postExperiments, postSchedules } from '@/openapi'
 import { useStoreDispatch } from '@/store'
-import loadable from '@loadable/component'
 import { Box, Button, Card, Modal, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { Ace } from 'ace-builds'
 import clsx from 'clsx'
 import yaml from 'js-yaml'
-import { useEffect, useRef, useState } from 'react'
+import { lazy, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { setAlert, setConfirm } from '@/slices/globalStatus'
@@ -72,7 +71,7 @@ const Root = styled('div')(({ theme }) => ({
   },
 }))
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 const Predefined = () => {
   const intl = useIntl()

--- a/ui/app/src/pages/Experiments/Single.tsx
+++ b/ui/app/src/pages/Experiments/Single.tsx
@@ -26,13 +26,13 @@ import {
   usePutExperimentsStartUid,
 } from '@/openapi'
 import { useStoreDispatch } from '@/store'
-import loadable from '@loadable/component'
 import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined'
 import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline'
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline'
 import Alert from '@mui/lab/Alert'
 import { Box, Button, Grid, Grow } from '@mui/material'
 import yaml from 'js-yaml'
+import { lazy } from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate, useParams } from 'react-router'
 
@@ -42,7 +42,7 @@ import EventsTimeline from '@/components/EventsTimeline'
 import ObjectConfiguration from '@/components/ObjectConfiguration'
 import i18n from '@/components/T'
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 export default function Single() {
   const navigate = useNavigate()

--- a/ui/app/src/pages/Schedules/Single.tsx
+++ b/ui/app/src/pages/Schedules/Single.tsx
@@ -26,12 +26,12 @@ import {
   usePutSchedulesStartUid,
 } from '@/openapi'
 import { useStoreDispatch } from '@/store'
-import loadable from '@loadable/component'
 import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined'
 import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline'
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline'
 import { Box, Button, Grid, Grow } from '@mui/material'
 import yaml from 'js-yaml'
+import { lazy } from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate, useParams } from 'react-router'
 
@@ -41,7 +41,7 @@ import EventsTimeline from '@/components/EventsTimeline'
 import ObjectConfiguration from '@/components/ObjectConfiguration'
 import i18n from '@/components/T'
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 const Single = () => {
   const navigate = useNavigate()

--- a/ui/app/src/pages/Workflows/Single.tsx
+++ b/ui/app/src/pages/Workflows/Single.tsx
@@ -20,13 +20,12 @@ import Space from '@/mui-extends/Space'
 import { useDeleteWorkflowsUid, useGetEventsWorkflowUid, useGetWorkflowsUid } from '@/openapi'
 import { CoreWorkflowDetail } from '@/openapi/index.schemas'
 import { useStoreDispatch } from '@/store'
-import loadable from '@loadable/component'
 import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined'
 import { Box, Button, Grid, Grow, Modal, useTheme } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { EventHandler } from 'cytoscape'
 import yaml from 'js-yaml'
-import { useEffect, useRef, useState } from 'react'
+import { lazy, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useNavigate, useParams } from 'react-router'
 
@@ -63,7 +62,7 @@ const Root = styled('div')(({ theme }) => ({
   },
 }))
 
-const YAMLEditor = loadable(() => import('@/components/YAMLEditor'))
+const YAMLEditor = lazy(() => import('@/components/YAMLEditor'))
 
 function transformWorkflow(data: CoreWorkflowDetail) {
   // TODO: remove noise in API

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.3.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@19.1.5)(react@19.1.0))(@types/react@19.1.5)(react@19.1.0)
-      '@loadable/component':
-        specifier: ^5.14.1
-        version: 5.16.7(react@19.1.0)
       '@mui/base':
         specifier: 5.0.0-alpha.120
         version: 5.0.0-alpha.120(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1320,12 +1317,6 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
-
-  '@loadable/component@5.16.7':
-    resolution: {integrity: sha512-XvkFixLUOTEaj8lI7uwc4nf8Wmq3IulYG7SZHCWcPm/Li5gjJDFfIkgWOLPnD7jqPJVtAG9bEz4SCek+SpHYYg==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@mswjs/cookies@0.2.2':
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -6581,13 +6572,6 @@ snapshots:
   '@jsep-plugin/ternary@1.1.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
-
-  '@loadable/component@5.16.7(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.1
-      hoist-non-react-statics: 3.3.2
-      react: 19.1.0
-      react-is: 16.13.1
 
   '@mswjs/cookies@0.2.2':
     dependencies:


### PR DESCRIPTION
## What problem does this PR solve?

Ref: #4688

## What's changed and how does it work?

Replace `@loadable/component` with `React.lazy`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
