### PR TITLE
fix(jvmchaos): return NotInjected when rule template generation fails

### DIFF
--- a/controllers/chaosimpl/jvmchaos/impl.go
+++ b/controllers/chaosimpl/jvmchaos/impl.go
@@ -130,7 +130,12 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 	if err != nil {
 		impl.Log.Error(err, "fail to generate rule data")
 
-		return v1alpha1.Injected, err
+		// No byteman rule has been sent to the JVM agent yet, so chaos has
+		// not been injected. Return NotInjected so the controller does not
+		// commit a misleading Injected status (and so a subsequent Recover
+		// does not try to UninstallJVMRules for a rule that was never
+		// installed).
+		return v1alpha1.NotInjected, err
 	}
 
 	_, err = decodedContainer.PbClient.InstallJVMRules(ctx, &pb.InstallJVMRulesRequest{


### PR DESCRIPTION
### Summary

`JVMChaos.Apply()` returns `v1alpha1.Injected` when `generateRuleData` fails. At that point the byteman rule has not been constructed and `InstallJVMRules` has not been called — no fault is active in the target JVM. The chaos object nevertheless reports `Injected` and a later `Recover` issues `UninstallJVMRules` for a rule that was never installed.

The branch is reachable from valid user input: an `action` outside the supported set, or a `mySQLConnectorVersion` other than `"5"` or `"8"`.

### Fix

Return `v1alpha1.NotInjected` together with the error on the template-generation failure path. This matches the convention used immediately below by the `InstallJVMRules` failure path, and by every other `ChaosImpl.Apply` implementation in the codebase: when no chaos has been applied to the target, the phase must not be `Injected`.

### Verification

Apply a `JVMChaos` with an invalid action, e.g.

```yaml
apiVersion: chaos-mesh.org/v1alpha1
kind: JVMChaos
metadata:
  name: jvm-bad-action
spec:
  action: not-a-real-action
  mode: one
  selector:
    namespaces: [default]
```

Before: status flips to `Injected`; subsequent deletion logs a failed `UninstallJVMRules`.
After: status remains `NotInjected` with the underlying error reported, and no spurious uninstall call is issued.

### Test

- `go build ./controllers/chaosimpl/jvmchaos/...` — ok
- `go vet ./controllers/chaosimpl/jvmchaos/...` — ok
- `go test ./controllers/chaosimpl/jvmchaos/...` — ok (`6.265s`, existing `impl_test.go` covers `generateRuleData`'s error returns)

### Risk

One-line change on an error path that already returns an error; the only observable difference is the phase value transitioning from `Injected` to `NotInjected` when no fault was applied.
