### PR TITLE
fix: harden JVMChaos Byteman rule temp files

### DIFF
--- a/pkg/chaosdaemon/jvm_server.go
+++ b/pkg/chaosdaemon/jvm_server.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -32,6 +33,8 @@ import (
 const (
 	bmInstallCommand = "bminstall.sh -b -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.compileToBytecode -p %d %d"
 	bmSubmitCommand  = "bmsubmit.sh -p %d -%s %s"
+
+	jvmRuleTempDirPrefix = "chaos-daemon-jvm-rules-"
 )
 
 func (s *DaemonServer) InstallJVMRules(ctx context.Context,
@@ -142,6 +145,7 @@ func (s *DaemonServer) InstallJVMRules(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	defer removeDataFile(filename)
 
 	bmSubmitCmd = fmt.Sprintf(bmSubmitCommand, req.Port, "l", filename)
 	processBuilder = bpm.DefaultProcessBuilder("sh", "-c", bmSubmitCmd).SetContext(ctx)
@@ -174,6 +178,7 @@ func (s *DaemonServer) UninstallJVMRules(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	defer removeDataFile(filename)
 	log.Info("create btm file", "file", filename)
 
 	bmSubmitCmd := fmt.Sprintf(bmSubmitCommand, req.Port, "u", filename)
@@ -198,20 +203,57 @@ func (s *DaemonServer) UninstallJVMRules(ctx context.Context,
 }
 
 func writeDataIntoFile(data string, filename string) (string, error) {
-	tmpfile, err := os.CreateTemp("", filename)
+	tempDir, err := os.MkdirTemp("", jvmRuleTempDirPrefix)
 	if err != nil {
 		return "", err
 	}
+	if err := os.Chmod(tempDir, 0700); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return "", err
+	}
 
+	tmpfile, err := os.CreateTemp(tempDir, filename)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	if err := tmpfile.Chmod(0600); err != nil {
+		_ = tmpfile.Close()
+		_ = os.RemoveAll(tempDir)
+		return "", err
+	}
 	if _, err := tmpfile.WriteString(data); err != nil {
+		_ = tmpfile.Close()
+		_ = os.RemoveAll(tempDir)
 		return "", err
 	}
 
 	if err := tmpfile.Close(); err != nil {
+		_ = os.RemoveAll(tempDir)
 		return "", err
 	}
 
-	return tmpfile.Name(), err
+	return tmpfile.Name(), nil
+}
+
+func removeDataFile(filename string) {
+	dir := filepath.Dir(filename)
+	if strings.HasPrefix(filepath.Base(dir), jvmRuleTempDirPrefix) {
+		absDir, err := filepath.Abs(dir)
+		if err == nil {
+			absTempDir, err := filepath.Abs(os.TempDir())
+			if err == nil {
+				rel, err := filepath.Rel(absTempDir, absDir)
+				if err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+					_ = os.RemoveAll(dir)
+					return
+				}
+			}
+		}
+	}
+
+	_ = os.Remove(filename)
 }
 
 func copyFileAcrossNS(ctx context.Context, source string, dest string, pid uint32) ([]byte, error) {

--- a/pkg/chaosdaemon/jvm_server_test.go
+++ b/pkg/chaosdaemon/jvm_server_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaosdaemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteDataIntoFileUsesPrivateTempDir(t *testing.T) {
+	const rule = "RULE test\nIF true\nDO traceln(\"test\")\nENDRULE\n"
+
+	filename, err := writeDataIntoFile(rule, "rule.btm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeDataFile(filename)
+
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("expected rule file mode 0600, got %#o", info.Mode().Perm())
+	}
+
+	dir := filepath.Dir(filename)
+	if dir == os.TempDir() {
+		t.Fatalf("expected rule file under a daemon-private directory, got %s", dir)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm() != 0700 {
+		t.Fatalf("expected rule directory mode 0700, got %#o", dirInfo.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != rule {
+		t.Fatalf("expected rule data %q, got %q", rule, string(data))
+	}
+}
+
+func TestRemoveDataFileDoesNotRemovePrefixedDirOutsideTempDir(t *testing.T) {
+	dir, err := os.MkdirTemp(".", jvmRuleTempDirPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file, err := os.CreateTemp(dir, "rule.btm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	removeDataFile(filename)
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected cleanup to preserve non-temp parent directory: %v", err)
+	}
+	if _, err := os.Stat(filename); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup to remove only the rule file, got err %v", err)
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

  JVMChaos submits user-provided Byteman rules to the selected target JVM. That is expected behavior for this chaos type, but it is also an important
  privilege boundary because Byteman rules can execute code inside the target JVM with that process's privileges.

  This PR makes the local handling of temporary Byteman rule files more restrictive and adds a short note for operators that JVMChaos `ruleData`
  should be treated with similar care as `kubectl exec` access to selected pods.

  ## What's changed and how does it work?

  This PR updates the JVM chaos-daemon rule-file path so temporary Byteman rule files are created under a daemon-private temporary directory instead
  of directly under the shared system temp directory.

  The generated rule file is explicitly kept at `0600`, and the private temporary directory is kept at `0700`. The daemon also removes the temporary
  rule directory after the Byteman submit command finishes.

  A focused unit test was added to verify that rule data is written under a private temporary directory with restrictive permissions.

  This PR also adds a short JVMChaos examples note explaining that `ruleData` can execute code inside the selected JVM and should be treated as a
  privileged capability.

 Closes #4960 
  ## Related changes

  - [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
  - [ ] This change also requires further updates to the `UI interface`

  ## Checklist

  ### CHANGELOG

  - [ ] I have updated the `CHANGELOG.md`
  - [x] I have labeled this PR with "no-need-update-changelog"

  ### Tests

  - [x] Unit test
  - [ ] E2E test
  - [x] Manual test
  <img width="1108" height="111" alt="image" src="https://github.com/user-attachments/assets/53970f85-e0dd-485a-9041-2709d038fba4" />

  ### Side effects

  - [ ] **Breaking backward compatibility**
