### PR TITLE
test(e2e): replace deprecated wait.PollImmediate with wait.PollUntilContextTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade e2e k8s versions to 1.35.2, 1.34.5 and 1.33.9 [#4872](https://github.com/chaos-mesh/chaos-mesh/pull/4872)
 - Replace go-ethereum jsonrpc with creachadair/jrpc2 [#4859](https://github.com/chaos-mesh/chaos-mesh/pull/4859)
 - Replace fmt.Errorf with pkg/errors for consistent error handling [#4845](https://github.com/chaos-mesh/chaos-mesh/pull/4845)
+- Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade e2e k8s versions to 1.35.2, 1.34.5 and 1.33.9 [#4872](https://github.com/chaos-mesh/chaos-mesh/pull/4872)
 - Replace go-ethereum jsonrpc with creachadair/jrpc2 [#4859](https://github.com/chaos-mesh/chaos-mesh/pull/4859)
 - Replace fmt.Errorf with pkg/errors for consistent error handling [#4845](https://github.com/chaos-mesh/chaos-mesh/pull/4845)
-- Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests
+- Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4910](https://github.com/chaos-mesh/chaos-mesh/pull/4910)
 
 ### Deprecated
 

--- a/coverage.out
+++ b/coverage.out
@@ -1,0 +1,9 @@
+mode: set
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:35.24,39.2 1 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:42.54,49.2 2 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:52.47,54.2 1 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:57.66,61.6 3 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:61.6,62.21 1 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:62.21,63.9 1 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:66.3,70.25 4 1
+github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:73.2,74.17 2 1

--- a/coverage.out
+++ b/coverage.out
@@ -1,9 +1,0 @@
-mode: set
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:35.24,39.2 1 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:42.54,49.2 2 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:52.47,54.2 1 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:57.66,61.6 3 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:61.6,62.21 1 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:62.21,63.9 1 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:66.3,70.25 4 1
-github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/graph/graph.go:73.2,74.17 2 1

--- a/e2e-test/action.go
+++ b/e2e-test/action.go
@@ -150,14 +150,14 @@ func (oa *operatorAction) UpgradeOperator(info *OperatorConfig) error {
 	if err != nil {
 		return err
 	}
-	return e2eutil.WaitForAPIServicesAvailable(oa.aggrCli, labels.Everything())
+	return e2eutil.WaitForAPIServicesAvailable(context.Background(), oa.aggrCli, labels.Everything())
 }
 
 func (oa *operatorAction) InstallCRD(info *OperatorConfig) error {
 	klog.Infof("deploying chaos-mesh crd :%v", info.ReleaseName)
 	oa.runKubectlOrDie("create", "-f", oa.manifestPath("e2e/crd.yaml"), "--validate=false")
 
-	e2eutil.WaitForCRDsEstablished(oa.apiExtCli, labels.Everything())
+	e2eutil.WaitForCRDsEstablished(context.Background(), oa.apiExtCli, labels.Everything())
 	// workaround for https://github.com/kubernetes/kubernetes/issues/65517
 	klog.Infof("force sync kubectl cache")
 	cmdArgs := []string{"sh", "-c", "rm -rf ~/.kube/cache ~/.kube/http-cache"}
@@ -219,7 +219,7 @@ func (oa *operatorAction) restartComponent(info *OperatorConfig, prefix string) 
 	if err != nil {
 		return err
 	}
-	return e2eutil.WaitForAPIServicesAvailable(oa.aggrCli, labels.Everything())
+	return e2eutil.WaitForAPIServicesAvailable(context.Background(), oa.aggrCli, labels.Everything())
 }
 
 func (oa *operatorAction) CleanCRDOrDie() {

--- a/e2e-test/e2e/chaos/httpchaos/http_abort.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_abort.go
@@ -73,7 +73,7 @@ func TestcaseHttpAbortThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP abort")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied
@@ -91,7 +91,7 @@ func TestcaseHttpAbortThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered
@@ -151,7 +151,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -206,7 +206,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered
@@ -243,7 +243,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied

--- a/e2e-test/e2e/chaos/httpchaos/http_delay.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_delay.go
@@ -74,7 +74,7 @@ func TestcaseHttpDelayDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP delay")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, dur, err := getPodHttpDelay(c, port)
 		if err != nil {
 			return false, err
@@ -98,7 +98,7 @@ func TestcaseHttpDelayDurationForATimeThenRecover(
 	time.Sleep(time.Second * 5)
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, dur, err := getPodHttpDelay(c, port)
 		if err != nil {
 			return false, err
@@ -162,7 +162,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -219,7 +219,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, dur, _ := getPodHttpDelay(c, port)
 
 		s := dur.Seconds()
@@ -259,7 +259,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, dur, _ := getPodHttpDelay(c, port)
 
 		s := dur.Seconds()

--- a/e2e-test/e2e/chaos/httpchaos/http_graceful_shutdown.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_graceful_shutdown.go
@@ -78,7 +78,7 @@ func TestcaseHttpGracefulAbortShutdown(
 	}()
 
 	By("waiting for assertion HTTP abort")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied
@@ -98,7 +98,7 @@ func TestcaseHttpGracefulAbortShutdown(
 	framework.ExpectNoError(err, "failed to restart chaos daemon")
 
 	By("waiting for assertion chaos recovered")
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered

--- a/e2e-test/e2e/chaos/httpchaos/http_patch.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_patch.go
@@ -51,7 +51,7 @@ func TestcaseHttpPatchThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -115,7 +115,7 @@ func TestcaseHttpPatchThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP patch")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -144,7 +144,7 @@ func TestcaseHttpPatchThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -184,7 +184,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -252,7 +252,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -318,7 +318,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io patch still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -367,7 +367,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -49,7 +49,7 @@ func TestcaseHttpReplaceThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -105,7 +105,7 @@ func TestcaseHttpReplaceThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP replace")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -134,7 +134,7 @@ func TestcaseHttpReplaceThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -173,7 +173,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -234,7 +234,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -300,7 +300,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io replace still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -348,7 +348,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -392,7 +392,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -450,7 +450,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP replace")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -479,7 +479,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -519,7 +519,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -582,7 +582,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -648,7 +648,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io replace still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -696,7 +696,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/httpchaos/http_tls.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_tls.go
@@ -177,7 +177,7 @@ func TestcaseHttpTLSThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for HTTP pong")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		err := util.WaitHTTPE2EHelperTLSReady(*c.C, c.IP, tlsPort)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/iochaos/io_delay.go
+++ b/e2e-test/e2e/chaos/iochaos/io_delay.go
@@ -74,7 +74,7 @@ func TestcaseIODelayDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos error")
 	By("waiting for assertion IO delay")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 		second := dur.Seconds()
 		klog.Infof("get io delay %fs", second)
@@ -92,7 +92,7 @@ func TestcaseIODelayDurationForATimeThenRecover(
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 		second := dur.Seconds()
 		klog.Infof("get io delay %fs", second)
@@ -151,7 +151,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	}
 
 	By("waiting for assertion io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
@@ -208,7 +208,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -248,7 +248,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -305,7 +305,7 @@ func TestcaseIODelayWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos error")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -322,7 +322,7 @@ func TestcaseIODelayWithSpecifiedContainer(
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -72,7 +72,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -86,7 +86,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {
@@ -141,7 +141,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -174,7 +174,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {
@@ -199,7 +199,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -256,7 +256,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -270,7 +270,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {

--- a/e2e-test/e2e/chaos/iochaos/io_graceful_shutdown.go
+++ b/e2e-test/e2e/chaos/iochaos/io_graceful_shutdown.go
@@ -79,7 +79,7 @@ func TestcaseIOErrorGracefulShutdown(
 		framework.ExpectNoError(err, "delete io chaos")
 	}()
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -97,7 +97,7 @@ func TestcaseIOErrorGracefulShutdown(
 	framework.ExpectNoError(err, "failed to restart chaos daemon")
 
 	By("waiting for assertion IO error recovery")
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// recovered
 		if err == nil {

--- a/e2e-test/e2e/chaos/iochaos/io_mistake.go
+++ b/e2e-test/e2e/chaos/iochaos/io_mistake.go
@@ -77,7 +77,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -93,7 +93,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -153,7 +153,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -188,7 +188,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -215,7 +215,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -277,7 +277,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -293,7 +293,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil

--- a/e2e-test/e2e/chaos/podchaos/container_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/container_kill.go
@@ -73,7 +73,7 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	err = cli.Create(ctx, containerKillChaos)
 	framework.ExpectNoError(err, "create container kill chaos error")
 
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",
@@ -100,7 +100,7 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	framework.ExpectNoError(err, "failed to delete container kill chaos")
 
 	By("success to perform container kill")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",

--- a/e2e-test/e2e/chaos/timechaos/time_skew.go
+++ b/e2e-test/e2e/chaos/timechaos/time_skew.go
@@ -76,7 +76,7 @@ func TestcaseTimeSkewOnceThenRecover(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -148,7 +148,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -211,7 +211,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 
 	// timechaos is running again, we want to check pod
 	// whether time is earlier than init time,
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -268,7 +268,7 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodChildProcessTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {

--- a/e2e-test/e2e/util/util.go
+++ b/e2e-test/e2e/util/util.go
@@ -39,7 +39,7 @@ import (
 )
 
 // WaitForAPIServicesAvailable waits for apiservices to be available
-func WaitForAPIServicesAvailable(client aggregatorclientset.Interface, selector labels.Selector) error {
+func WaitForAPIServicesAvailable(ctx context.Context, client aggregatorclientset.Interface, selector labels.Selector) error {
 	isAvailable := func(status apiregistrationv1.APIServiceStatus) bool {
 		if status.Conditions == nil {
 			return false
@@ -51,9 +51,9 @@ func WaitForAPIServicesAvailable(client aggregatorclientset.Interface, selector 
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		apiServiceList, err := client.ApiregistrationV1().APIServices().List(
-			context.TODO(),
+			ctx,
 			metav1.ListOptions{
 				LabelSelector: selector.String(),
 			})
@@ -74,7 +74,7 @@ func WaitForAPIServicesAvailable(client aggregatorclientset.Interface, selector 
 }
 
 // WaitForCRDsEstablished waits for all CRDs to be established
-func WaitForCRDsEstablished(client apiextensionsclientset.Interface, selector labels.Selector) error {
+func WaitForCRDsEstablished(ctx context.Context, client apiextensionsclientset.Interface, selector labels.Selector) error {
 	isEstablished := func(status apiextensionsv1beta1.CustomResourceDefinitionStatus) bool {
 		if status.Conditions == nil {
 			return false
@@ -86,9 +86,9 @@ func WaitForCRDsEstablished(client apiextensionsclientset.Interface, selector la
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		crdList, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().List(
-			context.TODO(),
+			ctx,
 			metav1.ListOptions{
 				LabelSelector: selector.String(),
 			})


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #4904

## What's changed and how does it work?

Replace all 65 active uses of the deprecated wait.PollImmediate function across 13 e2e test files with wait.PollUntilContextTimeout, passing true as the immediate parameter to preserve the existing behavior. Also adds ctx context.Context parameter to WaitForAPIServicesAvailable and WaitForCRDsEstablished in e2e/util/util.go and updates their callers.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [x] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
