### PR TITLE
fix(dnschaos): keep phase Injected when DNS-pod listing fails on Recover

### DIFF
--- a/controllers/chaosimpl/dnschaos/types.go
+++ b/controllers/chaosimpl/dnschaos/types.go
@@ -155,7 +155,11 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	dnsPods, err := impl.getPodsFromSelector(ctx, config.ControllerCfg.Namespace, service.Spec.Selector)
 	if err != nil {
 		impl.Log.Error(err, "fail to get pods from selector")
-		return v1alpha1.NotInjected, err
+		// Chaos rules have not yet been cleaned up from the chaos-coredns
+		// pods, so the chaos is still active. Mirror the getService failure
+		// path above (Injected, err) instead of falsely claiming recovery
+		// completed.
+		return v1alpha1.Injected, err
 	}
 
 	for _, pod := range dnsPods {


### PR DESCRIPTION
### Problem

Inside `DNSChaos.Recover()`, the call that lists chaos-coredns pods can fail (transient API outage, controller-SA RBAC drift). When it does, the function returns:

```go
return v1alpha1.NotInjected, err
```

The `NotInjected` phase says recovery completed; the non-nil `err` says it didn't. The two are contradictory, and the consequence is that the chaos-coredns pods retain the rules pushed during `Apply` even though the controller has decided the chaos object is now `NotInjected`. Targeted pods continue receiving poisoned DNS responses for the configured patterns, with no chaos object visibly indicating it.

The neighbouring failure path two lines above — `getService` failing under the same kinds of conditions — already returns `v1alpha1.Injected, err`, which is the correct behaviour: chaos is still active, retry.

### Patch

Return `v1alpha1.Injected, err` from the `getPodsFromSelector` failure path so the two pre-cleanup error branches behave consistently. The controller will requeue with backoff and retry cleanup once the API call succeeds.

### Validation

`go build`, `go vet`, and `go test ./controllers/chaosimpl/dnschaos/...` all pass on the change. The package has no `_test.go` (pre-existing); the fix is verified by inspection against the surrounding success and failure paths.
