### PR TITLE
fix(ui): set the correct env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Correct the parsing of the physical machines in the Dashboard UI [#4580](https://github.com/chaos-mesh/chaos-mesh/pull/4580)
 - Correct the processing of no-selector chaos experiments in the Dashboard UI [#4671](https://github.com/chaos-mesh/chaos-mesh/pull/4671)
 - Re-add the `ExpressionSelectors` to the OpenAPI spec [#4683](https://github.com/chaos-mesh/chaos-mesh/pull/4683)
+- Set then correct env when parsing `PhysicalMachineChaos` in the Dashboard UI
 
 ### Security
 

--- a/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
+++ b/ui/app/src/components/NewExperimentNext/ByYAML/index.tsx
@@ -48,7 +48,9 @@ const ByYAML: ReactFCWithChildren<ByYAMLProps> = ({ callback }) => {
   const handleSubmit = () => {
     const data = yaml.load(yamlEditor!.getValue())
 
-    callback && callback(data)
+    if (callback && typeof callback === 'function') {
+      callback(data)
+    }
 
     setAlert({
       type: 'success',

--- a/ui/app/src/components/NewExperimentNext/Step1.tsx
+++ b/ui/app/src/components/NewExperimentNext/Step1.tsx
@@ -141,7 +141,7 @@ const Step1 = () => {
       : values
 
     if (import.meta.env.DEV) {
-      console.debug('Debug handleSubmitStep1:', result)
+      console.info('Debug handleSubmitStep1:', result)
     }
 
     setSpec(result)

--- a/ui/app/src/components/NewExperimentNext/Step2.tsx
+++ b/ui/app/src/components/NewExperimentNext/Step2.tsx
@@ -97,7 +97,7 @@ const Step2: ReactFCWithChildren<Step2Props> = ({ inWorkflow = false, inSchedule
     const values = schema.cast(_values) as Record<string, any>
 
     if (import.meta.env.DEV) {
-      console.debug('Debug handleSubmitStep2:', values)
+      console.info('Debug handleSubmitStep2:', values)
     }
 
     setBasic(values)

--- a/ui/app/src/components/NewExperimentNext/Step3.tsx
+++ b/ui/app/src/components/NewExperimentNext/Step3.tsx
@@ -63,7 +63,7 @@ const Step3: ReactFCWithChildren<Step3Props> = ({ onSubmit, inSchedule }) => {
     )
 
     if (import.meta.env.DEV || debugMode) {
-      console.debug('Here is the experiment you are going to submit:', JSON.stringify(parsedValues, null, 2))
+      console.info('Here is the experiment you are going to submit:', JSON.stringify(parsedValues, null, 2))
     }
 
     if (!debugMode) {

--- a/ui/app/src/components/NewExperimentNext/index.tsx
+++ b/ui/app/src/components/NewExperimentNext/index.tsx
@@ -63,8 +63,9 @@ const NewExperiment: React.ForwardRefRenderFunction<NewExperimentHandles, NewExp
   }
 
   const fillExperiment = (original: any) => {
-    const { kind, basic, spec } = parseYAML(original)
-    const env = kind === 'PhysicalMachineChaos' ? 'physic' : 'k8s'
+    const { env, data } = parseYAML(original)
+    const { kind, basic, spec } = data
+
     const action = spec.action ?? ''
 
     setExternalExp({

--- a/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
+++ b/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
@@ -95,7 +95,7 @@ export default function SubmitWorkflow({ open, setOpen, workflow }: SubmitWorkfl
     const payload: any = yaml.load(data)
 
     if (debugMode) {
-      console.debug('submitWorkflow => payload', payload)
+      console.info('submitWorkflow => payload', payload)
 
       return
     }

--- a/ui/app/src/components/YAMLEditor/index.tsx
+++ b/ui/app/src/components/YAMLEditor/index.tsx
@@ -16,6 +16,7 @@
  */
 import Space from '@/mui-extends/Space'
 import { useComponentActions } from '@/zustand/component'
+import { useSystemStore } from '@/zustand/system'
 import CloudDownloadOutlinedIcon from '@mui/icons-material/CloudDownloadOutlined'
 import PublishIcon from '@mui/icons-material/Publish'
 import { Box, Button } from '@mui/material'

--- a/ui/app/src/lib/formikhelpers.ts
+++ b/ui/app/src/lib/formikhelpers.ts
@@ -239,8 +239,9 @@ function shouldHasSelector(kind: ExperimentKind | 'Schedule') {
   )
 }
 
-export function parseYAML(yamlObj: any): { kind: ExperimentKind; basic: any; spec: any } {
+export function parseYAML(yamlObj: any) {
   let { kind, metadata, spec }: { kind: ExperimentKind; metadata: any; spec: any } = yamlObj
+  const env: Env = kind === 'PhysicalMachineChaos' ? 'physic' : 'k8s'
 
   if (!kind || !metadata || !spec) {
     throw new Error('Fail to parse the YAML file. Please check the kind, metadata, and spec fields.')
@@ -385,11 +386,14 @@ export function parseYAML(yamlObj: any): { kind: ExperimentKind; basic: any; spe
     spec = rest
   }
 
-  return sanitize({
-    kind,
-    basic,
-    spec,
-  })
+  return {
+    env,
+    data: sanitize({
+      kind,
+      basic,
+      spec,
+    }),
+  }
 }
 
 function validate(defaultI18n: string, i18n?: string) {


### PR DESCRIPTION
## What problem does this PR solve?

Close #4703

## What's changed and how does it work?

Parsing `env` before transforming the original kind to the UI-specific kind.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
