### PR TITLE
fix: remove junit upload

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -240,13 +240,6 @@ jobs:
           name: profiling-${{ matrix.focus }}-k8s-${{ matrix.kubernetes-version }}
           path: ./output/chaos-mesh-profile
           retention-days: 7
-      - name: post run - upload junit test reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-junit-reports-${{ matrix.focus }}-k8s-${{ matrix.kubernetes-version }}
-          path: "**/*.xml"
-          retention-days: 7
 
   pass:
     needs:


### PR DESCRIPTION
## What problem does this PR solve?

In #2710, this was the first time the JUnit reporter was used, but in #4154, we removed it. Therefore, the old upload code is no longer valid.

## What's changed and how does it work?

Remove the dead code in `e2e_test.yml`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [x] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
