### PR TITLE
test(e2e): add e2e test for external network delay with ExternalTargets

### DIFF
--- a/e2e-test/e2e/chaos/basic.go
+++ b/e2e-test/e2e/chaos/basic.go
@@ -439,6 +439,9 @@ var _ = ginkgo.Describe("[Basic]", func() {
 			ginkgo.It("[PeersCrossoverWithDirectionBoth]", func() {
 				networkchaostestcases.TestcasePeersCrossover(ns, cli, networkPeers, ports, c)
 			})
+			ginkgo.It("[ExternalTargets]", func() {
+				networkchaostestcases.TestcaseExternalNetworkDelay(ns, cli, networkPeers, ports, c)
+			})
 		})
 
 		ginkgo.JustAfterEach(func() {

--- a/e2e-test/e2e/chaos/networkchaos/misc.go
+++ b/e2e-test/e2e/chaos/networkchaos/misc.go
@@ -191,6 +191,35 @@ func makeNetworkDelayChaos(
 	}
 }
 
+func makeExternalNetworkDelayChaos(
+	namespace, name string, fromLabelSelectors map[string]string,
+	fromPodMode v1alpha1.SelectorMode, direction v1alpha1.Direction,
+	tcparam v1alpha1.TcParameter, externalTargets []string, duration *string,
+) *v1alpha1.NetworkChaos {
+	return &v1alpha1.NetworkChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.NetworkChaosSpec{
+			Action:          v1alpha1.DelayAction,
+			TcParameter:     tcparam,
+			Duration:        duration,
+			Direction:       direction,
+			ExternalTargets: externalTargets,
+			PodSelector: v1alpha1.PodSelector{
+				Selector: v1alpha1.PodSelectorSpec{
+					GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+						Namespaces:     []string{namespace},
+						LabelSelectors: fromLabelSelectors,
+					},
+				},
+				Mode: fromPodMode,
+			},
+		},
+	}
+}
+
 func probeNetworkCondition(c http.Client, peers []*corev1.Pod, ports []uint16, bidirection bool) map[string][][]int {
 	result := make(map[string][][]int)
 

--- a/e2e-test/e2e/chaos/networkchaos/network_external_delay.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_external_delay.go
@@ -82,13 +82,14 @@ func TestcaseExternalNetworkDelay(
 	framework.ExpectNoError(err, "create network chaos error")
 
 	By("waiting for delay to external target to be applied")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for delay to external target")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}}))
@@ -97,13 +98,14 @@ func TestcaseExternalNetworkDelay(
 	err = cli.Delete(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for recovery from single external target delay")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
@@ -128,13 +130,14 @@ func TestcaseExternalNetworkDelay(
 	framework.ExpectNoError(err, "create network chaos error")
 
 	By("waiting for delay to multiple external targets to be applied")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for delay to multiple external targets")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}}))
@@ -143,13 +146,14 @@ func TestcaseExternalNetworkDelay(
 	err = cli.Delete(ctx, networkDelayMulti.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for recovery from multiple external targets delay")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())

--- a/e2e-test/e2e/chaos/networkchaos/network_external_delay.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_external_delay.go
@@ -1,0 +1,156 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package networkchaos
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
+)
+
+func TestcaseExternalNetworkDelay(
+	ns string,
+	cli client.Client,
+	networkPeers []*corev1.Pod,
+	ports []uint16,
+	c http.Client,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	By("prepare experiment playground")
+	for index := range networkPeers {
+		err := util.WaitE2EHelperReady(c, ports[index])
+		framework.ExpectNoError(err, "wait e2e helper ready error")
+	}
+
+	By("verify baseline network condition")
+	result := probeNetworkCondition(c, networkPeers, ports, false)
+	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
+	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
+
+	var (
+		testDelayTcParam = v1alpha1.TcParameter{
+			Delay: &v1alpha1.DelaySpec{
+				Latency:     "200ms",
+				Correlation: "25",
+				Jitter:      "0ms",
+			},
+		}
+		testDelayDuration = pointer.String("9m")
+	)
+
+	// Use peer pod IPs as external targets to test the ExternalTargets code path
+	// without depending on external connectivity.
+	singleExternalTarget := networkPeers[1].Status.PodIP
+
+	By("create network delay chaos with single external target")
+	networkDelay := makeExternalNetworkDelayChaos(
+		ns, "external-delay-1",
+		map[string]string{"app": "network-peer-0"},
+		v1alpha1.OneMode,
+		v1alpha1.To,
+		testDelayTcParam,
+		[]string{singleExternalTarget},
+		testDelayDuration,
+	)
+	err := cli.Create(ctx, networkDelay.DeepCopy())
+	framework.ExpectNoError(err, "create network chaos error")
+
+	By("waiting for delay to external target to be applied")
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+		result = probeNetworkCondition(c, networkPeers, ports, false)
+		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
+	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}}))
+
+	By("recover from single external target delay")
+	err = cli.Delete(ctx, networkDelay.DeepCopy())
+	framework.ExpectNoError(err, "delete network chaos error")
+
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+		result = probeNetworkCondition(c, networkPeers, ports, false)
+		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
+	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
+
+	// Test with multiple external targets
+	multipleExternalTargets := []string{
+		networkPeers[1].Status.PodIP,
+		networkPeers[2].Status.PodIP,
+	}
+
+	By("create network delay chaos with multiple external targets")
+	networkDelayMulti := makeExternalNetworkDelayChaos(
+		ns, "external-delay-2",
+		map[string]string{"app": "network-peer-0"},
+		v1alpha1.OneMode,
+		v1alpha1.To,
+		testDelayTcParam,
+		multipleExternalTargets,
+		testDelayDuration,
+	)
+	err = cli.Create(ctx, networkDelayMulti.DeepCopy())
+	framework.ExpectNoError(err, "create network chaos error")
+
+	By("waiting for delay to multiple external targets to be applied")
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+		result = probeNetworkCondition(c, networkPeers, ports, false)
+		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
+	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}}))
+
+	By("recover from multiple external targets delay")
+	err = cli.Delete(ctx, networkDelayMulti.DeepCopy())
+	framework.ExpectNoError(err, "delete network chaos error")
+
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+		result = probeNetworkCondition(c, networkPeers, ports, false)
+		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
+	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
+}


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #1047

There was no e2e test coverage for `NetworkChaos` with the `ExternalTargets` field. This field allows targeting IPs/domains outside Kubernetes, but the code path had no tests.

## What's changed

Added `TestcaseExternalNetworkDelay` covering two scenarios:

1. **Single external target** - applies delay chaos targeting one IP, verifies only that specific connection is slowed
2. **Multiple external targets** - applies delay chaos targeting two IPs, verifies both connections are slowed and recovery works

Uses peer pod IPs as external targets so the test is self-contained and doesn't depend on external connectivity, while still exercising the `ExternalTargets` code path in the controller.

### Files changed

- `e2e-test/e2e/chaos/networkchaos/network_external_delay.go` - new test function
- `e2e-test/e2e/chaos/networkchaos/misc.go` - new `makeExternalNetworkDelayChaos` helper
- `e2e-test/e2e/chaos/basic.go` - registered test under `[Netem][ExternalTargets]`

## Checklist

- [x] Follows existing patterns from `network_delay.go` and `misc.go`
- [x] Verified with `go vet`