### PR TITLE
fix(api): handle json.Marshal error in AWSSelector, GCPSelector, Azur…

### DIFF
--- a/api/v1alpha1/awschaos_types.go
+++ b/api/v1alpha1/awschaos_types.go
@@ -115,9 +115,9 @@ func (obj *AWSChaos) GetSelectorSpecs() map[string]interface{} {
 }
 
 func (selector *AWSSelector) Id() string {
-	// TODO: handle the error here
-	// or ignore it is enough ?
-	json, _ := json.Marshal(selector)
-
-	return string(json)
+	b, err := json.Marshal(selector)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }

--- a/api/v1alpha1/azurechaos_types.go
+++ b/api/v1alpha1/azurechaos_types.go
@@ -108,9 +108,9 @@ func (obj *AzureChaos) GetSelectorSpecs() map[string]interface{} {
 }
 
 func (selector *AzureSelector) Id() string {
-	// TODO: handle the error here
-	// or ignore it is enough ?
-	json, _ := json.Marshal(selector)
-
-	return string(json)
+	b, err := json.Marshal(selector)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }

--- a/api/v1alpha1/gcpchaos_types.go
+++ b/api/v1alpha1/gcpchaos_types.go
@@ -100,11 +100,11 @@ func (obj *GCPChaos) GetSelectorSpecs() map[string]interface{} {
 }
 
 func (selector *GCPSelector) Id() string {
-	// TODO: handle the error here
-	// or ignore it is enough ?
-	json, _ := json.Marshal(selector)
-
-	return string(json)
+	b, err := json.Marshal(selector)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
 // GCPChaosStatus represents the status of a GCPChaos


### PR DESCRIPTION
…eSelector Id()

The Id() methods in AWSSelector, GCPSelector, and AzureSelector were silently discarding the error from json.Marshal using the blank identifier (_). This meant that if marshaling ever failed, the method would return an empty string with no indication of why, making it impossible to diagnose selector identity issues.

Since these selectors contain only basic Go types that json.Marshal cannot fail on, the error is truly impossible in practice. Replace the silent discard with an explicit panic so that any future change that introduces an unmarshalable field is caught immediately rather than silently producing an empty string.

> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

> [!TIP]
> Please replace this with a brief description of the problem this PR solves.
> You can also close #issue_number if this PR solves the issue.

## What's changed and how does it work?

> [!TIP]
> Please replace this with a brief description of the changes and how it works.
> You can also refer to a proposal or design doc if it exists.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
