### PR TITLE
fix(stresschaos): route StressngStressors to chaos-daemon

### DIFF
--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -62,13 +62,18 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return v1alpha1.Injected, nil
 	}
 
-	stressors := stresschaos.Spec.StressngStressors
 	cpuStressors := ""
 	memoryStressors := ""
-	if len(stressors) == 0 {
+	if len(stresschaos.Spec.StressngStressors) != 0 {
+		// StressngStressors is a raw stress-ng argument string that takes
+		// precedence over Stressors. stress-ng handles CPU/memory/IO in a
+		// single process, so route it through CpuStressors which the daemon
+		// passes verbatim to stress-ng.
+		cpuStressors = stresschaos.Spec.StressngStressors
+	} else {
 		cpuStressors, memoryStressors, err = stresschaos.Spec.Stressors.Normalize()
 		if err != nil {
-			impl.Log.Info("fail to ")
+			impl.Log.Error(err, "fail to normalize stressors")
 			// TODO: add an event here
 			return v1alpha1.NotInjected, err
 		}
@@ -81,7 +86,7 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		MemoryStressors: memoryStressors,
 		EnterNS:         true,
 	}
-	if stresschaos.Spec.Stressors.MemoryStressor != nil {
+	if stresschaos.Spec.Stressors != nil && stresschaos.Spec.Stressors.MemoryStressor != nil {
 		req.OomScoreAdj = int32(stresschaos.Spec.Stressors.MemoryStressor.OOMScoreAdj)
 	}
 	res, err := pbClient.ExecStressors(ctx, &req)


### PR DESCRIPTION
## Summary
`StressChaos.Spec.StressngStressors` is a raw stress-ng argument string that is meant to take precedence over the structured `Stressors` field, but the previous code only consulted `StressngStressors` when `Stressors` was empty and never forwarded the raw string to the chaos-daemon. As a result, experiments that set `stressngStressors` reported `Injected` while no stress-ng process was actually started.

This change:
- Forwards `StressngStressors` to chaos-daemon via the `CpuStressors` field (the daemon passes it verbatim to `stress-ng`, which handles CPU/memory/IO in a single process).
- Guards the `Stressors.MemoryStressor` dereference with a nil check on `Stressors` so the controller no longer panics when only `StressngStressors` is set.
- Replaces a truncated `impl.Log.Info("fail to ")` with a proper `impl.Log.Error(err, "fail to normalize stressors")`.

## Test plan
- [ ] Apply a StressChaos with only `stressngStressors: "--cpu 1 --timeout 60s"` set and confirm a stress-ng process actually runs inside the target container.
- [ ] Apply a StressChaos with only the structured `stressors:` block set and confirm existing behavior is unchanged.
- [ ] Apply a StressChaos with neither field set and confirm the existing validation path still rejects it without panicking.