### PR TITLE
chore(ui): remove stale jss-to-styled codemod comment

### DIFF
--- a/ui/app/src/pages/Workflows/Single.tsx
+++ b/ui/app/src/pages/Workflows/Single.tsx
@@ -42,7 +42,6 @@ const classes = {
   configPaper: `${PREFIX}-configPaper`,
 }
 
-// TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
 const Root = styled('div')(({ theme }) => ({
   [`& .${classes.root}`]: {},
 


### PR DESCRIPTION
## What problem does this PR solve?

A stale comment left by the automated jss-to-styled codemod was still present in `ui/app/src/pages/Workflows/Single.tsx`. The migration has been fully completed across the entire UI codebase — no `makeStyles`, `withStyles`, or `useStyles` remain anywhere — making this comment outdated noise.

## What's changed and how does it work?

Removes the single leftover codemod comment on line 45 of `Workflows/Single.tsx`. No logic changes.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**