### PR TITLE
test(cgroups): add unit tests for parseCgroupFromReader in pkg/chaosdaemon/cgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add a toggle for displaying absolute/relative event time in the Dashboard UI [#4816](https://github.com/chaos-mesh/chaos-mesh/pull/4816)
 - Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
+- Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
 
 ### Changed
 

--- a/pkg/chaosdaemon/cgroups/pidpath_test.go
+++ b/pkg/chaosdaemon/cgroups/pidpath_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cgroups
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCgroupFromReader_Valid(t *testing.T) {
+	input := "0::/user.slice/user-1001.slice/session-1.scope\n"
+	r := strings.NewReader(input)
+	got, err := parseCgroupFromReader(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/user.slice/user-1001.slice/session-1.scope" {
+		t.Errorf("expected /user.slice/user-1001.slice/session-1.scope, got %q", got)
+	}
+}
+
+func TestParseCgroupFromReader_MultipleLines(t *testing.T) {
+	input := "11:blkio:/system.slice\n10:memory:/system.slice\n0::/system.slice/test.scope\n"
+	r := strings.NewReader(input)
+	got, err := parseCgroupFromReader(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/system.slice/test.scope" {
+		t.Errorf("expected /system.slice/test.scope, got %q", got)
+	}
+}
+
+func TestParseCgroupFromReader_RootPath(t *testing.T) {
+	input := "0::/\n"
+	r := strings.NewReader(input)
+	got, err := parseCgroupFromReader(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/" {
+		t.Errorf("expected /, got %q", got)
+	}
+}
+
+func TestParseCgroupFromReader_NoCgroupV2Line(t *testing.T) {
+	input := "11:blkio:/system.slice\n10:memory:/system.slice\n"
+	r := strings.NewReader(input)
+	_, err := parseCgroupFromReader(r)
+	if err == nil {
+		t.Error("expected error for missing cgroup v2 line, got nil")
+	}
+}
+
+func TestParseCgroupFromReader_EmptyInput(t *testing.T) {
+	r := strings.NewReader("")
+	_, err := parseCgroupFromReader(r)
+	if err == nil {
+		t.Error("expected error for empty input, got nil")
+	}
+}
+
+func TestParseCgroupFromReader_InvalidEntry(t *testing.T) {
+	input := "invalidline\n"
+	r := strings.NewReader(input)
+	_, err := parseCgroupFromReader(r)
+	if err == nil {
+		t.Error("expected error for invalid entry, got nil")
+	}
+}
+
+func TestParseCgroupFromReader_OnlyTwoParts(t *testing.T) {
+	input := "0:/only-two-parts\n"
+	r := strings.NewReader(input)
+	_, err := parseCgroupFromReader(r)
+	if err == nil {
+		t.Error("expected error for entry with only 2 parts, got nil")
+	}
+}


### PR DESCRIPTION

> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?
- Adds `pkg/chaosdaemon/cgroups/pidpath_test.go` with 7 unit tests
- Covers all branches of `parseCgroupFromReader` using `strings.NewReader`
- No filesystem access or mocks needed — pure parser logic


## What's changed and how does it work?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
