### PR TITLE
test: standardize custom zap logger usage in integration tests

### DIFF
--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -28,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	chaoslog "github.com/chaos-mesh/chaos-mesh/pkg/log"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -46,7 +47,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func(ctx SpecContext) {
 
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(chaoslog.NewZapLoggerWithWriter(GinkgoWriter))
 
 	By("bootstrapping test environment")
 	t := true

--- a/controllers/statuscheck/suite_test.go
+++ b/controllers/statuscheck/suite_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
@@ -61,7 +60,7 @@ func TestStatusCheck(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx SpecContext) {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(log.NewZapLoggerWithWriter(GinkgoWriter))
 	By("bootstrapping test environment")
 	t := true
 	if os.Getenv("USE_EXISTING_CLUSTER") == "true" {


### PR DESCRIPTION
## What problem does this PR solve?

This PR addresses leftover tasks from #2892 by standardizing the logger initialization in the integration test suites. Instead of instantiating loggers inline via `controller-runtime`'s `zap.New(...)`, this ensures the test suites uniformly use Chaos Mesh's custom `NewZapLoggerWithWriter(GinkgoWriter)` constructor from `pkg/log`.
Resolves #2892

## What's changed and how does it work?

- Updates `api/v1alpha1/suite_test.go` to initialize the logger using `chaoslog.NewZapLoggerWithWriter(GinkgoWriter)`.
- Aliases the `github.com/chaos-mesh/chaos-mesh/pkg/log` import to `chaoslog` in order to safely inject the logger without colliding with the existing package-level `var log` defined in `api/v1alpha1/common_types.go`.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
