### PR TITLE
Partial crd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
+- Add `ENABLED_COLLECTORS` env var and `dashboard.enabledCollectors` Helm value to gate dashboard collectors and API handlers for partial CRD installations [#4874](https://github.com/chaos-mesh/chaos-mesh/issues/4874)
 - Resource profiles for chaos-daemon with customizable overrides [#4806](https://github.com/chaos-mesh/chaos-mesh/pull/4806)
 - Add a toggle for displaying absolute/relative event time in the Dashboard UI [#4816](https://github.com/chaos-mesh/chaos-mesh/pull/4816)
 
@@ -44,6 +45,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
+- Fix controller-manager failing to register sub-controllers when ENABLED_CONTROLLERS is set to a subset of chaos types [#4874](https://github.com/chaos-mesh/chaos-mesh/issues/4874)
 
 ### Security
 

--- a/controllers/common/condition/step.go
+++ b/controllers/common/condition/step.go
@@ -24,7 +24,7 @@ import (
 
 func Step(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-condition")
-	name := ctx.Object.Name + "-condition"
+	name := ctx.Object.Name
 	if !config.ShouldSpawnController(name) {
 		return nil
 	}

--- a/controllers/common/desiredphase/step.go
+++ b/controllers/common/desiredphase/step.go
@@ -24,7 +24,7 @@ import (
 
 func Step(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-desiredphase")
-	name := ctx.Object.Name + "-desiredphase"
+	name := ctx.Object.Name
 	if !config.ShouldSpawnController(name) {
 		return nil
 	}

--- a/controllers/common/finalizers/step.go
+++ b/controllers/common/finalizers/step.go
@@ -24,7 +24,7 @@ import (
 
 func InitStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-initFinalizers")
-	name := ctx.Object.Name + "-initFinalizers"
+	name := ctx.Object.Name
 	if !config.ShouldSpawnController(name) {
 		return nil
 	}
@@ -43,7 +43,7 @@ func InitStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 
 func CleanStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-cleanFinalizers")
-	name := ctx.Object.Name + "-cleanFinalizers"
+	name := ctx.Object.Name
 	if !config.ShouldSpawnController(name) {
 		return nil
 	}

--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -64,9 +64,9 @@ func Bootstrap(params Params) error {
 
 	setupLog := logger.WithName("setup-common")
 	for _, pair := range pairs {
-		name := pair.Name + "-records"
+		name := pair.Name
 		if !config.ShouldSpawnController(name) {
-			return nil
+			continue
 		}
 
 		setupLog.Info("setting up controller", "resource-name", pair.Name)

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -102,6 +102,8 @@ spec:
               value: "{{ tpl .Values.dashboard.rootUrl . }}"
             - name: ENABLE_PROFILING
               value: "{{ .Values.enableProfiling }}"
+            - name: ENABLED_COLLECTORS
+              value: {{ .Values.dashboard.enabledCollectors | join "," | quote }}
             {{- if .Values.dashboard.databaseSecretName }}
             - name: DATABASE_DATASOURCE
               valueFrom:

--- a/helm/chaos-mesh/values.schema.json
+++ b/helm/chaos-mesh/values.schema.json
@@ -536,6 +536,12 @@
                 "securityContext": {
                     "type": "object"
                 },
+                "enabledCollectors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "securityMode": {
                     "type": "boolean"
                 },

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -291,6 +291,10 @@ dashboard:
     tag: ""
   # Image pull policy
   imagePullPolicy: IfNotPresent
+  # A list of collector types to enable. "*" enables all collectors by default.
+  # Use lowercase chaos kind names (e.g., podchaos, networkchaos) or schedule/workflow.
+  enabledCollectors:
+    - "*"
   # securityMode requires user to provide credentials on Chaos Dashboard, instead of using chaos-dashboard service account
   securityMode: true
   # Enable GCP Authentication Integration, see: https://chaos-mesh.org/docs/gcp-authentication/ for more details

--- a/pkg/config/dashboard.go
+++ b/pkg/config/dashboard.go
@@ -16,6 +16,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -54,6 +55,10 @@ type ChaosDashboardConfig struct {
 	// After v2.5, the DNS server is created by default.
 	DNSServerCreate bool   `envconfig:"DNS_SERVER_CREATE" default:"true" json:"dns_server_create"`
 	Version         string `json:"version"`
+
+	// EnabledCollectors is a list of chaos types to collect.
+	// "*" enables all collectors by default.
+	EnabledCollectors []string `envconfig:"ENABLED_COLLECTORS" default:"*"`
 
 	// The QPS config for kubernetes client
 	QPS float32 `envconfig:"QPS" default:"200" json:"-"`
@@ -128,6 +133,18 @@ func (config *TTLConfigWithStringTime) Parse() (*TTLConfig, error) {
 		ScheduleTTL:   scheduleTTL,
 		WorkflowTTL:   workflowTTL,
 	}, nil
+}
+
+// ShouldCollect returns true if the given kind name is enabled for collection.
+// The name comparison is case-insensitive.
+func (c *ChaosDashboardConfig) ShouldCollect(name string) bool {
+	name = strings.ToLower(name)
+	for _, e := range c.EnabledCollectors {
+		if e == "*" || strings.ToLower(e) == name {
+			return true
+		}
+	}
+	return false
 }
 
 // GetChaosDashboardEnv gets all env variables related to dashboard.

--- a/pkg/config/dashboard.go
+++ b/pkg/config/dashboard.go
@@ -58,7 +58,7 @@ type ChaosDashboardConfig struct {
 
 	// EnabledCollectors is a list of chaos types to collect.
 	// "*" enables all collectors by default.
-	EnabledCollectors []string `envconfig:"ENABLED_COLLECTORS" default:"*"`
+	EnabledCollectors []string `envconfig:"ENABLED_COLLECTORS" default:"*" json:"-"`
 
 	// The QPS config for kubernetes client
 	QPS float32 `envconfig:"QPS" default:"200" json:"-"`

--- a/pkg/config/dashboard_test.go
+++ b/pkg/config/dashboard_test.go
@@ -53,6 +53,50 @@ func TestChaosDashboardConfig(t *testing.T) {
 	}
 }
 
+func TestShouldCollect(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  []string
+		query    string
+		expected bool
+	}{
+		{"wildcard matches anything", []string{"*"}, "PodChaos", true},
+		{"wildcard matches lowercase", []string{"*"}, "podchaos", true},
+		{"exact match", []string{"PodChaos", "NetworkChaos"}, "PodChaos", true},
+		{"case insensitive match", []string{"PodChaos", "NetworkChaos"}, "podchaos", true},
+		{"case insensitive enabled", []string{"podchaos", "networkchaos"}, "PodChaos", true},
+		{"no match", []string{"PodChaos", "NetworkChaos"}, "TimeChaos", false},
+		{"empty list", []string{}, "PodChaos", false},
+		{"schedule", []string{"schedule"}, "Schedule", true},
+		{"workflow not enabled", []string{"PodChaos"}, "workflow", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &ChaosDashboardConfig{EnabledCollectors: tt.enabled}
+			if got := config.ShouldCollect(tt.query); got != tt.expected {
+				t.Errorf("ShouldCollect(%q) = %v, want %v (enabled: %v)", tt.query, got, tt.expected, tt.enabled)
+			}
+		})
+	}
+}
+
+func TestEnabledCollectorsDefault(t *testing.T) {
+	config := ChaosDashboardConfig{}
+	err := envconfig.Process("", &config)
+	if err != nil {
+		t.Fatal("Error parsing empty ChaosDashboardConfig", err)
+	}
+
+	if len(config.EnabledCollectors) != 1 || config.EnabledCollectors[0] != "*" {
+		t.Errorf("EnabledCollectors default should be [\"*\"], got %v", config.EnabledCollectors)
+	}
+
+	if !config.ShouldCollect("PodChaos") {
+		t.Error("default config should collect all types")
+	}
+}
+
 func TestTTLConfigWithStringTime(t *testing.T) {
 	config := TTLConfigWithStringTime{}
 	err := envconfig.Process("", &config)

--- a/pkg/dashboard/apiserver/common/common.go
+++ b/pkg/dashboard/apiserver/common/common.go
@@ -254,6 +254,9 @@ func (s *Service) getKinds(c *gin.Context) {
 
 	allKinds := v1alpha1.AllKinds()
 	for name := range allKinds {
+		if !s.conf.ShouldCollect(name) {
+			continue
+		}
 		kinds = append(kinds, name)
 	}
 

--- a/pkg/dashboard/apiserver/experiment/experiment.go
+++ b/pkg/dashboard/apiserver/experiment/experiment.go
@@ -118,6 +118,9 @@ func (s *Service) list(c *gin.Context) {
 		if kind != "" && k != kind {
 			continue
 		}
+		if !s.config.ShouldCollect(k) {
+			continue
+		}
 
 		list := chaosKind.SpawnList()
 		if err := kubeCli.List(context.Background(), list, &client.ListOptions{Namespace: ns}); err != nil {
@@ -581,7 +584,10 @@ func (s *Service) state(c *gin.Context) {
 	var listOptions []client.ListOption
 	listOptions = append(listOptions, &client.ListOptions{Namespace: ns})
 
-	for _, chaosKind := range v1alpha1.AllKinds() {
+	for k, chaosKind := range v1alpha1.AllKinds() {
+		if !s.config.ShouldCollect(k) {
+			continue
+		}
 		list := chaosKind.SpawnList()
 
 		g.Go(func() error {

--- a/pkg/dashboard/apiserver/schedule/schedule.go
+++ b/pkg/dashboard/apiserver/schedule/schedule.go
@@ -90,6 +90,11 @@ func Register(r *gin.RouterGroup, s *Service) {
 // @Failure 500 {object} u.APIError
 // @Router /schedules [get]
 func (s *Service) list(c *gin.Context) {
+	if !s.config.ShouldCollect("schedule") {
+		c.JSON(http.StatusOK, []*apiservertypes.Schedule{})
+		return
+	}
+
 	kubeCli, err := clientpool.ExtractTokenAndGetClient(c.Request.Header)
 	if err != nil {
 		u.SetAPIError(c, u.ErrBadRequest.WrapWithNoMessage(err))

--- a/pkg/dashboard/apiserver/workflow/workflow.go
+++ b/pkg/dashboard/apiserver/workflow/workflow.go
@@ -131,6 +131,11 @@ func (it *Service) parseHTTPTask(c *gin.Context) {
 // @Router /workflows [get]
 // @Failure 500 {object} utils.APIError
 func (it *Service) listWorkflows(c *gin.Context) {
+	if !it.conf.ShouldCollect("workflow") {
+		c.JSON(http.StatusOK, []core.WorkflowMeta{})
+		return
+	}
+
 	namespace := c.Query("namespace")
 	if len(namespace) == 0 && !it.conf.ClusterScoped &&
 		len(it.conf.TargetNamespace) != 0 {

--- a/pkg/dashboard/collector/server.go
+++ b/pkg/dashboard/collector/server.go
@@ -17,20 +17,19 @@ package collector
 
 import (
 	"context"
-	"net"
-	"os"
-	"strconv"
-
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"net"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"strconv"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/pkg/clientpool"
@@ -119,6 +118,10 @@ func NewServer(
 	}
 
 	for kind, chaosKind := range v1alpha1.AllKinds() {
+		if !conf.ShouldCollect(kind) {
+			logger.Info("skipping collector (not enabled)", "collector", kind)
+			continue
+		}
 		if err = (&ChaosCollector{
 			Client:  s.Manager.GetClient(),
 			Log:     logger.WithName(kind),
@@ -130,13 +133,15 @@ func NewServer(
 		}
 	}
 
-	if err = (&ScheduleCollector{
-		Client:  s.Manager.GetClient(),
-		Log:     logger.WithName("schedule-collector").WithName(v1alpha1.KindSchedule),
-		archive: scheduleArchive,
-	}).Setup(s.Manager, &v1alpha1.Schedule{}); err != nil {
-		logger.Error(err, "unable to create collector", "collector", v1alpha1.KindSchedule)
-		os.Exit(1)
+	if conf.ShouldCollect("schedule") {
+		if err = (&ScheduleCollector{
+			Client:  s.Manager.GetClient(),
+			Log:     logger.WithName("schedule-collector").WithName(v1alpha1.KindSchedule),
+			archive: scheduleArchive,
+		}).Setup(s.Manager, &v1alpha1.Schedule{}); err != nil {
+			logger.Error(err, "unable to create collector", "collector", v1alpha1.KindSchedule)
+			os.Exit(1)
+		}
 	}
 
 	if err = (&EventCollector{
@@ -148,13 +153,15 @@ func NewServer(
 		os.Exit(1)
 	}
 
-	if err = (&WorkflowCollector{
-		kubeClient: s.Manager.GetClient(),
-		Log:        logger.WithName("workflow-collector").WithName(v1alpha1.KindWorkflow),
-		store:      workflowStore,
-	}).Setup(s.Manager, &v1alpha1.Workflow{}); err != nil {
-		logger.Error(err, "unable to create collector", "collector", v1alpha1.KindWorkflow)
-		os.Exit(1)
+	if conf.ShouldCollect("workflow") {
+		if err = (&WorkflowCollector{
+			kubeClient: s.Manager.GetClient(),
+			Log:        logger.WithName("workflow-collector").WithName(v1alpha1.KindWorkflow),
+			store:      workflowStore,
+		}).Setup(s.Manager, &v1alpha1.Workflow{}); err != nil {
+			logger.Error(err, "unable to create collector", "collector", v1alpha1.KindWorkflow)
+			os.Exit(1)
+		}
 	}
 
 	return s, s.Manager.GetClient(), s.Manager.GetAPIReader(), s.Manager.GetScheme()


### PR DESCRIPTION
## What problem does this PR solve?

This PR adds the ability to configure which CRDs the controllers and dashboard watch. This allows cluster operator to only install a subset of the Chaos Mesh CRDs.

Fixes #4874

## What's changed and how does it work?

[!IMPORTANT]  These changes are fully backward compatible.

The controller and dashboard look at an optional environment variable to know which CRDs they should be watching.

The PR is split into multiple commits to ease reviewing:

1. Small bug fix to the controller
2. Same change for the dashboard
3. Dashboard API returns empty lists if a CRD is not enabled
4. Helm chart changes
5. Changelog updated



## Related changes

- [x] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Checklist

Ran everything locally on a KinD cluster and manually verified that both controller and dashboards are no longer erroring when only a subset of CRDs are installed.

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [x] Manual test

I'd be happy to add E2E tests with the proper guidance.

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
