### PR TITLE
ci: pin localstack to 4.14.0

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -78,22 +78,20 @@ jobs:
           minikube image load ghcr.io/chaos-mesh/chaos-dashboard:latest
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Install Chaos Mesh
-        # Set DOCKER_API_VERSION to 1.41 to bypass https://github.com/chaos-mesh/chaos-mesh/pull/4154#issuecomment-1704442551.
         run: |
           helm install --wait --create-namespace chaos-mesh helm/chaos-mesh \
-            -n=chaos-mesh --set images.tag=latest --set chaosDaemon.env.DOCKER_API_VERSION=1.41 \
+            -n=chaos-mesh --set images.tag=latest \
             --set controllerManager.chaosdSecurityMode=false
           kubectl port-forward -n chaos-mesh svc/chaos-dashboard 2333:2333 &
 
-      - uses: actions/setup-python@v6
-      - name: Install localstack && aws client
+      - name: Install localstack
         run: |
-          helm repo add localstack-repo http://helm.localstack.cloud
-          helm upgrade --install localstack localstack-repo/localstack --version 0.6.14
-          pip install awscli
+          helm repo add localstack https://localstack.github.io/helm-charts
+          helm install localstack localstack/localstack --version 0.7.0 \
+            --set "extraEnvVars[0].name=LOCALSTACK_AUTH_TOKEN,extraEnvVars[0].value=${{ secrets.LOCALSTACK_AUTH_TOKEN }}"
           kubectl wait --timeout=60s --for=condition=ready --all pod
 
       - name: Run integration test

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -90,8 +90,9 @@ jobs:
       - name: Install localstack
         run: |
           helm repo add localstack https://localstack.github.io/helm-charts
-          helm install localstack localstack/localstack --version 0.7.0 \
-            --set "extraEnvVars[0].name=LOCALSTACK_AUTH_TOKEN,extraEnvVars[0].value=${{ secrets.LOCALSTACK_AUTH_TOKEN }}"
+          helm install localstack localstack/localstack \
+            --version 0.6.27 \
+            --set image.tag=4.14.0
           kubectl wait --timeout=60s --for=condition=ready --all pod
 
       - name: Run integration test

--- a/.github/workflows/upload_image.yml
+++ b/.github/workflows/upload_image.yml
@@ -59,7 +59,7 @@ jobs:
           else
             UI=0
           fi
-          # ${VAR,,} convert VAR to lower case
+
           make -B \
             TARGET_PLATFORM=$ARCH \
             IMAGE_TAG=$IMAGE_TAG-$ARCH \
@@ -74,8 +74,8 @@ jobs:
           ARCH: ${{ matrix.arch }}
           IMAGE: ${{ matrix.image }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        # ${VAR,,} convert VAR to lower case
         run: |
-          # ${VAR,,} convert VAR to lower case
           docker push ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE:$IMAGE_TAG-$ARCH
 
   upload-manifest:
@@ -102,8 +102,8 @@ jobs:
       - name: Create and push the manifest list
         env:
           IMAGE: ${{ matrix.image }}
+        # ${VAR,,} convert VAR to lower case
         run: |
-          # ${VAR,,} convert VAR to lower case
           docker buildx imagetools create -t ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE:$IMAGE_TAG \
             ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE:$IMAGE_TAG-amd64 \
             ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$IMAGE:$IMAGE_TAG-arm64


### PR DESCRIPTION
## What problem does this PR solve?

Close #4873

## What's changed and how does it work?

As the title says.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
