### PR TITLE
test(e2e): add By() step annotations to 13 test functions

### DIFF
--- a/e2e-test/e2e/chaos/dnschaos/dns.go
+++ b/e2e-test/e2e/chaos/dnschaos/dns.go
@@ -43,6 +43,7 @@ func TestcaseDNSRandom(
 	c http.Client,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
@@ -100,8 +101,6 @@ func TestcaseDNSRandom(
 	By("delete DNS random chaos")
 	err = cli.Delete(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "failed to delete dns chaos")
-
-	cancel()
 }
 
 func TestcaseDNSError(
@@ -111,6 +110,7 @@ func TestcaseDNSError(
 	c http.Client,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
@@ -168,8 +168,6 @@ func TestcaseDNSError(
 	By("delete DNS error chaos")
 	err = cli.Delete(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "failed to delete dns chaos")
-
-	cancel()
 }
 
 func testDNSServer(c http.Client, port uint16, url string) (string, error) {

--- a/e2e-test/e2e/chaos/dnschaos/dns.go
+++ b/e2e-test/e2e/chaos/dnschaos/dns.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,13 +44,14 @@ func TestcaseDNSRandom(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 
 	effectDomainNames := []string{"not-exist-host.abc", "not_exist_host.abc", "not-exist-host.def"}
 
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
-	// get IP of a non exists host, and will get error
+	By("verify baseline DNS resolution fails for non-existent hosts")
 	for _, domainName := range effectDomainNames {
 		_, err = testDNSServer(c, port, domainName)
 		gomega.Expect(err).Should(gomega.HaveOccurred(), "test DNS server failed")
@@ -77,9 +79,11 @@ func TestcaseDNSRandom(
 		},
 	}
 
+	By("create DNS random chaos")
 	err = cli.Create(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "create dns chaos error")
 
+	By("waiting for assertion DNS random chaos resolves non-existent hosts")
 	for _, domainName := range effectDomainNames {
 		err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
 			// get IP of a non exists host, because chaos DNS server will return a random IP,
@@ -93,6 +97,7 @@ func TestcaseDNSRandom(
 		framework.ExpectNoError(err, "test DNS server failed")
 	}
 
+	By("delete DNS random chaos")
 	err = cli.Delete(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "failed to delete dns chaos")
 
@@ -107,13 +112,14 @@ func TestcaseDNSError(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
 	effectDomainNames := []string{"chaos-mesh.org", "github.com", "163.com"}
 
-	// get IP of chaos-mesh.org, and will get no error
+	By("verify baseline DNS resolution succeeds for existing hosts")
 	for _, domainName := range effectDomainNames {
 		_, err = testDNSServer(c, port, domainName)
 		framework.ExpectNoError(err, "test DNS server failed")
@@ -141,9 +147,11 @@ func TestcaseDNSError(
 		},
 	}
 
+	By("create DNS error chaos")
 	err = cli.Create(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "create dns chaos error")
 
+	By("waiting for assertion DNS error chaos breaks resolution")
 	for _, domainName := range effectDomainNames {
 		err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
 			// get IP of some domain names, because chaos DNS server will return error,
@@ -157,6 +165,7 @@ func TestcaseDNSError(
 		framework.ExpectNoError(err, "test DNS server failed")
 	}
 
+	By("delete DNS error chaos")
 	err = cli.Delete(ctx, dnsChaos.DeepCopy())
 	framework.ExpectNoError(err, "failed to delete dns chaos")
 

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -40,6 +40,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	port uint16,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
@@ -100,8 +101,6 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 		return false, nil
 	})
 	framework.ExpectNoError(err, "fail to recover io chaos")
-
-	cancel()
 }
 
 func TestcaseIOErrorDurationForATimePauseAndUnPause(
@@ -111,6 +110,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	port uint16,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
@@ -220,7 +220,6 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 
 	// cleanup
 	cli.Delete(ctx, ioChaos)
-	cancel()
 }
 
 func TestcaseIOErrorWithSpecifiedContainer(

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -39,9 +40,11 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	port uint16,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io error chaos")
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "io-chaos",
@@ -72,6 +75,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
+	By("waiting for assertion io error is injected")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
@@ -82,6 +86,7 @@ func TestcaseIOErrorDurationForATimeThenRecover(
 	})
 	framework.ExpectNoError(err, "io chaos doesn't work as expected")
 
+	By("delete io error chaos and wait for recovery")
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
@@ -106,9 +111,11 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	port uint16,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io error chaos")
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "io-chaos",
@@ -141,6 +148,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
+	By("waiting for assertion io error is injected")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
@@ -156,7 +164,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 		Name:      "io-chaos",
 	}
 
-	// pause experiment
+	By("pause the experiment")
 	err = util.PauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
@@ -173,7 +181,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check paused chaos failed")
 
-	// wait 1 min to check whether io delay still exists
+	By("assert io error is gone while paused")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 
@@ -184,7 +192,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "fail to recover io chaos")
 
-	// resume experiment
+	By("resume the experiment")
 	err = util.UnPauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
@@ -199,6 +207,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
+	By("assert io error is re-injected after resume")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
@@ -221,9 +230,11 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	port uint16) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io error chaos with specified container")
 	containerName := "io"
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
@@ -256,6 +267,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
+	By("waiting for assertion io error is injected on specified container")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err = getPodIODelay(c, port)
 		// input/output error is errno 5
@@ -266,6 +278,7 @@ func TestcaseIOErrorWithSpecifiedContainer(
 	})
 	framework.ExpectNoError(err, "io chaos doesn't work as expected")
 
+	By("delete io error chaos and wait for recovery")
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 

--- a/e2e-test/e2e/chaos/iochaos/io_mistake.go
+++ b/e2e-test/e2e/chaos/iochaos/io_mistake.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -40,9 +41,11 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io mistake chaos")
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "io-chaos",
@@ -77,6 +80,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
+	By("waiting for assertion io mistake is injected")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
@@ -89,6 +93,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 	})
 	framework.ExpectNoError(err, "io chaos doesn't work as expected")
 
+	By("delete io mistake chaos and wait for recovery")
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 
@@ -114,9 +119,11 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io mistake chaos")
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "io-chaos",
@@ -153,6 +160,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 
 	klog.Info("create iochaos successfully")
 
+	By("waiting for assertion io mistake is injected")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
@@ -170,7 +178,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 		Name:      "io-chaos",
 	}
 
-	// pause experiment
+	By("pause the experiment")
 	err = util.PauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
@@ -187,7 +195,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check paused chaos failed")
 
-	// wait 1 min to check whether io delay still exists
+	By("assert io mistake is gone while paused")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
@@ -200,7 +208,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "fail to recover io chaos")
 
-	// resume experiment
+	By("resume the experiment")
 	err = util.UnPauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
@@ -215,6 +223,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	})
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
+	By("assert io mistake is re-injected after resume")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
@@ -238,9 +247,11 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	port uint16) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("prepare experiment playground")
 	err := util.WaitE2EHelperReady(c, port)
 	framework.ExpectNoError(err, "wait e2e helper ready error")
 
+	By("create io mistake chaos with specified container")
 	containerName := "io"
 	ioChaos := &v1alpha1.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
@@ -277,6 +288,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	err = cli.Create(ctx, ioChaos)
 	framework.ExpectNoError(err, "create io chaos")
 
+	By("waiting for assertion io mistake is injected on specified container")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		res, err := getPodIoMistake(c, port)
 		if err != nil {
@@ -289,6 +301,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 	})
 	framework.ExpectNoError(err, "io chaos doesn't work as expected")
 
+	By("delete io mistake chaos and wait for recovery")
 	err = cli.Delete(ctx, ioChaos)
 	framework.ExpectNoError(err, "failed to delete io chaos")
 

--- a/e2e-test/e2e/chaos/podchaos/pod_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_kill.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,6 +87,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	By("preparing nginx deployment")
 	nd := fixture.NewCommonNginxDeployment("nginx", ns, 3)
 	_, err := kubeCli.AppsV1().Deployments(ns).Create(context.TODO(), nd, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "create nginx deployment error")
@@ -102,6 +104,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 
+	By("create pod kill chaos CRD objects")
 	podKillChaos := &v1alpha1.PodChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx-kill",
@@ -134,7 +137,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 		Name:      "nginx-kill",
 	}
 
-	// some pod is killed as expected
+	By("waiting for assertion some pod is killed")
 	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
@@ -142,7 +145,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	})
 	framework.ExpectNoError(err, "wait pod killed failed")
 
-	// pause experiment
+	By("pause the experiment")
 	err = util.PauseChaos(ctx, cli, podKillChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
@@ -157,7 +160,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "chaos shouldn't enter stopped phase")
 
-	// wait for 1 minutes and no pod is killed
+	By("assert no pod is killed while paused")
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {

--- a/e2e-test/e2e/chaos/sidecar/injection_config.go
+++ b/e2e-test/e2e/chaos/sidecar/injection_config.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,6 +41,7 @@ func TestcaseNoTemplate(
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("create injection config without template")
 	err := createInjectionConfig(ctx, cli, ns, cmName,
 		map[string]string{
 			"chaosfs-io": `name: chaosfs-io
@@ -48,6 +50,7 @@ selector:
     app: io`})
 	framework.ExpectNoError(err, "failed to create injection config")
 
+	By("assert controller-manager does not crash")
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/component": "controller-manager",
@@ -70,6 +73,7 @@ selector:
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
 	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
 
+	By("enable webhook and deploy io-test")
 	err = enableWebhook(ns)
 	framework.ExpectNoError(err, "enable webhook on ns error")
 	nd := fixture.NewIOTestDeployment("io-test", ns)
@@ -77,9 +81,6 @@ selector:
 	framework.ExpectNoError(err, "create io-test deployment error")
 	err = util.WaitDeploymentReady("io-test", ns, kubeCli)
 	framework.ExpectNoError(err, "wait io-test deployment ready error")
-
-	// cleanup
-
 }
 
 func TestcaseNoTemplateArgs(
@@ -92,6 +93,7 @@ func TestcaseNoTemplateArgs(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	By("create injection config with template but no args")
 	err := createInjectionConfig(ctx, cli, ns, cmName,
 		map[string]string{
 			"chaosfs-io": `name: chaosfs-io
@@ -101,6 +103,7 @@ selector:
     app: io`})
 	framework.ExpectNoError(err, "failed to create injection config")
 
+	By("assert controller-manager does not crash")
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/component": "controller-manager",
@@ -123,6 +126,7 @@ selector:
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
 	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
 
+	By("enable webhook and deploy io-test")
 	err = enableWebhook(ns)
 	framework.ExpectNoError(err, "enable webhook on ns error")
 	nd := fixture.NewIOTestDeployment("io-test", ns)

--- a/e2e-test/e2e/chaos/sidecar/template_config.go
+++ b/e2e-test/e2e/chaos/sidecar/template_config.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,6 +40,7 @@ func TestcaseInvalidConfigMapKey(
 ) {
 
 	ctx, cancel := context.WithCancel(context.Background())
+	By("create template config with invalid configmap key")
 	err := createTemplateConfig(ctx, cli, cmName,
 		map[string]string{
 			"chaos-pd.yaml": `name: chaosfs-pd
@@ -47,6 +49,7 @@ selector:
     "app.kubernetes.io/component": "pd"`})
 	framework.ExpectNoError(err, "failed to create template config")
 
+	By("assert controller-manager does not crash")
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/component": "controller-manager",
@@ -82,6 +85,7 @@ func TestcaseInvalidConfiguration(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	By("create template config with invalid configuration")
 	err := createTemplateConfig(ctx, cli, cmName,
 		map[string]string{
 			"data": `name: chaosfs-pd
@@ -90,6 +94,7 @@ selector:
     "app.kubernetes.io/component": "pd"`})
 	framework.ExpectNoError(err, "failed to create template config")
 
+	By("assert controller-manager does not crash")
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/component": "controller-manager",

--- a/e2e-test/e2e/chaos/sidecar/template_config.go
+++ b/e2e-test/e2e/chaos/sidecar/template_config.go
@@ -40,6 +40,7 @@ func TestcaseInvalidConfigMapKey(
 ) {
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	By("create template config with invalid configmap key")
 	err := createTemplateConfig(ctx, cli, cmName,
 		map[string]string{
@@ -71,8 +72,6 @@ selector:
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
 	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
-
-	cancel()
 }
 
 func TestcaseInvalidConfiguration(


### PR DESCRIPTION
Adds ginkgo `By()` step annotations to 13 e2e test functions across 6 files
that were missing them. This makes test output easier to follow when debugging
failures, since ginkgo prints the current step on failure.

Files changed:
- `podchaos/pod_kill.go` - TestcasePodKillPauseThenUnPause
- `dnschaos/dns.go` - TestcaseDNSRandom, TestcaseDNSError
- `iochaos/io_error.go` - 3 functions
- `iochaos/io_mistake.go` - 3 functions
- `sidecar/injection_config.go` - TestcaseNoTemplate, TestcaseNoTemplateArgs
- `sidecar/template_config.go` - TestcaseInvalidConfigMapKey, TestcaseInvalidConfiguration

Follows the same pattern used in existing annotated tests like
`TestcasePodKillOnceThenDelete` and `TestcaseIOErrorDurationForATimeThenRecover`.