### PR TITLE
chore: bump chaosd to v1.4.1

### DIFF
--- a/test/integration_test/physical_machine/run.sh
+++ b/test/integration_test/physical_machine/run.sh
@@ -38,7 +38,7 @@ cd $cur
 echo "download and deploy chaosd"
 localIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | head -1`
 
-CHAOSD_VERSION=v1.1.0
+CHAOSD_VERSION=v1.4.1
 curl -fsSL -o chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz https://mirrors.chaos-mesh.org/chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz
 tar zxvf chaosd-${CHAOSD_VERSION}-linux-amd64.tar.gz
 ./chaosd-${CHAOSD_VERSION}-linux-amd64/chaosd server --port 31768 > chaosd.log 2>&1 &


### PR DESCRIPTION
## Summary
- Bump `CHAOSD_VERSION` in `test/integration_test/physical_machine/run.sh` from `v1.1.0` to `v1.4.1`.
- chaosd v1.4.1 release: https://github.com/chaos-mesh/chaosd/releases/tag/v1.4.1

## Test plan
- [ ] Physical machine integration test passes with chaosd v1.4.1