### PR TITLE
fix(finalizers): propagate context and fix error handling in reconcilers

### DIFF
--- a/controllers/common/finalizers/controller.go
+++ b/controllers/common/finalizers/controller.go
@@ -60,12 +60,12 @@ type InitReconciler struct {
 func (r *InitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	obj := r.Object.DeepCopyObject().(v1alpha1.InnerObject)
 
-	if err := r.Client.Get(context.TODO(), req.NamespacedName, obj); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("chaos not found")
 		} else {
-			// TODO: handle this error
 			r.Log.Error(err, "unable to get chaos")
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
@@ -74,7 +74,7 @@ func (r *InitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if !ContainsFinalizer(obj.(metav1.Object), RecordFinalizer) {
 			r.Recorder.Event(obj, recorder.FinalizerInited{})
 			finalizers := append(obj.GetFinalizers(), RecordFinalizer)
-			return updateFinalizer(r.ReconcilerMeta, obj, req, finalizers)
+			return updateFinalizer(ctx, r.ReconcilerMeta, obj, req, finalizers)
 		}
 	}
 
@@ -90,12 +90,12 @@ type CleanReconciler struct {
 func (r *CleanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	obj := r.Object.DeepCopyObject().(v1alpha1.InnerObject)
 
-	if err := r.Client.Get(context.TODO(), req.NamespacedName, obj); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("chaos not found")
 		} else {
-			// TODO: handle this error
 			r.Log.Error(err, "unable to get chaos")
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
@@ -113,33 +113,32 @@ func (r *CleanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if obj.GetAnnotations()[AnnotationCleanFinalizer] == AnnotationCleanFinalizerForced || (resumed && len(finalizers) != 0) {
 			r.Recorder.Event(obj, recorder.FinalizerRemoved{})
 			finalizers = []string{}
-			return updateFinalizer(r.ReconcilerMeta, obj, req, finalizers)
+			return updateFinalizer(ctx, r.ReconcilerMeta, obj, req, finalizers)
 		}
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func updateFinalizer(r ReconcilerMeta, obj v1alpha1.InnerObject, req ctrl.Request, finalizers []string) (ctrl.Result, error) {
+func updateFinalizer(ctx context.Context, r ReconcilerMeta, obj v1alpha1.InnerObject, req ctrl.Request, finalizers []string) (ctrl.Result, error) {
 	updateError := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		obj := r.Object.DeepCopyObject().(v1alpha1.InnerObject)
 
-		if err := r.Client.Get(context.TODO(), req.NamespacedName, obj); err != nil {
+		if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
 			r.Log.Error(err, "unable to get chaos")
 			return err
 		}
 
 		obj.SetFinalizers(finalizers)
-		return r.Client.Update(context.TODO(), obj)
+		return r.Client.Update(ctx, obj)
 	})
 	if updateError != nil {
-		// TODO: handle this error
 		r.Log.Error(updateError, "fail to update")
 		r.Recorder.Event(obj, recorder.Failed{
 			Activity: "update finalizer",
-			Err:      "updateError.Error()",
+			Err:      updateError.Error(),
 		})
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, updateError
 	}
 
 	r.Recorder.Event(obj, recorder.Updated{


### PR DESCRIPTION
- Replace context.TODO() with the passed ctx in InitReconciler, CleanReconciler, and updateFinalizer so cancellation and deadlines from controller-runtime are respected
- Return errors from Client.Get failures instead of swallowing them, enabling controller-runtime exponential backoff retry
- Fix literal string bug: 'updateError.Error()' was recorded as a static string instead of calling .Error() on the actual error value
- Return updateError from updateFinalizer so failed updates trigger controller-runtime retry instead of silently succeeding

> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

> [!TIP]
> Please replace this with a brief description of the problem this PR solves.
> You can also close #issue_number if this PR solves the issue.

## What's changed and how does it work?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
