### PR TITLE
added fallback so on pause it will retrigger the label selector

### DIFF
--- a/controllers/common/desiredphase/controller.go
+++ b/controllers/common/desiredphase/controller.go
@@ -144,7 +144,7 @@ func (info *reconcileInfo) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				if obj.GetStatus().Experiment.DesiredPhase == v1alpha1.StoppedPhase &&
 					desiredPhase == v1alpha1.RunningPhase {
 					obj.GetStatus().Experiment.Records = nil
-					info.Log.Info("unpaused: clearing stale records to force target re-discovery",
+					info.Log.Info("desired phase transitioned from stopped to running; clearing stale records to force target re-discovery",
 						"namespace", obj.GetNamespace(), "name", obj.GetName())
 				}
 				obj.GetStatus().Experiment.DesiredPhase = desiredPhase

--- a/controllers/common/desiredphase/controller.go
+++ b/controllers/common/desiredphase/controller.go
@@ -141,9 +141,15 @@ func (info *reconcileInfo) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 
 			if obj.GetStatus().Experiment.DesiredPhase != desiredPhase {
+				if obj.GetStatus().Experiment.DesiredPhase == v1alpha1.StoppedPhase &&
+					desiredPhase == v1alpha1.RunningPhase {
+					obj.GetStatus().Experiment.Records = nil
+					info.Log.Info("unpaused: clearing stale records to force target re-discovery",
+						"namespace", obj.GetNamespace(), "name", obj.GetName())
+				}
 				obj.GetStatus().Experiment.DesiredPhase = desiredPhase
 				info.Log.Info("update object", "namespace", obj.GetNamespace(), "name", obj.GetName())
-				return info.Client.Update(context.TODO(), obj)
+				return info.Client.Status().Update(context.TODO(), obj)
 			}
 
 			return nil


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #4911

When a Chaos experiment is created in a `paused: true` state and the target Deployment is redeployed (pods killed and recreated with new UIDs) while the experiment remains paused, the controller fails to discover the new pods upon unpause. This is because the controller anchors to the original pod UIDs stored in `Status.Experiment.Records` and never re-runs the label selector discovery, leaving the experiment broken with no valid targets.

This is a critical issue for GitOps workflows (e.g. ArgoCD + GitHub Actions) where experiments are kept paused in the cluster and activated on demand.

## What's changed and how does it work?

Modified the `Reconcile` function in `controllers/common/desiredphase/controller.go` to detect the `Stopped → Running` phase transition (i.e. when an experiment is unpaused).

When this transition is detected, `Status.Experiment.Records` is cleared (set to `nil`) before persisting the new `DesiredPhase`. This forces the controller to treat the experiment as if it has no anchored targets, triggering a fresh pod discovery via the configured `labelSelectors` on the next reconcile loop.

The status update is performed using a single `Status().Update()` call since both `DesiredPhase` and `Records` are fields of the Status subresource. The previous `Client.Update()` call for spec has been removed as it was redundant and could cause ResourceVersion conflicts inside the `RetryOnConflict` loop.

**Key change:**
```go
if obj.GetStatus().Experiment.DesiredPhase == v1alpha1.StoppedPhase &&
    desiredPhase == v1alpha1.RunningPhase {
    obj.GetStatus().Experiment.Records = nil
}
obj.GetStatus().Experiment.DesiredPhase = desiredPhase
return info.Client.Status().Update(context.TODO(), obj)
```

## Related changes
- [ ] This change also requires further updates to the website (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)
- [ ] release-2.8
- [x] release-2.7 *(bug is reproducible on 2.7.2)*

## Checklist

### CHANGELOG
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests
- [ ] Unit test
- [ ] E2E test
- [x] Manual test — verified by reproducing the issue: applied a paused NetworkChaos, restarted the target deployment, unpaused the experiment, confirmed fresh pod discovery succeeds

### Side effects
- [ ] **Breaking backward compatibility** — this change does not break backward compatibility. Experiments that are never paused are unaffected. Only the Stopped → Running transition is touched.

written using claude 