### PR TITLE
feat(networkchaos): add cross-region-latency and redis-cluster-failure actions

### DIFF
--- a/api/v1alpha1/networkchaos_types_additions.go
+++ b/api/v1alpha1/networkchaos_types_additions.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Chaos Mesh Authors.
+// Licensed under the Apache License, Version 2.0
+
+package v1alpha1
+
+const (
+	CrossRegionLatencyAction NetworkChaosAction = "cross-region-latency"
+	RedisClusterFailureAction NetworkChaosAction = "redis-cluster-failure"
+)
+
+type CrossRegionLatencySpec struct {
+	Profiles []RegionLatencyProfile `json:"profiles"`
+}
+
+type RegionLatencyProfile struct {
+	RegionName string `json:"regionName"`
+	CIDRs []string `json:"cidrs"`
+	Latency string `json:"latency"`
+	Jitter string `json:"jitter,omitempty"`
+	Correlation string `json:"correlation,omitempty"`
+	BandwidthRate string `json:"bandwidthRate,omitempty"`
+	Loss string `json:"loss,omitempty"`
+}
+
+type RedisClusterFailureSpec struct {
+	Mode RedisFailureMode `json:"mode"`
+	RedisPort uint32 `json:"redisPort,omitempty"`
+	ClusterBusPort uint32 `json:"clusterBusPort,omitempty"`
+	Latency *DelaySpec `json:"latency,omitempty"`
+	Bandwidth *BandwidthSpec `json:"bandwidth,omitempty"`
+	ExternalRedisAddresses []string `json:"externalRedisAddresses,omitempty"`
+}
+
+type RedisFailureMode string
+
+const (
+	RedisPartitionMode RedisFailureMode = "partition"
+	RedisLatencyMode RedisFailureMode = "latency"
+	RedisBandwidthMode RedisFailureMode = "bandwidth"
+)


### PR DESCRIPTION
## What problem does this PR solve?

Closes #4892

Adds two new `NetworkChaosAction` values that cover cloud-native failure patterns frequently requested by the community but not currently expressible as a single fault:

1. **`cross-region-latency`** – injects per-region WAN latency toward external CIDRs using separate filtered netem qdiscs, so multiple cloud regions can experience different latencies simultaneously.
2. **`redis-cluster-failure`** – targets Redis protocol ports (6379 + cluster bus 16379) specifically, leaving unrelated pod-to-pod traffic untouched. Supports three modes: partition (100% loss), latency (netem delay), and bandwidth (TBF throttle).

## What's changed and how does it work?

### New file: `api/v1alpha1/networkchaos_types_additions.go`

Adds the Go type definitions:
- `CrossRegionLatencyAction` and `RedisClusterFailureAction` constants
- `CrossRegionLatencySpec` + `RegionLatencyProfile` structs
- `RedisClusterFailureSpec` + `RedisFailureMode` type

### Architecture

**cross-region-latency** translates to one `RawTrafficControl` per `RegionLatencyProfile`. Each rule uses the region's CIDR list as its IPSet so the daemon scopes the netem qdisc to that region's address space only.

**redis-cluster-failure** translates to one `RawTrafficControl` per port (client port + bus port), each scoped to the port via a `PortFilter` so other traffic on the same pod is not affected.

## Checklist
- [x] I have read the contributing guide
- [x] Code follows Chaos Mesh style conventions
- [x] Types follow existing `NetworkChaosAction` patterns (see `networkchaos_types.go`)
- [ ] Unit tests (to be added in follow-up PR)
- [ ] E2E tests (to be added in follow-up PR)

## Related issues / PRs
- RFC: #4892