### PR TITLE
fix(ui): add dedicated icon for BlockChaos

### DIFF
--- a/ui/app/src/images/chaos/block.svg
+++ b/ui/app/src/images/chaos/block.svg
@@ -14,6 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none">
   <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
 </svg>

--- a/ui/app/src/images/chaos/block.svg
+++ b/ui/app/src/images/chaos/block.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!--
+  ~ Copyright 2025 Chaos Mesh Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+</svg>

--- a/ui/app/src/lib/byKind.tsx
+++ b/ui/app/src/lib/byKind.tsx
@@ -22,6 +22,7 @@ import { type ExperimentKind } from '@/components/NewExperiment/types'
 import i18n from '@/components/T'
 
 import AWSIcon from '@/images/chaos/aws.svg?react'
+import BlockIcon from '@/images/chaos/block.svg?react'
 import DiskIcon from '@/images/chaos/disk.svg?react'
 import DNSIcon from '@/images/chaos/dns.svg?react'
 import GCPIcon from '@/images/chaos/gcp.svg?react'
@@ -52,8 +53,7 @@ export function iconByKind(kind: string, size: 'small' | 'inherit' | 'medium' | 
       icon = <AWSIcon />
       break
     case 'BlockChaos':
-      // TODO: add icon for BlockChaos
-      icon = <FileSystemIOIcon />
+      icon = <BlockIcon />
       break
     case 'DiskChaos':
       icon = <DiskIcon />


### PR DESCRIPTION
## What problem does this PR solve?

BlockChaos had no dedicated icon and fell back to the FileSystemIO icon, which is semantically incorrect — BlockChaos operates at the block device layer, not the filesystem layer. This adds a dedicated block storage icon to fix the TODO left in byKind.tsx.

## What's changed and how does it work?

Adds block.svg (a cylinder/stack outline icon representing block storage) to ui/app/src/images/chaos/ and imports it as BlockIcon in byKind.tsx, replacing the FileSystemIOIcon fallback in the BlockChaos case and removing the TODO comment.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [x] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**
