### PR TITLE
ci: fix excessive GitHub workflow token permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:


### PR DESCRIPTION
Fixes #4865

## What problem does this PR solve?

This PR fixes GitHub Actions workflows with missing and excessive token permissions, addressing OpenSSF Scorecard Token-Permissions issues.

## What's changed and how it works?

- Added missing top-level `permissions` block to claude.yml with `contents: read`
- Added missing top-level `permissions` block to labeler.yml with `contents: read`

These changes ensure workflows explicitly declare their minimal required permissions, improving the security posture and compliance with OpenSSF best practices.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Manual test (verified YAML syntax and permissions structure)

### Side effects

- [ ] **Breaking backward compatibility**