### PR TITLE
test(e2e): add missing By() step annotations in podchaos pod kill tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Added
 
+- Add missing `By()` step annotations in podchaos pod kill tests to improve test readability and prepare for BDD/Godog migration [#4913](https://github.com/chaos-mesh/chaos-mesh/pull/4913)
 - Resource profiles for chaos-daemon with customizable overrides [#4806](https://github.com/chaos-mesh/chaos-mesh/pull/4806)
 - Add a toggle for displaying absolute/relative event time in the Dashboard UI [#4816](https://github.com/chaos-mesh/chaos-mesh/pull/4816)
 

--- a/e2e-test/e2e/chaos/podchaos/pod_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_kill.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,12 +40,14 @@ func TestcasePodKillOnceThenDelete(ns string, kubeCli kubernetes.Interface, cli 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	By("preparing experiment pod")
 	pod := fixture.NewCommonNginxPod("nginx", ns)
 	_, err := kubeCli.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "create nginx pod error")
 	err = waitPodRunning("nginx", ns, kubeCli)
 	framework.ExpectNoError(err, "wait nginx running error")
 
+	By("create pod kill chaos CRD objects")
 	podKillChaos := &v1alpha1.PodChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx-kill",
@@ -72,6 +75,7 @@ func TestcasePodKillOnceThenDelete(ns string, kubeCli kubernetes.Interface, cli 
 	err = cli.Create(ctx, podKillChaos)
 	framework.ExpectNoError(err, "create pod chaos error")
 
+	By("waiting for pod to be killed")
 	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
 		_, err = kubeCli.CoreV1().Pods(ns).Get(context.TODO(), "nginx", metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
@@ -86,6 +90,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	By("preparing experiment pods")
 	nd := fixture.NewCommonNginxDeployment("nginx", ns, 3)
 	_, err := kubeCli.AppsV1().Deployments(ns).Create(context.TODO(), nd, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "create nginx deployment error")
@@ -102,6 +107,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 
+	By("create pod kill chaos CRD objects")
 	podKillChaos := &v1alpha1.PodChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx-kill",
@@ -134,7 +140,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 		Name:      "nginx-kill",
 	}
 
-	// some pod is killed as expected
+	By("waiting for assertion some pod is killed")
 	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
@@ -142,10 +148,11 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	})
 	framework.ExpectNoError(err, "wait pod killed failed")
 
-	// pause experiment
+	By("pause pod kill chaos experiment")
 	err = util.PauseChaos(ctx, cli, podKillChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
+	By("waiting for assertion that one-shot chaos does not enter stopped phase")
 	err = wait.Poll(1*time.Second, 5*time.Second, func() (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
@@ -157,7 +164,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "chaos shouldn't enter stopped phase")
 
-	// wait for 1 minutes and no pod is killed
+	By("wait for 1 minute and verify no pod is killed while paused")
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

Add missing `By()` step annotations to `TestcasePodKillOnceThenDelete` and
`TestcasePodKillPauseThenUnPause` in `e2e/chaos/podchaos/pod_kill.go`.

## Why

These functions had no `By()` annotations while other test functions like
`TestcasePodFailureOnceThenDelete` use them consistently. This inconsistency
makes tests harder to follow in CI output.

This also prepares the pod kill tests for the upcoming BDD/Godog migration,
where `By()` steps map directly to Gherkin `Given/When/Then` lines.

Fixes #4912 


## What's changed and how does it work?

- Added `ginkgo/v2` import to `pod_kill.go`
- Added `By()` annotations to `TestcasePodKillOnceThenDelete`
- Added `By()` annotations to `TestcasePodKillPauseThenUnPause`


## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [x] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
