### PR TITLE
refactor: replace context.TODO() with context.Background() in metrics collector

### DIFF
--- a/pkg/dashboard/store/metrics/metrics.go
+++ b/pkg/dashboard/store/metrics/metrics.go
@@ -84,7 +84,7 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 func (collector *Collector) collectArchivedExperiments() {
 	collector.archivedExperiments.Reset()
 
-	metas, err := collector.experimentStore.ListMeta(context.TODO(), "", "", "", true)
+	metas, err := collector.experimentStore.ListMeta(context.Background(), "", "", "", true)
 	if err != nil {
 		collector.log.Error(err, "fail to list all archived chaos experiments")
 		return
@@ -109,7 +109,7 @@ func (collector *Collector) collectArchivedExperiments() {
 func (collector *Collector) collectArchivedSchedules() {
 	collector.archivedSchedules.Reset()
 
-	metas, err := collector.scheduleStore.ListMeta(context.TODO(), "", "", true)
+	metas, err := collector.scheduleStore.ListMeta(context.Background(), "", "", true)
 	if err != nil {
 		collector.log.Error(err, "fail to list all archived schedules")
 		return
@@ -128,7 +128,7 @@ func (collector *Collector) collectArchivedSchedules() {
 func (collector *Collector) collectArchivedWorkflows() {
 	collector.archivedWorkflows.Reset()
 
-	metas, err := collector.workflowStore.ListMeta(context.TODO(), "", "", true)
+	metas, err := collector.workflowStore.ListMeta(context.Background(), "", "", true)
 	if err != nil {
 		collector.log.Error(err, "fail to list all archived workflows")
 		return


### PR DESCRIPTION
## What problem does this PR solve?

While exploring the codebase, I noticed that three background collector 
functions in `pkg/dashboard/store/metrics/metrics.go` were using 
`context.TODO()`. Since these functions run as background goroutines with 
no incoming request context, `context.Background()` is more appropriate here.

Closes #4937

## What's changed and how does it work?

Replaced `context.TODO()` with `context.Background()` in:
- `collectArchivedExperiments()` (line 87)
- `collectArchivedSchedules()` (line 112)
- `collectArchivedWorkflows()` (line 131)

`context.TODO()` is generally a temporary placeholder when the right context 
hasn't been decided yet, whereas `context.Background()` clearly communicates 
that this is a long-running background operation.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

## Checklist

### CHANGELOG
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests
- [x] Manual test

### Side effects
- [ ] **Breaking backward compatibility**