### PR TITLE
fix: nil pointer dereference in StressChaos Apply when Stressors is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Fix nil pointer dereference in StressChaos Apply when Stressors is nil and StressngStressors is empty [#4936](https://github.com/chaos-mesh/chaos-mesh/pull/4936)
 - Fixed NetworkChaos recovery failure when target container is in CrashLoopBackOff by falling back to sandbox (pause) container PID for network namespace operations
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)

--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -81,7 +81,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		MemoryStressors: memoryStressors,
 		EnterNS:         true,
 	}
-	if stresschaos.Spec.Stressors.MemoryStressor != nil {
+	if stresschaos.Spec.Stressors != nil && stresschaos.Spec.Stressors.MemoryStressor != nil {
 		req.OomScoreAdj = int32(stresschaos.Spec.Stressors.MemoryStressor.OOMScoreAdj)
 	}
 	res, err := pbClient.ExecStressors(ctx, &req)

--- a/e2e-test/e2e/chaos/networkchaos/network_delay.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_delay.go
@@ -98,13 +98,14 @@ func TestcaseNetworkDelay(
 	err := cli.Create(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}, {0, 3}}))
@@ -113,13 +114,14 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to recover")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
@@ -139,13 +141,14 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}}))
@@ -153,13 +156,14 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to recover")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
@@ -178,13 +182,14 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}}))
 
@@ -192,39 +197,42 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}}))
 
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}}))
 
 	err = cli.Delete(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 
@@ -241,13 +249,14 @@ func TestcaseNetworkDelay(
 	By("Injecting complicate chaos for 0")
 	err = cli.Create(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}, {0, 3}}))
 
@@ -255,13 +264,14 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 
@@ -278,13 +288,14 @@ func TestcaseNetworkDelay(
 	By("Injecting both direction chaos for 0")
 	err = cli.Create(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}, {2, 0}}))
 
@@ -292,13 +303,14 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 }

--- a/e2e-test/e2e/chaos/networkchaos/network_delay.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_delay.go
@@ -98,14 +98,13 @@ func TestcaseNetworkDelay(
 	err := cli.Create(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}, {0, 3}}))
@@ -114,14 +113,13 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to recover")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
@@ -141,14 +139,13 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}}))
@@ -156,14 +153,13 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to recover")
 
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
@@ -182,14 +178,13 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}}))
 
@@ -197,42 +192,39 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}}))
 
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}}))
 
 	err = cli.Delete(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 
@@ -249,14 +241,13 @@ func TestcaseNetworkDelay(
 	By("Injecting complicate chaos for 0")
 	err = cli.Create(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 1}, {0, 2}, {0, 3}}))
 
@@ -264,14 +255,13 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 
@@ -288,14 +278,13 @@ func TestcaseNetworkDelay(
 	By("Injecting both direction chaos for 0")
 	err = cli.Create(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to propagate")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(result[networkConditionSlow]).To(gomega.Equal([][]int{{0, 2}, {2, 0}}))
 
@@ -303,14 +292,13 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err, "wait for network delay to recover")
 	gomega.Expect(len(result[networkConditionBlocked])).To(gomega.BeZero())
 	gomega.Expect(len(result[networkConditionSlow])).To(gomega.BeZero())
 }


### PR DESCRIPTION

### **What problem does this PR solve?**
Prevents a nil pointer dereference in `StressChaos.Apply()` when `stressngStressors` is used without defining `stressors`.
In this case, `Spec.Stressors` is nil, and accessing `MemoryStressor` can crash the controller-manager.

---

### **What's changed and how does it work?**

Added a nil check before accessing `MemoryStressor`:

```go
if stresschaos.Spec.Stressors != nil && stresschaos.Spec.Stressors.MemoryStressor != nil {
    req.OomScoreAdj = int32(stresschaos.Spec.Stressors.MemoryStressor.OOMScoreAdj)
}
```

---

### **Checklist**

#### CHANGELOG

* [x] I have updated the CHANGELOG.md

#### Tests

* [x] Manual test

---

### **Side effects**

No breaking changes. Defensive fix only.