### PR TITLE
chore: upgrade base image packages during build

### DIFF
--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -10,7 +10,7 @@ ARG HTTP_PROXY
 ENV http_proxy=$HTTP_PROXY
 ENV https_proxy=$HTTPS_PROXY
 
-RUN apt update && apt install -y build-essential curl git pkg-config libfuse-dev fuse
+RUN apt update && apt upgrade -y && apt install -y build-essential curl git pkg-config libfuse-dev fuse
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt install -y nodejs
 RUN rm -rf /var/lib/apt/lists/*
 RUN npm install -g pnpm@9

--- a/images/chaos-dlv/Dockerfile
+++ b/images/chaos-dlv/Dockerfile
@@ -6,6 +6,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 FROM debian:bookworm-slim
 
 RUN apt update && \
+    apt upgrade -y && \
     apt install procps -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/chaos-mesh/Dockerfile
+++ b/images/chaos-mesh/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.23
+FROM alpine:3
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
 
-RUN apk add tzdata --no-cache
+RUN apk upgrade --no-cache && apk add --no-cache tzdata
 
 COPY bin/chaos-controller-manager /usr/local/bin/chaos-controller-manager

--- a/images/dev-env/Dockerfile
+++ b/images/dev-env/Dockerfile
@@ -28,6 +28,7 @@ ENV http_proxy=$HTTP_PROXY
 ENV https_proxy=$HTTPS_PROXY
 
 RUN apt update && \
+    apt upgrade -y && \
     apt install unzip git build-essential curl musl musl-dev ebtables -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Recent image vulnerability scans rated several published images D–F, with most fixable CVEs coming from outdated OS packages in the base image. Adding \`apk upgrade\` / \`apt upgrade\` during build closes the gap between when upstream ships a security patch and when the base image gets retagged.

### Changes
- \`images/chaos-mesh/Dockerfile\`: switch from \`alpine:3.23\` to \`alpine:3\` floating tag, add \`apk upgrade --no-cache\`
- \`images/chaos-dlv/Dockerfile\`: add \`apt upgrade -y\`
- \`images/build-env/Dockerfile\`: add \`apt upgrade -y\`
- \`images/dev-env/Dockerfile\`: add \`apt upgrade -y\`

\`images/chaos-daemon/Dockerfile\` and \`images/chaos-dashboard/Dockerfile\` already run \`apt upgrade -y\` — unchanged.

### Out of scope
- \`images/chaos-kernel/Dockerfile\` still on \`ubuntu:bionic\` (EOL). Needs a separate base image migration.
- Bundled pinned binaries (memStress, toda, nsexec, chaos-tproxy, byteman) — tracked separately.

## Test plan
- [ ] CI image builds pass for all modified Dockerfiles
- [ ] Re-run vulnerability scan on rebuilt images and confirm reduced CVE count