### PR TITLE
 test(tproxyconfig): add unit tests for pkg/chaosdaemon/tproxyconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
 - Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
+- Add unit tests for `pkg/chaosdaemon/tproxyconfig` covering custom JSON unmarshaling logic [#4952](https://github.com/chaos-mesh/chaos-mesh/pull/4952)
 
 ### Changed
 

--- a/pkg/chaosdaemon/tproxyconfig/config_test.go
+++ b/pkg/chaosdaemon/tproxyconfig/config_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 )
 
-// ---------- PodHttpChaosPatchBody ----------
-
 func TestPodHttpChaosPatchBody_UnmarshalJSON_Valid(t *testing.T) {
 	raw := `{"type":"JSON","value":"patch-value"}`
 	var b PodHttpChaosPatchBody
@@ -58,8 +56,6 @@ func TestPodHttpChaosPatchBody_UnmarshalJSON_EmptyValue(t *testing.T) {
 	}
 }
 
-// ---------- PodHttpChaosReplaceBody ----------
-
 func TestPodHttpChaosReplaceBody_UnmarshalJSON_AsStruct(t *testing.T) {
 	raw := `{"type":"JSON","value":"replace-value"}`
 	var b PodHttpChaosReplaceBody
@@ -75,8 +71,6 @@ func TestPodHttpChaosReplaceBody_UnmarshalJSON_AsStruct(t *testing.T) {
 }
 
 func TestPodHttpChaosReplaceBody_UnmarshalJSON_FallbackToText(t *testing.T) {
-	// The fallback path unmarshals to []byte (base64 in JSON encoding).
-	// "aGVsbG8=" is base64 for "hello".
 	raw := `"aGVsbG8="`
 	var b PodHttpChaosReplaceBody
 	if err := json.Unmarshal([]byte(raw), &b); err != nil {
@@ -91,7 +85,6 @@ func TestPodHttpChaosReplaceBody_UnmarshalJSON_FallbackToText(t *testing.T) {
 }
 
 func TestPodHttpChaosReplaceBody_UnmarshalJSON_Invalid(t *testing.T) {
-	// Neither a valid struct nor a valid byte slice
 	raw := `not-json`
 	var b PodHttpChaosReplaceBody
 	if err := json.Unmarshal([]byte(raw), &b); err == nil {

--- a/pkg/chaosdaemon/tproxyconfig/config_test.go
+++ b/pkg/chaosdaemon/tproxyconfig/config_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tproxyconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ---------- PodHttpChaosPatchBody ----------
+
+func TestPodHttpChaosPatchBody_UnmarshalJSON_Valid(t *testing.T) {
+	raw := `{"type":"JSON","value":"patch-value"}`
+	var b PodHttpChaosPatchBody
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.Contents.Type != "JSON" {
+		t.Errorf("expected Type=JSON, got %q", b.Contents.Type)
+	}
+	if b.Contents.Value != "patch-value" {
+		t.Errorf("expected Value=patch-value, got %q", b.Contents.Value)
+	}
+}
+
+func TestPodHttpChaosPatchBody_UnmarshalJSON_Invalid(t *testing.T) {
+	raw := `not-json`
+	var b PodHttpChaosPatchBody
+	if err := json.Unmarshal([]byte(raw), &b); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestPodHttpChaosPatchBody_UnmarshalJSON_EmptyValue(t *testing.T) {
+	raw := `{"type":"JSON","value":""}`
+	var b PodHttpChaosPatchBody
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.Contents.Type != "JSON" {
+		t.Errorf("expected Type=JSON, got %q", b.Contents.Type)
+	}
+	if b.Contents.Value != "" {
+		t.Errorf("expected empty Value, got %q", b.Contents.Value)
+	}
+}
+
+// ---------- PodHttpChaosReplaceBody ----------
+
+func TestPodHttpChaosReplaceBody_UnmarshalJSON_AsStruct(t *testing.T) {
+	raw := `{"type":"JSON","value":"replace-value"}`
+	var b PodHttpChaosReplaceBody
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.Contents.Type != "JSON" {
+		t.Errorf("expected Type=JSON, got %q", b.Contents.Type)
+	}
+	if b.Contents.Value != "replace-value" {
+		t.Errorf("expected Value=replace-value, got %q", b.Contents.Value)
+	}
+}
+
+func TestPodHttpChaosReplaceBody_UnmarshalJSON_FallbackToText(t *testing.T) {
+	// The fallback path unmarshals to []byte (base64 in JSON encoding).
+	// "aGVsbG8=" is base64 for "hello".
+	raw := `"aGVsbG8="`
+	var b PodHttpChaosReplaceBody
+	if err := json.Unmarshal([]byte(raw), &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.Contents.Type != "TEXT" {
+		t.Errorf("expected Type=TEXT, got %q", b.Contents.Type)
+	}
+	if b.Contents.Value != "hello" {
+		t.Errorf("expected Value=hello, got %q", b.Contents.Value)
+	}
+}
+
+func TestPodHttpChaosReplaceBody_UnmarshalJSON_Invalid(t *testing.T) {
+	// Neither a valid struct nor a valid byte slice
+	raw := `not-json`
+	var b PodHttpChaosReplaceBody
+	if err := json.Unmarshal([]byte(raw), &b); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

Adds unit tests for the custom JSON unmarshaling logic in
`pkg/chaosdaemon/tproxyconfig/config.go`:

- `PodHttpChaosPatchBody.UnmarshalJSON` — valid struct, empty value, invalid JSON
- `PodHttpChaosReplaceBody.UnmarshalJSON` — struct path, base64 fallback (TEXT type), invalid JSON


**Coverage:** 88.2% statement coverage


## What's changed and how does it work?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
