### PR TITLE
fix: update ace-builds

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -40,7 +40,7 @@
     "luxon": "^1.28.1",
     "re-resizable": "^6.9.9",
     "react": "^19.1.0",
-    "react-ace": "^9.2.1",
+    "react-ace": "^14.0.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",

--- a/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
+++ b/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
@@ -19,7 +19,7 @@ import Space from '@/mui-extends/Space'
 import { useStoreDispatch } from '@/store'
 import PublishIcon from '@mui/icons-material/Publish'
 import { Button, Typography } from '@mui/material'
-import { Ace } from 'ace-builds'
+import { type Editor } from 'ace-builds'
 import yaml from 'js-yaml'
 import { lazy, useState } from 'react'
 import { useIntl } from 'react-intl'
@@ -41,7 +41,7 @@ const ByYAML: ReactFCWithChildren<ByYAMLProps> = ({ callback }) => {
   const dispatch = useStoreDispatch()
 
   const [empty, setEmpty] = useState(true)
-  const [yamlEditor, setYAMLEditor] = useState<Ace.Editor>()
+  const [yamlEditor, setYAMLEditor] = useState<Editor>()
 
   const onChange = (value: string) => setEmpty(value === '')
 

--- a/ui/app/src/components/NewWorkflow/index.tsx
+++ b/ui/app/src/components/NewWorkflow/index.tsx
@@ -38,7 +38,7 @@ import {
   Typography,
 } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { Ace } from 'ace-builds'
+import { type Editor } from 'ace-builds'
 import { Form, Formik } from 'formik'
 import yaml from 'js-yaml'
 import _ from 'lodash'
@@ -113,7 +113,7 @@ const NewWorkflow = () => {
     namespace: '',
     deadline: '',
   })
-  const [yamlEditor, setYAMLEditor] = useState<Ace.Editor>()
+  const [yamlEditor, setYAMLEditor] = useState<Editor>()
 
   const { data: namespaces } = useGetCommonChaosAvailableNamespaces({
     query: {

--- a/ui/app/src/components/YAMLEditor/index.tsx
+++ b/ui/app/src/components/YAMLEditor/index.tsx
@@ -19,16 +19,14 @@ import { useStoreDispatch, useStoreSelector } from '@/store'
 import CloudDownloadOutlinedIcon from '@mui/icons-material/CloudDownloadOutlined'
 import PublishIcon from '@mui/icons-material/Publish'
 import { Box, Button } from '@mui/material'
-import 'ace-builds'
-import { Ace } from 'ace-builds'
-import 'ace-builds/src-min-noconflict/mode-yaml'
-import 'ace-builds/src-min-noconflict/theme-tomorrow'
-import 'ace-builds/src-min-noconflict/theme-tomorrow_night_eighties'
-import 'ace-builds/webpack-resolver'
+import { type Editor } from 'ace-builds'
+import 'ace-builds/src-noconflict/ace'
+import 'ace-builds/src-noconflict/mode-yaml'
+import 'ace-builds/src-noconflict/theme-tomorrow'
+import 'ace-builds/src-noconflict/theme-tomorrow_night'
 import fileDownload from 'js-file-download'
 import yaml from 'js-yaml'
-import { memo } from 'react'
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import AceEditor, { IAceEditorProps } from 'react-ace'
 import { useIntl } from 'react-intl'
 
@@ -39,7 +37,7 @@ import i18n from '@/components/T'
 interface YAMLEditorProps {
   name?: string
   data?: string
-  mountEditor?: (editor: Ace.Editor) => void
+  mountEditor?: (editor: Editor) => void
   onUpdate?: (data: any) => void
   download?: boolean
   aceProps?: IAceEditorProps
@@ -58,9 +56,9 @@ const YAMLEditor: ReactFCWithChildren<YAMLEditorProps> = ({
   const { theme } = useStoreSelector((state) => state.settings)
   const dispatch = useStoreDispatch()
 
-  const [editor, setEditor] = useState<Ace.Editor>()
+  const [editor, setEditor] = useState<Editor>()
 
-  const handleOnLoad = (editor: Ace.Editor) => {
+  const handleOnLoad = (editor: Editor) => {
     setEditor(editor)
 
     typeof mountEditor === 'function' && mountEditor(editor)
@@ -89,7 +87,7 @@ const YAMLEditor: ReactFCWithChildren<YAMLEditorProps> = ({
         height="100%"
         style={{ borderBottomLeftRadius: 4, borderBottomRightRadius: 4 }}
         mode="yaml"
-        theme={theme === 'light' ? 'tomorrow' : 'tomorrow_night_eighties'}
+        theme={theme === 'light' ? 'tomorrow' : 'tomorrow_night'}
         value={data}
         {...aceProps}
       />

--- a/ui/app/src/pages/Dashboard/Predefined.tsx
+++ b/ui/app/src/pages/Dashboard/Predefined.tsx
@@ -21,7 +21,7 @@ import { postExperiments, postSchedules } from '@/openapi'
 import { useStoreDispatch } from '@/store'
 import { Box, Button, Card, Modal, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { Ace } from 'ace-builds'
+import { type Editor } from 'ace-builds'
 import clsx from 'clsx'
 import yaml from 'js-yaml'
 import { lazy, useEffect, useRef, useState } from 'react'
@@ -80,7 +80,7 @@ const Predefined = () => {
 
   const idb = useRef(getDB())
 
-  const [yamlEditor, setYAMLEditor] = useState<Ace.Editor>()
+  const [yamlEditor, setYAMLEditor] = useState<Editor>()
   const [editorOpen, seteditorOpen] = useState(false)
   const [experiment, setExperiment] = useState<PreDefinedValue>()
   const [experiments, setExperiments] = useState<PreDefinedValue[]>([])

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.9.7(react-redux@7.2.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@tanstack/react-query':
         specifier: ^5.76.2
-        version: 5.76.2(react@19.1.0)
+        version: 5.77.0(react@19.1.0)
       ace-builds:
         specifier: ^1.4.12
         version: 1.41.0
@@ -117,8 +117,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0
       react-ace:
-        specifier: ^9.2.1
-        version: 9.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^14.0.1
+        version: 14.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-dnd:
         specifier: ^16.0.1
         version: 16.0.1(@types/hoist-non-react-statics@3.3.6)(@types/node@22.15.21)(@types/react@19.1.5)(react@19.1.0)
@@ -161,7 +161,7 @@ importers:
         version: 7.6.0
       '@tanstack/react-query-devtools':
         specifier: ^5.76.2
-        version: 5.76.2(@tanstack/react-query@5.76.2(react@19.1.0))(react@19.1.0)
+        version: 5.77.0(@tanstack/react-query@5.77.0(react@19.1.0))(react@19.1.0)
       '@testing-library/jest-dom':
         specifier: ^5.15.1
         version: 5.17.0
@@ -1965,20 +1965,20 @@ packages:
   '@swc/types@0.1.21':
     resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
 
-  '@tanstack/query-core@5.76.2':
-    resolution: {integrity: sha512-PFGwWh5ss9cJQ67l6bZ7hqXbisX2gy13G2jP+VGY1bgdbCfOMWh6UBVnN62QbFXro6CCoX9hYzTnZHr6Rz00YQ==}
+  '@tanstack/query-core@5.77.0':
+    resolution: {integrity: sha512-PFeWjgMQjOsnxBwnW/TJoO0pCja2dzuMQoZ3Diho7dPz7FnTUwTrjNmdf08evrhSE5nvPIKeqV6R0fvQfmhGeg==}
 
   '@tanstack/query-devtools@5.76.0':
     resolution: {integrity: sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==}
 
-  '@tanstack/react-query-devtools@5.76.2':
-    resolution: {integrity: sha512-XQqPM7ByqhitYtzzRXpFcPXY2FIMGY13atJoQnDInxX+ko7wOhAJg51QGzSxQwZ2JEy91taj0IaIUh3pOz2buw==}
+  '@tanstack/react-query-devtools@5.77.0':
+    resolution: {integrity: sha512-Dwvs+ksXiK1tW4YnTtHwYPO5+d8IUk1l8QQJ4aGEIqKz6uTLu/67NIo7EnUF0G/Edv+UOn9P1V3tYWuVfvhbmg==}
     peerDependencies:
-      '@tanstack/react-query': ^5.76.2
+      '@tanstack/react-query': ^5.77.0
       react: ^18 || ^19
 
-  '@tanstack/react-query@5.76.2':
-    resolution: {integrity: sha512-rGkWberCrFdIxMdvSAJM/UOKeu0O/JVTbMmfhQoJpiU9Uq0EDx2EMCadnNuJWbXR4smDA2t7DY3NKkYFmDVS5A==}
+  '@tanstack/react-query@5.77.0':
+    resolution: {integrity: sha512-jX52ot8WxWzWnAknpRSEWj6PTR/7nkULOfoiaVPk6nKu0otwt30UMBC9PTg/m1x0uhz1g71/imwjViTm/oYHxA==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -4504,11 +4504,11 @@ packages:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-ace@9.5.0:
-    resolution: {integrity: sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==}
+  react-ace@14.0.1:
+    resolution: {integrity: sha512-z6YAZ20PNf/FqmYEic//G/UK6uw0rn21g58ASgHJHl9rfE4nITQLqthr9rHMVQK4ezwohJbp2dGrZpkq979PYQ==}
     peerDependencies:
-      react: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0
-      react-dom: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0
+      react: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dnd-html5-backend@16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
@@ -7400,19 +7400,19 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tanstack/query-core@5.76.2': {}
+  '@tanstack/query-core@5.77.0': {}
 
   '@tanstack/query-devtools@5.76.0': {}
 
-  '@tanstack/react-query-devtools@5.76.2(@tanstack/react-query@5.76.2(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query-devtools@5.77.0(@tanstack/react-query@5.77.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/query-devtools': 5.76.0
-      '@tanstack/react-query': 5.76.2(react@19.1.0)
+      '@tanstack/react-query': 5.77.0(react@19.1.0)
       react: 19.1.0
 
-  '@tanstack/react-query@5.76.2(react@19.1.0)':
+  '@tanstack/react-query@5.77.0(react@19.1.0)':
     dependencies:
-      '@tanstack/query-core': 5.76.2
+      '@tanstack/query-core': 5.77.0
       react: 19.1.0
 
   '@testing-library/dom@8.20.0':
@@ -10420,7 +10420,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  react-ace@9.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-ace@14.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       ace-builds: 1.41.0
       diff-match-patch: 1.0.5


### PR DESCRIPTION
## What problem does this PR solve?

Ref: #4688

## What's changed and how does it work?

Remove `ace-builds/webpack-resolver`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
