### PR TITLE
fix: use continue instead of return in pipeline loops

### DIFF
--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -66,7 +66,7 @@ func Bootstrap(params Params) error {
 	for _, pair := range pairs {
 		name := pair.Name + "-records"
 		if !config.ShouldSpawnController(name) {
-			return nil
+			continue
 		}
 
 		setupLog.Info("setting up controller", "resource-name", pair.Name)

--- a/controllers/common/pipeline/pipeline.go
+++ b/controllers/common/pipeline/pipeline.go
@@ -59,7 +59,7 @@ func (p *Pipeline) AddSteps(steps ...PipelineStep) {
 	for _, step := range steps {
 		reconciler := step(p.ctx)
 		if reconciler == nil {
-			return
+			continue
 		}
 		p.controllers = append(p.controllers, reconciler)
 	}

--- a/controllers/multicluster/remotechaos/fx.go
+++ b/controllers/multicluster/remotechaos/fx.go
@@ -53,7 +53,7 @@ func Bootstrap(params Params) error {
 	for _, obj := range objs {
 		name := obj.Name + "-remote-apply"
 		if !config.ShouldSpawnController(name) {
-			return nil
+			continue
 		}
 
 		setupLog.Info("setting up controller", "resource-name", obj.Name)

--- a/controllers/multicluster/remotechaosmonitor/fx.go
+++ b/controllers/multicluster/remotechaosmonitor/fx.go
@@ -47,7 +47,7 @@ func Bootstrap(params Params) error {
 		name := obj.Name + "-remotechaos-monitor"
 
 		if !config.ShouldSpawnController(name) {
-			return nil
+			continue
 		}
 
 		setupLog.Info("setting up controller", "resource-name", obj.Name)


### PR DESCRIPTION
Fixes #4957 

In AddSteps (pipeline.go) and three Bootstrap loops (fx.go, remotechaos/fx.go, remotechaosmonitor/fx.go), return/return nil was used inside for loops when ShouldSpawnController returns false. This silently drops all remaining steps instead of just skipping the disabled one.

The critical impact: disabling any early step (e.g. initFinalizers) also drops records.Step — the step that actually injects and recovers chaos — with no error or log. The bug is latent under the default config (ENABLED_CONTROLLERS=*) but triggers when a non-wildcard list is set.

Introduced in #2465 (commit 409238e).