### PR TITLE
test(workflow): add unit tests for pkg/workflow/errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
 - Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
+- Add unit tests for `pkg/workflow/errors` covering all error types and sentinel errors [#4935](https://github.com/chaos-mesh/chaos-mesh/pull/4935)
 
 ### Changed
 

--- a/pkg/workflow/errors/errors_test.go
+++ b/pkg/workflow/errors/errors_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package errors
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ---------- WorkflowError ----------
+
+func TestWorkflowError_Error(t *testing.T) {
+	err := New("something went wrong")
+	if err.Error() != "something went wrong" {
+		t.Errorf("expected 'something went wrong', got %q", err.Error())
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *WorkflowError
+		want string
+	}{
+		{"ErrNoSuchNode", ErrNoSuchNode, "no such node"},
+		{"ErrNoSuchTemplate", ErrNoSuchTemplate, "no such template"},
+		{"ErrParseTemplateFailed", ErrParseTemplateFailed, "failed to parse certain type of template"},
+		{"ErrNoMoreTemplateInSerialTemplate", ErrNoMoreTemplateInSerialTemplate, "no more template could schedule in serial template"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err == nil {
+				t.Fatal("expected non-nil sentinel error")
+			}
+			if tc.err.Error() != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, tc.err.Error())
+			}
+		})
+	}
+}
+
+// ---------- NoSuchTemplateError ----------
+
+func TestNoSuchTemplateError_Fields(t *testing.T) {
+	err := NewNoSuchTemplateError("get", "my-workflow", "my-template")
+	if err.Op != "get" {
+		t.Errorf("expected Op=get, got %q", err.Op)
+	}
+	if err.WorkflowName != "my-workflow" {
+		t.Errorf("expected WorkflowName=my-workflow, got %q", err.WorkflowName)
+	}
+	if err.TemplateName != "my-template" {
+		t.Errorf("expected TemplateName=my-template, got %q", err.TemplateName)
+	}
+	if err.Unwrap() != ErrNoSuchTemplate {
+		t.Errorf("expected Unwrap to return ErrNoSuchTemplate")
+	}
+}
+
+func TestNoSuchTemplateError_ErrorIsJSON(t *testing.T) {
+	err := NewNoSuchTemplateError("get", "my-workflow", "my-template")
+	msg := err.Error()
+	if !json.Valid([]byte(msg)) {
+		t.Errorf("expected Error() to return valid JSON, got %q", msg)
+	}
+}
+
+func TestNewNoSuchTemplateErrorInTemplates(t *testing.T) {
+	available := []string{"tmpl-a", "tmpl-b"}
+	err := NewNoSuchTemplateErrorInTemplates("list", "missing-tmpl", available)
+	if err.TemplateName != "missing-tmpl" {
+		t.Errorf("expected TemplateName=missing-tmpl, got %q", err.TemplateName)
+	}
+	if len(err.AllAvailableTemplates) != 2 {
+		t.Errorf("expected 2 available templates, got %d", len(err.AllAvailableTemplates))
+	}
+}
+
+// ---------- NoSuchTreeNodeError ----------
+
+func TestNoSuchTreeNodeError_Fields(t *testing.T) {
+	err := NewNoSuchTreeNodeError("find", "parent-node", "my-workflow")
+	if err.Op != "find" {
+		t.Errorf("expected Op=find, got %q", err.Op)
+	}
+	if err.ParentNodeName != "parent-node" {
+		t.Errorf("expected ParentNodeName=parent-node, got %q", err.ParentNodeName)
+	}
+	if err.WorkflowName != "my-workflow" {
+		t.Errorf("expected WorkflowName=my-workflow, got %q", err.WorkflowName)
+	}
+	if err.Unwrap() != ErrNoSuchNode {
+		t.Errorf("expected Unwrap to return ErrNoSuchNode")
+	}
+}
+
+func TestNoSuchTreeNodeError_ErrorIsJSON(t *testing.T) {
+	err := NewNoSuchTreeNodeError("find", "parent-node", "my-workflow")
+	msg := err.Error()
+	if !json.Valid([]byte(msg)) {
+		t.Errorf("expected Error() to return valid JSON, got %q", msg)
+	}
+}
+
+// ---------- ParseTemplateFailedError ----------
+
+func TestParseTemplateFailedError_Fields(t *testing.T) {
+	err := NewParseSerialTemplateFailedError("parse", "some-raw-value")
+	if err.Op != "parse" {
+		t.Errorf("expected Op=parse, got %q", err.Op)
+	}
+	if err.Unwrap() != ErrParseTemplateFailed {
+		t.Errorf("expected Unwrap to return ErrParseTemplateFailed")
+	}
+	if !strings.Contains(err.RawType, "string") {
+		t.Errorf("expected RawType to contain 'string', got %q", err.RawType)
+	}
+}
+
+func TestParseTemplateFailedError_ErrorIsJSON(t *testing.T) {
+	err := NewParseSerialTemplateFailedError("parse", "some-raw-value")
+	msg := err.Error()
+	if !json.Valid([]byte(msg)) {
+		t.Errorf("expected Error() to return valid JSON, got %q", msg)
+	}
+}
+
+// ---------- NoMoreTemplateInSerialTemplateError ----------
+
+func TestNoMoreTemplateInSerialTemplateError_Fields(t *testing.T) {
+	err := NewNoMoreTemplateInSerialTemplateError("schedule", "my-workflow", "serial-tmpl", "node-1")
+	if err.Op != "schedule" {
+		t.Errorf("expected Op=schedule, got %q", err.Op)
+	}
+	if err.WorkflowName != "my-workflow" {
+		t.Errorf("expected WorkflowName=my-workflow, got %q", err.WorkflowName)
+	}
+	if err.TemplateName != "serial-tmpl" {
+		t.Errorf("expected TemplateName=serial-tmpl, got %q", err.TemplateName)
+	}
+	if err.NodeName != "node-1" {
+		t.Errorf("expected NodeName=node-1, got %q", err.NodeName)
+	}
+	if err.Unwrap() != ErrNoMoreTemplateInSerialTemplate {
+		t.Errorf("expected Unwrap to return ErrNoMoreTemplateInSerialTemplate")
+	}
+}
+
+func TestNoMoreTemplateInSerialTemplateError_ErrorIsJSON(t *testing.T) {
+	err := NewNoMoreTemplateInSerialTemplateError("schedule", "my-workflow", "serial-tmpl", "node-1")
+	msg := err.Error()
+	if !json.Valid([]byte(msg)) {
+		t.Errorf("expected Error() to return valid JSON, got %q", msg)
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

Adds unit tests for all error types in `pkg/workflow/errors`, covering:

- `WorkflowError` base type and `.Error()` method
- All 4 sentinel errors (`ErrNoSuchNode`, `ErrNoSuchTemplate`, `ErrParseTemplateFailed`, `ErrNoMoreTemplateInSerialTemplate`)
- `NoSuchTemplateError` — field population, JSON output, `Unwrap()`
- `NoSuchTreeNodeError` — field population, JSON output, `Unwrap()`
- `ParseTemplateFailedError` — field population, JSON output, RawType via reflect
- `NoMoreTemplateInSerialTemplateError` — field population, JSON output, `Unwrap()`


## What's changed and how does it work?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
