### PR TITLE
fix(schedule/cron): claim tick before spawning to avoid duplicate chaos children

### DIFF
--- a/controllers/schedule/cron/controller.go
+++ b/controllers/schedule/cron/controller.go
@@ -150,20 +150,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		newObj.SetNamespace(schedule.Namespace)
 		newObj.SetName(names.SimpleNameGenerator.GenerateName(schedule.Name + "-"))
 
-		err = r.Create(ctx, newObj)
-		if err != nil {
-			r.Recorder.Event(schedule, recorder.Failed{
-				Activity: "create new object",
-				Err:      err.Error(),
-			})
-			r.Log.Error(err, "fail to create new object", "obj", newObj)
-			return ctrl.Result{}, nil
-		}
-		r.Recorder.Event(schedule, recorder.ScheduleSpawn{
-			Name: newObj.GetName(),
-		})
-		r.Log.Info("create new object", "namespace", newObj.GetNamespace(), "name", newObj.GetName())
-
+		// Claim the tick by advancing LastScheduleTime *before* creating the
+		// child object. Otherwise a transient failure between Create and the
+		// status update causes the next reconcile to recompute the same
+		// missedRun and spawn a duplicate child for this tick (especially
+		// dangerous when ConcurrencyPolicy is not Forbid).
 		lastScheduleTime := now
 		updateError := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			r.Log.Info("updating lastScheduleTime", "time", lastScheduleTime)
@@ -178,17 +169,34 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return r.Client.Update(ctx, schedule)
 		})
 		if updateError != nil {
-			r.Log.Error(updateError, "fail to update")
+			r.Log.Error(updateError, "fail to update lastScheduleTime; skipping spawn for this tick")
 			r.Recorder.Event(schedule, recorder.Failed{
 				Activity: "update lastScheduleTime",
 				Err:      updateError.Error(),
 			})
-			return ctrl.Result{}, nil
+			// Surface the error so controller-runtime requeues with backoff.
+			// No child has been created yet, so retrying is safe.
+			return ctrl.Result{}, updateError
 		}
-
 		r.Recorder.Event(schedule, recorder.Updated{
 			Field: "lastScheduleTime",
 		})
+
+		// LastScheduleTime is now advanced; even if Create fails below, the
+		// next reconcile will not re-spawn for this tick.
+		err = r.Create(ctx, newObj)
+		if err != nil {
+			r.Recorder.Event(schedule, recorder.Failed{
+				Activity: "create new object",
+				Err:      err.Error(),
+			})
+			r.Log.Error(err, "fail to create new object", "obj", newObj)
+			return ctrl.Result{}, nil
+		}
+		r.Recorder.Event(schedule, recorder.ScheduleSpawn{
+			Name: newObj.GetName(),
+		})
+		r.Log.Info("create new object", "namespace", newObj.GetNamespace(), "name", newObj.GetName())
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
### Summary

The cron `Schedule` controller can spawn duplicate chaos children for a single scheduled tick. Without `ConcurrencyPolicy=Forbid`, the duplicates run concurrently and multiply the blast radius of one configured tick.

### Root Cause

`controllers/schedule/cron/controller.go` — `Reconcile()` creates the chaos child *before* advancing `Status.LastScheduleTime`. If the status update fails (transient API conflict, network blip, exhausted retries), the function returns `nil` so controller-runtime does not requeue. On the next reconcile, `getRecentUnmetScheduleTime()` reads the unchanged `LastScheduleTime`, recomputes the same `missedRun`, and calls `Create` again — silently producing a second child for the same tick.

### Fix

Reorder to claim-then-create (the same pattern Kubernetes' CronJob controller uses):

1. Advance `LastScheduleTime` first. On failure, return the error so controller-runtime requeues with backoff. No child has been created yet, so retrying is idempotent.
2. Create the child after. If Create fails, the tick is consumed and skipped, but a duplicate is never spawned.

This trades a rare missed iteration for the elimination of silent duplicate spawning — the right tradeoff for a chaos-engineering tool where blast-radius control is a core safety guarantee.

### Testing

- `go build ./controllers/schedule/cron/...` — passes
- `go vet ./controllers/schedule/cron/...` — passes
- `go test ./controllers/schedule/cron/...` — existing `utils_test.go` still green (no behavioral changes to `getRecentUnmetScheduleTime`)

### Risk

Low. Local reorder within a single `if shouldSpawn` block. Success path is unchanged; the only observable difference is that transient failures retry cleanly or skip — instead of silently duplicating.
