### PR TITLE
test(chaosdaemon): add unit tests for pkg/chaosdaemon/graph with 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
+- Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Resource profiles for chaos-daemon with customizable overrides [#4806](https://github.com/chaos-mesh/chaos-mesh/pull/4806)
 - Add a toggle for displaying absolute/relative event time in the Dashboard UI [#4816](https://github.com/chaos-mesh/chaos-mesh/pull/4816)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
-- Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Resource profiles for chaos-daemon with customizable overrides [#4806](https://github.com/chaos-mesh/chaos-mesh/pull/4806)
 - Add a toggle for displaying absolute/relative event time in the Dashboard UI [#4816](https://github.com/chaos-mesh/chaos-mesh/pull/4816)
+- Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 
 ### Changed
 

--- a/pkg/chaosdaemon/graph/graph_test.go
+++ b/pkg/chaosdaemon/graph/graph_test.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGraph(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Graph Suite")
+}
+
+var _ = Describe("graph", func() {
+	Context("NewGraph", func() {
+		It("should return a non-nil graph with empty head map", func() {
+			g := NewGraph()
+			Expect(g).NotTo(BeNil())
+			Expect(g.head).NotTo(BeNil())
+			Expect(g.head).To(BeEmpty())
+		})
+	})
+
+	Context("Insert", func() {
+		It("should insert an edge with nil Next on first insert", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+
+			edge := g.head[1]
+			Expect(edge).NotTo(BeNil())
+			Expect(edge.Source).To(Equal(uint32(1)))
+			Expect(edge.Target).To(Equal(uint32(2)))
+			Expect(edge.Next).To(BeNil())
+		})
+
+		It("should prepend and link Next on second insert to same source", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+			g.Insert(1, 3)
+
+			edge := g.head[1]
+			Expect(edge.Target).To(Equal(uint32(3)))
+			Expect(edge.Next).NotTo(BeNil())
+			Expect(edge.Next.Target).To(Equal(uint32(2)))
+			Expect(edge.Next.Next).To(BeNil())
+		})
+
+		It("should keep inserts to different sources independent", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+			g.Insert(3, 4)
+
+			Expect(g.head[1].Target).To(Equal(uint32(2)))
+			Expect(g.head[3].Target).To(Equal(uint32(4)))
+		})
+	})
+
+	Context("IterFrom", func() {
+		It("should return the head edge for an existing source", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+
+			edge := g.IterFrom(1)
+			Expect(edge).NotTo(BeNil())
+			Expect(edge.Target).To(Equal(uint32(2)))
+		})
+
+		It("should return nil for a non-existing source", func() {
+			g := NewGraph()
+
+			edge := g.IterFrom(99)
+			Expect(edge).To(BeNil())
+		})
+	})
+
+	Context("Flatten", func() {
+		logger := logr.Discard()
+
+		It("should return empty slice when source has no edges", func() {
+			g := NewGraph()
+			result := g.Flatten(1, logger)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should return the single child when source has one edge", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+
+			result := g.Flatten(1, logger)
+			Expect(result).To(ConsistOf(uint32(2)))
+		})
+
+		It("should return all direct children when source has multiple edges", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+			g.Insert(1, 3)
+
+			result := g.Flatten(1, logger)
+			Expect(result).To(ConsistOf(uint32(2), uint32(3)))
+		})
+
+		It("should include grandchildren in a multi-level tree", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+			g.Insert(2, 4)
+			g.Insert(2, 5)
+
+			result := g.Flatten(1, logger)
+			Expect(result).To(ConsistOf(uint32(2), uint32(4), uint32(5)))
+		})
+
+		It("should include all descendants in a deep chain", func() {
+			g := NewGraph()
+			g.Insert(1, 2)
+			g.Insert(2, 3)
+			g.Insert(3, 4)
+
+			result := g.Flatten(1, logger)
+			Expect(result).To(ConsistOf(uint32(2), uint32(3), uint32(4)))
+		})
+	})
+})

--- a/pkg/chaosdaemon/graph/graph_test.go
+++ b/pkg/chaosdaemon/graph/graph_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Chaos Mesh Authors.
+// Copyright 2026 Chaos Mesh Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What problem does this PR solve?

Fixed #4905

## What's changed and how does it work?

The graph package builds directed process trees used by GetChildProcesses in pkg/chaosdaemon/util to track all descendant PIDs for chaos injection. Despite being production-critical, it had no unit tests.

Added Ginkgo v2 + Gomega tests covering all four exported functions:
- NewGraph: verifies empty map initialisation
- Insert: first insert (nil Next), prepend to existing source, independent sources
- IterFrom: existing and non-existing source lookup
- Flatten: empty source, single child, multiple siblings, multi-level tree, and deep chain — ensuring both the recursive non-empty-children path and the immediate-nil (break) path are exercised

Achieves 100% statement coverage on graph.go.

<img width="1521" height="520" alt="image" src="https://github.com/user-attachments/assets/c704d1a7-5bdf-447e-85a4-ba6c25eae0b9" />

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
