### PR TITLE
feat(multicluster): decouple Helm lifecycle from RemoteCluster coordination

### DIFF
--- a/controllers/multicluster/remotecluster/controller.go
+++ b/controllers/multicluster/remotecluster/controller.go
@@ -39,6 +39,7 @@ import (
 
 const remoteClusterControllerFinalizer = "chaos-mesh/remotecluster-controllers"
 const chaosMeshReleaseName = "chaos-mesh"
+const ManagedHelmLifecycleAnnotation = "chaos-mesh.org/managed-helm-lifecycle"
 
 type Reconciler struct {
 	Log      logr.Logger
@@ -65,6 +66,20 @@ func (r *Reconciler) getRestConfig(ctx context.Context, secretRef v1alpha1.Remot
 	}
 
 	return clientcmd.NewDefaultClientConfig(*config, nil), nil
+}
+
+// shouldManageHelmLifecycle checks the annotation to determine if Helm lifecycle should be managed.
+// Returns true by default (backwards compatibility) if the annotation is absent.
+func shouldManageHelmLifecycle(obj *v1alpha1.RemoteCluster) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return true
+	}
+	value, exists := annotations[ManagedHelmLifecycleAnnotation]
+	if !exists {
+		return true
+	}
+	return value != "false"
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -125,10 +140,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	currentVersion, err := r.ensureHelmRelease(ctx, &obj, clientConfig)
-	if err != nil {
-		r.Log.Error(err, "fail to list or install remote helm release")
-		return ctrl.Result{Requeue: true}, nil
+	// Check if Helm lifecycle management should be performed based on annotation
+	var currentVersion string
+	if shouldManageHelmLifecycle(&obj) {
+		var err error
+		currentVersion, err = r.ensureHelmRelease(ctx, &obj, clientConfig)
+		if err != nil {
+			r.Log.Error(err, "fail to list or install remote helm release")
+			return ctrl.Result{Requeue: true}, nil
+		}
+	} else {
+		// Helm lifecycle management is disabled via annotation
+		// Use the spec version for status tracking
+		currentVersion = obj.Spec.Version
+		r.Log.Info("skipping Helm lifecycle management due to annotation", "remoteCluster", obj.Namespace+"/"+obj.Name)
 	}
 
 	err = r.ensureClusterControllerManager(ctx, &obj, clientConfig)
@@ -137,11 +162,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{Requeue: true}, nil
 	}
 	obj.Finalizers = []string{remoteClusterControllerFinalizer}
-
-	if err != nil {
-		r.Log.Error(err, "fail to operate the helm release in remote cluster")
-		return ctrl.Result{Requeue: true}, nil
-	}
 
 	observedGeneration := obj.ObjectMeta.Generation
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
## What problem does this PR solve?

Closes #4831

Currently, the `RemoteCluster` reconciler tightly couples:

* Helm lifecycle management (`ensureHelmRelease`)
* Remote cluster controller coordination (`ensureClusterControllerManager`)

This creates issues in:

* air-gapped environments where Helm chart downloads fail
* environments with pre-installed or externally managed Chaos Mesh deployments
* setups requiring custom RBAC or organization-managed Helm configurations

If Helm reconciliation fails, controller coordination is never attempted.

## What's changed and how does it work?

This PR introduces support for the annotation:

```yaml
chaos-mesh.org/managed-helm-lifecycle: "false"
```

When this annotation is present on a `RemoteCluster` resource:

* `ensureHelmRelease()` is skipped
* `ensureClusterControllerManager()` still executes normally

Changes included:

* added `ManagedHelmLifecycleAnnotation` constant
* added `shouldManageHelmLifecycle()` helper function
* updated reconciliation flow to conditionally skip Helm lifecycle management
* preserved backwards compatibility by defaulting to existing behavior when the annotation is absent
* added reconciliation logging when Helm lifecycle management is skipped

When Helm lifecycle management is disabled, the reconciler uses `obj.Spec.Version` for version tracking.

## Related changes

* [ ] This change also requires further updates to the website (e.g. docs)
* [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

* [ ] release-2.8
* [ ] release-2.7

## Checklist

### CHANGELOG

* [x] I have labeled this PR with "no-need-update-changelog"

### Tests

* [x] Manual test

### Side effects

* [ ] **Breaking backward compatibility**
