### PR TITLE
refactor: replace context.TODO() with context.Background() in chaos-controller-manager metrics collector

### DIFF
--- a/pkg/metrics/chaos-controller-manager.go
+++ b/pkg/metrics/chaos-controller-manager.go
@@ -172,7 +172,7 @@ func (collector *ChaosControllerManagerMetricsCollector) collectChaosExperiments
 	for kind, obj := range v1alpha1.AllKinds() {
 		expCache := map[string]map[string]int{}
 		chaosList := obj.SpawnList()
-		if err := collector.store.List(context.TODO(), chaosList); err != nil {
+		if err := collector.store.List(context.Background(), chaosList); err != nil {
 			collector.logger.Error(err, "failed to list chaos", "kind", kind)
 			return
 		}
@@ -199,7 +199,7 @@ func (collector *ChaosControllerManagerMetricsCollector) collectChaosSchedules()
 	collector.chaosSchedules.Reset()
 
 	schedules := &v1alpha1.ScheduleList{}
-	if err := collector.store.List(context.TODO(), schedules); err != nil {
+	if err := collector.store.List(context.Background(), schedules); err != nil {
 		collector.logger.Error(err, "failed to list schedules")
 		return
 	}
@@ -219,7 +219,7 @@ func (collector *ChaosControllerManagerMetricsCollector) collectChaosWorkflows()
 	collector.chaosWorkflows.Reset()
 
 	workflows := &v1alpha1.WorkflowList{}
-	if err := collector.store.List(context.TODO(), workflows); err != nil {
+	if err := collector.store.List(context.Background(), workflows); err != nil {
 		collector.logger.Error(err, "failed to list workflows")
 		return
 	}


### PR DESCRIPTION
## What problem does this PR solve?

While exploring the codebase, I noticed that three background collector 
functions in `pkg/metrics/chaos-controller-manager.go` were using 
`context.TODO()`. Since these functions run as background goroutines with 
no incoming request context, `context.Background()` is more appropriate here.

Closes #4939

## What's changed and how does it work?

Replaced `context.TODO()` with `context.Background()` in:
- `collectChaosExperiments()` (line 175)
- `collectChaosSchedules()` (line 202)
- `collectChaosWorkflows()` (line 222)

`context.TODO()` is generally a temporary placeholder when the right context 
hasn't been decided yet, whereas `context.Background()` clearly communicates 
that this is a long-running background operation.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Checklist

### CHANGELOG
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests
- [x] Manual test

### Side effects
- [ ] **Breaking backward compatibility**