### PR TITLE
fix(chaosdaemon): normalize IPv6 address before shell interpolation in SetDNSServer

### DIFF
--- a/pkg/chaosdaemon/dns_server.go
+++ b/pkg/chaosdaemon/dns_server.go
@@ -49,7 +49,8 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 	if req.Enable {
 		// set dns server to the chaos dns server's address
 
-		if net.ParseIP(req.DnsServer) == nil {
+		ip := net.ParseIP(req.DnsServer)
+		if ip == nil {
 			return nil, ErrInvalidDNSServer
 		}
 
@@ -71,7 +72,7 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 
 		// add chaos dns server to the first line of /etc/resolv.conf
 		// Note: can not replace the /etc/resolv.conf like `mv resolv_conf_dnschaos_temp resolv.conf`, will execute with error `Device or resource busy`
-		processBuilder = bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("cp %s /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver %s/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > %s && rm /etc/resolv_conf_dnschaos_temp", DNSServerConfFile, req.DnsServer, DNSServerConfFile)).SetContext(ctx)
+		processBuilder = bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("cp %s /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver %s/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > %s && rm /etc/resolv_conf_dnschaos_temp", DNSServerConfFile, ip.String(), DNSServerConfFile)).SetContext(ctx)
 		if req.EnterNS {
 			processBuilder = processBuilder.SetNS(pid, bpm.MountNS)
 		}

--- a/pkg/chaosdaemon/dns_server_test.go
+++ b/pkg/chaosdaemon/dns_server_test.go
@@ -145,12 +145,12 @@ func Test_SetDNSServer_Enable_IPv6NonCanonical(t *testing.T) {
 	}
 	var executedCommands []mockCmd
 
-	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+	defer mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
 		executedCommands = append(executedCommands, mockCmd{cmd, args})
 		return exec.Command("echo", "mock command")
-	})
+	})()
 
-	mock.With("MockContainerdClient", &test.MockClient{})
+	defer mock.With("MockContainerdClient", &test.MockClient{})()
 
 	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
 		Runtime: crclients.ContainerRuntimeContainerd,

--- a/pkg/chaosdaemon/dns_server_test.go
+++ b/pkg/chaosdaemon/dns_server_test.go
@@ -135,3 +135,42 @@ func Test_SetDNSServer_Disable(t *testing.T) {
 		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak && cat /etc/resolv.conf.chaos.bak > /etc/resolv.conf || true"}},
 	}))
 }
+
+func Test_SetDNSServer_Enable_IPv6NonCanonical(t *testing.T) {
+	g := NewWithT(t)
+
+	type mockCmd struct {
+		cmd  string
+		args []string
+	}
+	var executedCommands []mockCmd
+
+	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+		executedCommands = append(executedCommands, mockCmd{cmd, args})
+		return exec.Command("echo", "mock command")
+	})
+
+	mock.With("MockContainerdClient", &test.MockClient{})
+
+	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	server := chaosdaemon.NewDaemonServerWithCRClient(crc, nil, logr.Discard())
+
+	// Non-canonical IPv6 representation — passes validation but must be normalized before shell interpolation
+	res, err := server.SetDNSServer(context.TODO(), &pb.SetDNSServerRequest{
+		ContainerId: "containerd://foo",
+		DnsServer:   "0:0:0:0:0:0:0:1",
+		Enable:      true,
+		EnterNS:     false,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).NotTo(BeNil())
+
+	g.Expect(executedCommands).To(Equal([]mockCmd{
+		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak || cp /etc/resolv.conf /etc/resolv.conf.chaos.bak"}},
+		{cmd: "sh", args: []string{"-c", "cp /etc/resolv.conf /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver ::1/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > /etc/resolv.conf && rm /etc/resolv_conf_dnschaos_temp"}},
+	}))
+}


### PR DESCRIPTION
`SetDNSServer` validates the DNS address with `net.ParseIP` but discards
the parsed result, using the raw input string directly in the sed command.
Non-canonical IPv6 addresses like `0:0:0:0:0:0:0:1` pass validation but
get written verbatim into `/etc/resolv.conf` instead of their canonical
form (`::1`). On dual-stack clusters this produces malformed nameserver
entries that break DNS chaos injection.

Fixes: #4943

 What's changed and how it works?

Capture the `net.ParseIP` return value and use `ip.String()` when
constructing the sed command so the written address is always canonical.
Adds `Test_SetDNSServer_Enable_IPv6NonCanonical` covering the
non-canonical IPv6 → canonical normalization path.

Checklist:
Tests
- [x] Unit test: `Test_SetDNSServer_Enable_IPv6NonCanonical` added
- [ ] E2E test: not required (unit test covers the fix)

Code changes
1) [x] Has Go code change: Yes
2) [x] Has CI related scripts change: No
3) [x] Has new or updated documentation: No

Does this PR introduce a breaking change?
 
No. IPv4 and already-canonical IPv6 addresses are unaffected —
`net.IP.String()` is idempotent for canonical forms.