### PR TITLE
fix(physicalmachinechaos): do not treat chaosd 404 as recovered

### DIFF
--- a/controllers/chaosimpl/physicalmachinechaos/impl.go
+++ b/controllers/chaosimpl/physicalmachinechaos/impl.go
@@ -167,7 +167,18 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	}
 
 	if statusCode == http.StatusNotFound {
-		impl.Log.Info("experiment not found", "uid", physicalMachineChaos.Spec.ExpInfo.UID)
+		// chaosd has no record of this UID. This can mean the experiment was
+		// already cleaned up, or that chaosd restarted and lost its in-memory
+		// registry while the underlying chaos (tc rules, stuck processes,
+		// disk-fill files, etc.) is still in effect on the host. We cannot
+		// distinguish the two from the controller side, so surface this as a
+		// retryable error rather than silently marking the chaos recovered.
+		err = errors.Errorf("chaosd reported experiment uid %s as not found; "+
+			"this may indicate chaosd lost state after a restart and the chaos "+
+			"is still active on %s — manual verification required",
+			physicalMachineChaos.Spec.ExpInfo.UID, address)
+		impl.Log.Error(err, body)
+		return v1alpha1.Injected, errors.Wrap(err, body)
 	} else if statusCode != http.StatusOK {
 		err = errors.New("HTTP status is not OK")
 		impl.Log.Error(err, body)


### PR DESCRIPTION
## Problem
`Recover()` calls `DELETE /api/attack/<uid>` on chaosd. If chaosd has restarted between `Apply()` and `Recover()`, its in-memory experiment registry is empty and every UID returns `404 Not Found`. The current code treats 404 as proof of cleanup and returns `(NotInjected, nil)`, marking the chaos `AllRecovered` while the host-side effects (tc rules, stuck processes, disk-fill files, paused services) remain active.

## Change
Treat 404 as ambiguous: the chaos may be cleaned up, or chaosd may have lost state. Return `(Injected, err)` with a descriptive error so the reconciler retries and the operator is alerted, rather than silently progressing the phase.

Single function, no behavior change for the 200 / non-404 paths.

## Test plan
- [ ] Stop chaosd while a PhysicalMachineChaos is active; delete the CR; confirm phase stays `Injected` with a clear error event instead of `AllRecovered`.
- [ ] Normal recovery (chaosd 200) still transitions to `NotInjected`.