### PR TITLE
fix(stresschaos): propagate CancelStressors error from Recover

### DIFF
--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -139,7 +139,13 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	}
 	if _, err = pbClient.CancelStressors(ctx, req); err != nil {
 		impl.Log.Error(err, "cancel stressors")
-		return v1alpha1.Injected, nil
+		// Propagate the error so controller-runtime requeues with backoff;
+		// returning nil here would tell the framework recovery completed
+		// successfully while stress-ng processes are still running in the
+		// target container. Phase stays Injected because the chaos is still
+		// active. Mirrors the convention used by every sibling chaos type
+		// (iochaos, jvmchaos, dnschaos).
+		return v1alpha1.Injected, err
 	}
 	delete(stresschaos.Status.Instances, records[index].Id)
 	return v1alpha1.NotInjected, nil


### PR DESCRIPTION
### Summary

`StressChaos.Recover()` currently discards the gRPC error returned by `pbClient.CancelStressors`:

```go
if _, err = pbClient.CancelStressors(ctx, req); err != nil {
    impl.Log.Error(err, "cancel stressors")
    return v1alpha1.Injected, nil
}
```

A `nil` second return value tells controller-runtime that recovery finished without issue, so the reconcile loop is not requeued. The `Status.Instances` map still holds the entry (delete only runs on the success path below), but in the meantime stress-ng / memStress processes may keep consuming CPU and memory inside the target container.

### Behaviour

| | Current | Expected |
| --- | --- | --- |
| `CancelStressors` succeeds | entry deleted, `NotInjected` returned | unchanged |
| `CancelStressors` fails | `Injected, nil` — no requeue, error swallowed | `Injected, err` — requeue with backoff |

The expected behaviour matches the convention already in use by `iochaos`, `jvmchaos`, `dnschaos`, and every other `Recover` implementation in the codebase that issues a daemon RPC.

### Fix

Return the underlying error alongside the `Injected` phase. The phase is correct as-is — the chaos is in fact still active — only the swallowed error needs to surface so controller-runtime can retry.

### Test

`go build`, `go vet`, and `go test ./controllers/chaosimpl/stresschaos/...` all pass on the change. The package has no `_test.go` (pre-existing); the fix is verified by inspection and against the surrounding `Recover` patterns it now matches.
