### PR TITLE
fix: upgrade cosign to v2

### DIFF
--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - "**.md"
+      - "!CHANGELOG.md"
       - ".github/checklink_config.json"
 
 permissions: read-all
@@ -18,5 +19,5 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
-          check-modified-files-only: 'yes'
+          check-modified-files-only: "yes"
           config-file: ".github/checklink_config.json"

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -136,9 +136,9 @@ jobs:
       IMAGE_TAG: ${{ needs.build-specific-architecture.outputs.image_tag }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v3.9.2
         with:
-          cosign-release: "v1.13.1"
+          cosign-release: "v2.5.3"
       - name: Login to GitHub Container registry
         uses: docker/login-action@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Update usage about helm-values-schema-json [#4719](https://github.com/chaos-mesh/chaos-mesh/pull/4719)
 - Update swag to v1.16.4
 - Update `enableCtrlServer` to `false` by default in the Helm chart [#4702](https://github.com/chaos-mesh/chaos-mesh/pull/4702)
-- Upgrade cosign to v2.5.3
+- Upgrade cosign to v2.5.3 [#4736](https://github.com/chaos-mesh/chaos-mesh/pull/4736)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Update usage about helm-values-schema-json [#4719](https://github.com/chaos-mesh/chaos-mesh/pull/4719)
 - Update swag to v1.16.4
 - Update `enableCtrlServer` to `false` by default in the Helm chart [#4702](https://github.com/chaos-mesh/chaos-mesh/pull/4702)
+- Upgrade cosign to v2.5.3
 
 ### Deprecated
 


### PR DESCRIPTION
## What problem does this PR solve?

CI: cosign versions below v2.0.0 are no longer supported.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
