### PR TITLE
fix: jvm latency experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix dashboard subpath serving by adding base path to Vite config [#5016](https://github.com/chaos-mesh/chaos-mesh/pull/5016)
 - Optimize RBAC Token Generator copy buttons in Dashboard UI [#4941](https://github.com/chaos-mesh/chaos-mesh/pull/4941)
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
+- Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 
 ### Security
 

--- a/controllers/chaosimpl/jvmchaos/impl.go
+++ b/controllers/chaosimpl/jvmchaos/impl.go
@@ -220,7 +220,7 @@ func generateRuleData(spec *v1alpha1.JVMChaosSpec) error {
 
 	switch spec.Action {
 	case v1alpha1.JVMLatencyAction:
-		bytemanTemplateSpec.Do = fmt.Sprintf("Thread.sleep(%d)", spec.LatencyDuration)
+		bytemanTemplateSpec.Do = fmt.Sprintf("Thread.sleep(%dL)", spec.LatencyDuration)
 	case v1alpha1.JVMExceptionAction:
 		bytemanTemplateSpec.Do = fmt.Sprintf("throw new %s", spec.ThrowException)
 	case v1alpha1.JVMReturnAction:
@@ -269,7 +269,7 @@ func generateRuleData(spec *v1alpha1.JVMChaosSpec) error {
 			exception := fmt.Sprintf(mysqlException, spec.ThrowException)
 			bytemanTemplateSpec.Do = fmt.Sprintf("throw new %s", exception)
 		} else if spec.LatencyDuration > 0 {
-			bytemanTemplateSpec.Do = fmt.Sprintf("Thread.sleep(%d)", spec.LatencyDuration)
+			bytemanTemplateSpec.Do = fmt.Sprintf("Thread.sleep(%dL)", spec.LatencyDuration)
 		}
 	}
 

--- a/controllers/chaosimpl/jvmchaos/impl_test.go
+++ b/controllers/chaosimpl/jvmchaos/impl_test.go
@@ -79,7 +79,7 @@ func TestGenerateRuleData(t *testing.T) {
 					LatencyDuration: 5000,
 				},
 			},
-			"\nRULE test\nCLASS testClass\nMETHOD testMethod\nAT ENTRY\nIF true\nDO\n\tThread.sleep(5000);\nENDRULE\n",
+			"\nRULE test\nCLASS testClass\nMETHOD testMethod\nAT ENTRY\nIF true\nDO\n\tThread.sleep(5000L);\nENDRULE\n",
 		},
 		{
 			&v1alpha1.JVMChaosSpec{
@@ -159,7 +159,7 @@ func TestGenerateRuleData(t *testing.T) {
 					LatencyDuration: 5000,
 				},
 			},
-			"\nRULE test\nCLASS com.mysql.cj.NativeSession\nMETHOD execSQL\nHELPER org.chaos_mesh.byteman.helper.SQLHelper\nAT ENTRY\nBIND flag:boolean=matchDBTable(\"\", $2, \"test\", \"t1\", \"select\");\nIF flag\nDO\n\tThread.sleep(5000);\nENDRULE\n",
+			"\nRULE test\nCLASS com.mysql.cj.NativeSession\nMETHOD execSQL\nHELPER org.chaos_mesh.byteman.helper.SQLHelper\nAT ENTRY\nBIND flag:boolean=matchDBTable(\"\", $2, \"test\", \"t1\", \"select\");\nIF flag\nDO\n\tThread.sleep(5000L);\nENDRULE\n",
 		},
 	}
 


### PR DESCRIPTION
## What problem does this PR solve?

Jvm latency experiment was failing for jdks version 19 and higher, as Byteman was not able to find matching method for Thread.sleep.

```
Rule.ensureTypeCheckedCompiled : error type checking rule systems.ajax.gradle.byteman.BytemanContuniousTest-test-latency-1769592601
org.jboss.byteman.rule.exception.TypeException: MethodExpression.typeCheck : invalid method sleep for target class java.lang.Thread file /tmp/rule.btm508946732 line 8
    at org.jboss.byteman.rule.expression.MethodExpression.findMethod(MethodExpression.java:331)
    at org.jboss.byteman.rule.expression.MethodExpression.typeCheck(MethodExpression.java:187)
    at org.jboss.byteman.rule.Action.typeCheck(Action.java:106)
    at org.jboss.byteman.rule.Rule.typeCheck(Rule.java:601)
    at org.jboss.byteman.rule.Rule.ensureTypeCheckedCompiled(Rule.java:529)
    at org.jboss.byteman.rule.Rule.execute(Rule.java:808)
    at org.jboss.byteman.rule.Rule.execute(Rule.java:789)
    at systems.ajax.gradle.byteman.BytemanContuniousTest.test(BytemanContuniousTest.kt)
    at systems.ajax.gradle.byteman.BytemanContuniousTestKt.main(BytemanContuniousTest.kt:15)
    at systems.ajax.gradle.byteman.BytemanContuniousTestKt.main(BytemanContuniousTest.kt)
```

Starting from java 19 new [overload of sleep method](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Thread.html#sleep(java.time.Duration)) was introduced which had Duration object as an argument.

Rule that chaos mesh provided was passing Integer value while Thread.sleep expects Long. After new overload was added, Byteman was not able to resolve which method should it use since there were no exact match by arguments.

## What's changed and how does it work?

The fix is to explicitly provide literal of type Long as Thread.sleep argument, allowing Byteman to unambiguously resolve correct overload of sleep method.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.7
- [ ] release-2.6

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
