### PR TITLE
fix(stresschaos): pass StressngStressors through to chaos-daemon

### DIFF
--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -62,15 +62,17 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return v1alpha1.Injected, nil
 	}
 
-	stressors := stresschaos.Spec.StressngStressors
-	cpuStressors := ""
+	// When StressngStressors is set, it takes precedence over the structured
+	// Stressors field (per the CRD doc on StressngStressors). The raw string
+	// is stress-ng dialect, so we feed it directly to stress-ng via CpuStressors
+	// — chaos-daemon executes `stress-ng <args>` for that field, and stress-ng
+	// itself handles both CPU and memory stressor flags.
+	cpuStressors := stresschaos.Spec.StressngStressors
 	memoryStressors := ""
-	if len(stressors) == 0 {
+	if len(cpuStressors) == 0 {
 		cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
 		if err != nil {
-			impl.Log.Info("fail to ")
-			// TODO: add an event here
-			return v1alpha1.NotInjected, err
+			return v1alpha1.NotInjected, errors.Wrap(err, "normalize stressors")
 		}
 	}
 
@@ -81,7 +83,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		MemoryStressors: memoryStressors,
 		EnterNS:         true,
 	}
-	if stresschaos.Spec.Stressors.MemoryStressor != nil {
+	if stresschaos.Spec.Stressors != nil && stresschaos.Spec.Stressors.MemoryStressor != nil {
 		req.OomScoreAdj = int32(stresschaos.Spec.Stressors.MemoryStressor.OOMScoreAdj)
 	}
 	res, err := pbClient.ExecStressors(ctx, &req)


### PR DESCRIPTION
### Summary

When `StressChaosSpec.stressngStressors` is set, the raw stress-ng dialect string is silently dropped before reaching chaos-daemon. The experiment status flips to `Injected`, but no stressors actually run inside the target container.

The CRD documentation on `StressngStressors` states:

> When both `StressngStressors` and `Stressors` are defined, `StressngStressors` wins.

So this is a contract violation, not a missing feature.

### Root Cause

`controllers/chaosimpl/stresschaos/impl.go` — `Apply()`.

The original implementation sent a single `stressors` string to the daemon. When `ExecStressRequest` was later split into `CpuStressors` / `MemoryStressors` (commit f7f4e198, "Replace stress-ng with memStress to implement memory stressChaos"), the `Stressors.Normalize()` branch was rewired to the new fields, but the `StressngStressors` branch was left assigning to a local variable that nothing reads:

```go
stressors := stresschaos.Spec.StressngStressors  // loaded
cpuStressors := ""
memoryStressors := ""
if len(stressors) == 0 {
    cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
    ...
}
// `stressors` is never used again — request goes out empty
```

### Fix

Route `StressngStressors` directly into `CpuStressors`. chaos-daemon executes `stress-ng strings.Fields(req.CpuStressors)...` for that field (`pkg/chaosdaemon/stress_server_linux.go:128`), and stress-ng accepts both CPU and memory stressor flags in its dialect, so this restores the original pre-split behavior.

Also nil-guarded `Spec.Stressors.MemoryStressor` access — the webhook permits `Stressors == nil` when `StressngStressors` is set, but the existing code dereferenced `Spec.Stressors` unconditionally for the OOM-score-adj copy, which would panic once this path actually reached the daemon.

Cleaned up a truncated `Log.Info("fail to ")` line while in the area.

### Reproduction

```yaml
apiVersion: chaos-mesh.org/v1alpha1
kind: StressChaos
metadata:
  name: stressng-vm-test
spec:
  mode: one
  selector:
    namespaces: [default]
  stressngStressors: "--vm 2 --vm-bytes 256M --timeout 60s"
  duration: "60s"
```

**Before:** experiment status reaches `Injected`; no `stress-ng` process appears in the target container.
**After:** `stress-ng` runs with the supplied args inside the target container.

### Testing

- `go build ./controllers/chaosimpl/stresschaos/...` — passes
- `go vet ./controllers/chaosimpl/stresschaos/...` — passes
- `go test ./controllers/chaosimpl/stresschaos/...` — passes (package has no `_test.go`, pre-existing)

<img width="1057" height="622" alt="Screenshot 2026-05-10 122205" src="https://github.com/user-attachments/assets/fbcf4767-76ab-4dda-b32a-c53c21c7756f" />

### Risk

Low. The change is local to one function, gated on `StressngStressors` being non-empty, and restores documented behavior. Users who don't set `stressngStressors` are unaffected.
