### PR TITLE
test(e2e): replace deprecated wait.PollImmediate with PollUntilContextTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
+- Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4907](https://github.com/chaos-mesh/chaos-mesh/pull/4907)
 - Allow customization of controller client-go QPS and BURST [#4779](https://github.com/chaos-mesh/chaos-mesh/pull/4779)
 - Use GitHub-managed ARM64 runners for ARM64 builds in upload_env_image workflow [#4794](https://github.com/chaos-mesh/chaos-mesh/pull/4794)
 - Setup CLAUDE.md, AGENTS.md and Claude Code Workflow for Coding Agent(#4797)(https://github.com/chaos-mesh/chaos-mesh/pull/4797)

--- a/e2e-test/e2e/chaos/httpchaos/http_abort.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_abort.go
@@ -73,7 +73,7 @@ func TestcaseHttpAbortThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP abort")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied
@@ -91,7 +91,7 @@ func TestcaseHttpAbortThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered
@@ -151,7 +151,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -206,7 +206,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered
@@ -243,7 +243,7 @@ func TestcaseHttpAbortPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied

--- a/e2e-test/e2e/chaos/httpchaos/http_delay.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_delay.go
@@ -74,7 +74,7 @@ func TestcaseHttpDelayDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP delay")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, dur, err := getPodHttpDelay(c, port)
 		if err != nil {
 			return false, err
@@ -98,7 +98,7 @@ func TestcaseHttpDelayDurationForATimeThenRecover(
 	time.Sleep(time.Second * 5)
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, dur, err := getPodHttpDelay(c, port)
 		if err != nil {
 			return false, err
@@ -162,7 +162,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -219,7 +219,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, dur, _ := getPodHttpDelay(c, port)
 
 		s := dur.Seconds()
@@ -259,7 +259,7 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, dur, _ := getPodHttpDelay(c, port)
 
 		s := dur.Seconds()

--- a/e2e-test/e2e/chaos/httpchaos/http_graceful_shutdown.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_graceful_shutdown.go
@@ -78,7 +78,7 @@ func TestcaseHttpGracefulAbortShutdown(
 	}()
 
 	By("waiting for assertion HTTP abort")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort applied
@@ -98,7 +98,7 @@ func TestcaseHttpGracefulAbortShutdown(
 	framework.ExpectNoError(err, "failed to restart chaos daemon")
 
 	By("waiting for assertion chaos recovered")
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err := getPodHttpNoBody(c, port)
 
 		// abort recovered

--- a/e2e-test/e2e/chaos/httpchaos/http_patch.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_patch.go
@@ -51,7 +51,7 @@ func TestcaseHttpPatchThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -115,7 +115,7 @@ func TestcaseHttpPatchThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP patch")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -144,7 +144,7 @@ func TestcaseHttpPatchThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -184,7 +184,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -252,7 +252,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -318,7 +318,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io patch still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -367,7 +367,7 @@ func TestcaseHttpPatchPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -49,7 +49,7 @@ func TestcaseHttpReplaceThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -105,7 +105,7 @@ func TestcaseHttpReplaceThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP replace")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -134,7 +134,7 @@ func TestcaseHttpReplaceThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -173,7 +173,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -234,7 +234,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -300,7 +300,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io replace still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -348,7 +348,7 @@ func TestcaseHttpReplacePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, "")
 		if err != nil {
 			return false, err
@@ -392,7 +392,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -450,7 +450,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for assertion HTTP replace")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -479,7 +479,7 @@ func TestcaseHttpReplaceBodyThenRecover(
 	framework.ExpectNoError(err, "failed to delete http chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -519,7 +519,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	secret := "Bar"
 
 	By("waiting for assertion normal behaviour")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -582,7 +582,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	}
 
 	By("waiting for assertion http chaos")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
@@ -648,7 +648,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io replace still exists
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err
@@ -696,7 +696,7 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		resp, err := getPodHttp(c, port, secret, body)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/httpchaos/http_tls.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_tls.go
@@ -177,7 +177,7 @@ func TestcaseHttpTLSThenRecover(
 	framework.ExpectNoError(err, "create http chaos error")
 
 	By("waiting for HTTP pong")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		err := util.WaitHTTPE2EHelperTLSReady(*c.C, c.IP, tlsPort)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/iochaos/io_delay.go
+++ b/e2e-test/e2e/chaos/iochaos/io_delay.go
@@ -74,7 +74,7 @@ func TestcaseIODelayDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos error")
 	By("waiting for assertion IO delay")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 		second := dur.Seconds()
 		klog.Infof("get io delay %fs", second)
@@ -92,7 +92,7 @@ func TestcaseIODelayDurationForATimeThenRecover(
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 	By("waiting for assertion recovering")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 		second := dur.Seconds()
 		klog.Infof("get io delay %fs", second)
@@ -151,7 +151,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	}
 
 	By("waiting for assertion io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
@@ -208,7 +208,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -248,7 +248,7 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -305,7 +305,7 @@ func TestcaseIODelayWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos error")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -322,7 +322,7 @@ func TestcaseIODelayWithSpecifiedContainer(
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		dur, _ := getPodIODelay(c, port)
 
 		ms := dur.Milliseconds()
@@ -377,7 +377,7 @@ func TestcaseIODelayWithWrongSpec(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos error")
 	// TODO: resume the e2e test
-	// err = wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+	// err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
 	// 	err := cli.Get(ctx, types.NamespacedName{Namespace: ioChaos.ObjectMeta.Namespace, Name: ioChaos.ObjectMeta.Name}, ioChaos)
 	// 	if err != nil {
 	// 		return false, err

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -72,7 +72,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -86,7 +86,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {
@@ -141,7 +141,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -174,7 +174,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {
@@ -199,7 +199,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -256,7 +256,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -270,7 +270,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
 		if err == nil {

--- a/e2e-test/e2e/chaos/iochaos/io_graceful_shutdown.go
+++ b/e2e-test/e2e/chaos/iochaos/io_graceful_shutdown.go
@@ -79,7 +79,7 @@ func TestcaseIOErrorGracefulShutdown(
 		framework.ExpectNoError(err, "delete io chaos")
 	}()
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
 		if err != nil && strings.Contains(err.Error(), "input/output error") {
@@ -97,7 +97,7 @@ func TestcaseIOErrorGracefulShutdown(
 	framework.ExpectNoError(err, "failed to restart chaos daemon")
 
 	By("waiting for assertion IO error recovery")
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// recovered
 		if err == nil {

--- a/e2e-test/e2e/chaos/iochaos/io_mistake.go
+++ b/e2e-test/e2e/chaos/iochaos/io_mistake.go
@@ -77,7 +77,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -93,7 +93,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -153,7 +153,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -188,7 +188,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "check paused chaos failed")
 
 	// wait 1 min to check whether io delay still exists
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -215,7 +215,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -277,7 +277,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil
@@ -293,7 +293,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
 	klog.Infof("success to perform io chaos")
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
 			return false, nil

--- a/e2e-test/e2e/chaos/podchaos/container_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/container_kill.go
@@ -73,13 +73,13 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	err = cli.Create(ctx, containerKillChaos)
 	framework.ExpectNoError(err, "create container kill chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",
 			}).String(),
 		}
-		pods, err := kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
+		pods, err := kubeCli.CoreV1().Pods(ns).List(ctx, listOption)
 		if err != nil {
 			return false, nil
 		}
@@ -100,13 +100,13 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	framework.ExpectNoError(err, "failed to delete container kill chaos")
 
 	By("success to perform container kill")
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",
 			}).String(),
 		}
-		pods, err := kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
+		pods, err := kubeCli.CoreV1().Pods(ns).List(ctx, listOption)
 		if err != nil {
 			return false, nil
 		}

--- a/e2e-test/e2e/chaos/podchaos/container_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/container_kill.go
@@ -73,7 +73,7 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	err = cli.Create(ctx, containerKillChaos)
 	framework.ExpectNoError(err, "create container kill chaos error")
 
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",
@@ -100,7 +100,7 @@ func TestcaseContainerKillOnceThenDelete(ns string, kubeCli kubernetes.Interface
 	framework.ExpectNoError(err, "failed to delete container kill chaos")
 
 	By("success to perform container kill")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		listOption := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app": "nginx",

--- a/e2e-test/e2e/chaos/timechaos/time_skew.go
+++ b/e2e-test/e2e/chaos/timechaos/time_skew.go
@@ -76,7 +76,7 @@ func TestcaseTimeSkewOnceThenRecover(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -148,7 +148,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -211,7 +211,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 
 	// timechaos is running again, we want to check pod
 	// whether time is earlier than init time,
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -268,7 +268,7 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 	framework.ExpectNoError(err, "create time chaos error")
 
 	By("waiting for assertion")
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 		podTime, err := getPodChildProcessTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {

--- a/e2e-test/e2e/util/util.go
+++ b/e2e-test/e2e/util/util.go
@@ -51,7 +51,7 @@ func WaitForAPIServicesAvailable(client aggregatorclientset.Interface, selector 
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true, func(_ context.Context) (bool, error) {
 		apiServiceList, err := client.ApiregistrationV1().APIServices().List(
 			context.TODO(),
 			metav1.ListOptions{
@@ -86,7 +86,7 @@ func WaitForCRDsEstablished(client apiextensionsclientset.Interface, selector la
 		}
 		return false
 	}
-	return wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true, func(_ context.Context) (bool, error) {
 		crdList, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().List(
 			context.TODO(),
 			metav1.ListOptions{


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #4904

`wait.PollImmediate` is deprecated since client-go v0.27. All call sites in the e2e test suite are migrated to `wait.PollUntilContextTimeout` with `immediate: true` to preserve the original poll-before-wait behavior.

## What's changed

- Replaced all 66 occurrences of `wait.PollImmediate` across 13 files in `e2e-test/`
- `wait.PollImmediate(interval, timeout, fn)` -> `wait.PollUntilContextTimeout(ctx, interval, timeout, true, fn)`
- For functions without `ctx` in scope (`util.go`), used `context.TODO()`
- Updated CHANGELOG

### Files changed

- `e2e-test/e2e/chaos/httpchaos/` - http_abort, http_delay, http_graceful_shutdown, http_patch, http_replace, http_tls
- `e2e-test/e2e/chaos/iochaos/` - io_delay, io_error, io_graceful_shutdown, io_mistake
- `e2e-test/e2e/chaos/podchaos/container_kill.go`
- `e2e-test/e2e/chaos/timechaos/time_skew.go`
- `e2e-test/e2e/util/util.go`

## Checklist

- [x] No breaking changes, 1:1 API-compatible replacement
- [x] Verified with `go vet`