### PR TITLE
feat(daemonset): detect iptables flavor (legacy or nft) at runtime

### DIFF
--- a/cmd/chaos-daemon/main.go
+++ b/cmd/chaos-daemon/main.go
@@ -89,6 +89,8 @@ func main() {
 		rootLogger.Error(err, "remount /sys with read-write permission")
 	}
 
+	chaosdaemon.InitIPTablesMode()
+
 	server, err := chaosdaemon.BuildServer(conf, reg, rootLogger)
 	if err != nil {
 		rootLogger.Error(err, "build chaos-daemon server")

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -46,9 +46,6 @@ RUN echo "deb http://security.debian.org/debian-security bookworm-security main 
     apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-17-jre && \
     rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ebtables /usr/sbin/ebtables-legacy
-
 ENV RUST_BACKTRACE=1
 ENV BYTEMAN_HOME=/usr/local/byteman
 ENV PATH=$PATH:/usr/local/byteman/bin

--- a/pkg/chaosdaemon/iptables_mode.go
+++ b/pkg/chaosdaemon/iptables_mode.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Detection algorithm adapted from kubernetes-sigs/iptables-wrappers v3
+// https://github.com/kubernetes-sigs/iptables-wrappers
+// Original files: internal/iptables/detect.go, internal/iptables/rules.go
+// Copyright 2023 The Kubernetes Authors — Apache-2.0 License
+
+package chaosdaemon
+
+import (
+	"os/exec"
+	"regexp"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	// iptablesCmd is set by InitIPTablesMode() at daemon startup.
+	// Left empty so any use before initialization fails obviously.
+	iptablesCmd string
+
+	kubeletChainsRegex = regexp.MustCompile(`(?m)^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)`)
+)
+
+// detectIPTablesMode detects whether the host is using iptables-nft or
+// iptables-legacy by checking for kubelet-created chains in the mangle table.
+// It checks nft first (more common on modern distros), then falls back to
+// legacy. If neither backend has kubelet chains, it defaults to nft.
+//
+// We nsenter into PID 1's network namespace to inspect the host's iptables
+// rules. The daemon runs with hostPID=true but may not have hostNetwork=true,
+// so its own namespace may not have kubelet chains.
+func detectIPTablesMode() string {
+	// Check nft first — it's more common these days and we can check
+	// efficiently by passing -t mangle.
+	for _, saveCmd := range []string{"iptables-save", "ip6tables-save"} {
+		out, err := exec.Command("nsenter", "-t", "1", "-n", "--", "xtables-nft-multi", saveCmd, "-t", "mangle").Output()
+		if err == nil && kubeletChainsRegex.Match(out) {
+			return "nft"
+		}
+	}
+
+	// Check legacy. We can't pass "-t mangle" to iptables-legacy-save because
+	// it would cause the kernel to create that table if it didn't already exist.
+	// So we grab all the rules.
+	for _, saveCmd := range []string{"iptables-save", "ip6tables-save"} {
+		out, err := exec.Command("nsenter", "-t", "1", "-n", "--", "xtables-legacy-multi", saveCmd).Output()
+		if err == nil && kubeletChainsRegex.Match(out) {
+			return "legacy"
+		}
+	}
+
+	return "nft"
+}
+
+// InitIPTablesMode detects the host's iptables backend and sets iptablesCmd
+// to the correct binary name (e.g. "iptables-nft" or "iptables-legacy").
+// Must be called before any iptables operations.
+func InitIPTablesMode() {
+	log := ctrl.Log.WithName("iptables-mode")
+	mode := detectIPTablesMode()
+	iptablesCmd = "iptables-" + mode
+	log.Info("detected iptables backend", "mode", mode, "iptablesCmd", iptablesCmd)
+}

--- a/pkg/chaosdaemon/iptables_mode_test.go
+++ b/pkg/chaosdaemon/iptables_mode_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chaosdaemon
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("iptables mode detection", func() {
+	Context("kubeletChainsRegex", func() {
+		It("should match KUBE-IPTABLES-HINT chain", func() {
+			output := []byte(`*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:KUBE-IPTABLES-HINT - [0:0]
+:KUBE-KUBELET-CANARY - [0:0]
+COMMIT
+`)
+			Expect(kubeletChainsRegex.Match(output)).To(BeTrue())
+		})
+
+		It("should match KUBE-KUBELET-CANARY chain", func() {
+			output := []byte(`*mangle
+:PREROUTING ACCEPT [0:0]
+:KUBE-KUBELET-CANARY - [0:0]
+COMMIT
+`)
+			Expect(kubeletChainsRegex.Match(output)).To(BeTrue())
+		})
+
+		It("should not match when no kubelet chains present", func() {
+			output := []byte(`*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+COMMIT
+`)
+			Expect(kubeletChainsRegex.Match(output)).To(BeFalse())
+		})
+
+		It("should not match empty output", func() {
+			Expect(kubeletChainsRegex.Match([]byte{})).To(BeFalse())
+		})
+
+		It("should not match chain name appearing in a rule (not a chain definition)", func() {
+			output := []byte(`*mangle
+:PREROUTING ACCEPT [0:0]
+-A PREROUTING -j KUBE-IPTABLES-HINT
+COMMIT
+`)
+			Expect(kubeletChainsRegex.Match(output)).To(BeFalse())
+		})
+	})
+
+	Context("InitIPTablesMode", func() {
+		It("should set iptablesCmd with a mode suffix", func() {
+			// On a dev machine without xtables binaries, detectIPTablesMode
+			// will fail all exec calls and default to "nft"
+			InitIPTablesMode()
+			Expect(iptablesCmd).To(SatisfyAny(
+				Equal("iptables-nft"),
+				Equal("iptables-legacy"),
+			))
+		})
+	})
+})

--- a/pkg/chaosdaemon/iptables_server.go
+++ b/pkg/chaosdaemon/iptables_server.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	iptablesCmd = "iptables"
-
 	iptablesChainAlreadyExistErr = "iptables: Chain already exists."
 )
 


### PR DESCRIPTION
## What problem does this PR solve?

The current implementation forces the use of legacy iptables by running the following command in the Daemonset Dockerfile:

```
RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
    update-alternatives --set ebtables /usr/sbin/ebtables-legacy
```

This is unfortunately not compatible with hosts/nodes that are using the `nft` iptables flavor.

## What's changed and how does it work?

The hardcoded `iptables` command is now established at runtime, when the daemonset container runs.

The `update-alternatives --set iptables /usr/sbin/iptables-legacy` has been removed from the Daemonset Dockerfile

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

