### PR TITLE
fix(chaosdaemon): make JVMChaos work on distroless target containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
+- Fix JVMChaos injection into distroless target containers by avoiding target-rootfs shell and coreutils dependencies [#4971](https://github.com/chaos-mesh/chaos-mesh/pull/4971)
 
 ### Security
 

--- a/pkg/chaosdaemon/jvm_server.go
+++ b/pkg/chaosdaemon/jvm_server.go
@@ -18,7 +18,9 @@ package chaosdaemon
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -28,6 +30,14 @@ import (
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/util"
 )
+
+// mkdirInContainer creates dir inside the target container's mount namespace
+// by writing through /proc/<pid>/root from chaos-daemon. The target rootfs may
+// be distroless (no /bin/sh, no /bin/mkdir), so we cannot rely on nsexec'ing
+// any binary into the target mount namespace.
+func mkdirInContainer(pid uint32, dir string) error {
+	return os.MkdirAll(filepath.Join(fmt.Sprintf("/proc/%d/root", pid), dir), 0o755)
+}
 
 const (
 	bmInstallCommand = "bminstall.sh -b -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.compileToBytecode -p %d %d"
@@ -68,14 +78,13 @@ func (s *DaemonServer) InstallJVMRules(ctx context.Context,
 	}
 
 	// Copy byteman.jar, byteman-helper.jar and chaos-agent.jar into container's namespace.
+	// Distroless target containers (e.g. Google distroless, scratch-based Java
+	// images) do not ship /bin/sh or /bin/mkdir, so nsexec'ing a shell into the
+	// target mount namespace fails with exit 101. Operate on the container
+	// rootfs from chaos-daemon directly through /proc/<pid>/root instead.
 	if req.EnterNS {
-		processBuilder := bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("mkdir -p %s/lib/", bytemanHome)).SetContext(ctx).SetNS(pid, bpm.MountNS)
-		output, err := processBuilder.Build(ctx).CombinedOutput()
-		if err != nil {
-			return nil, err
-		}
-		if len(output) > 0 {
-			log.Info("mkdir", "output", string(output))
+		if err := mkdirInContainer(pid, fmt.Sprintf("%s/lib", bytemanHome)); err != nil {
+			return nil, errors.Wrap(err, "create byteman lib dir in container")
 		}
 
 		jars := []string{"byteman.jar", "byteman-helper.jar", "chaos-agent.jar"}
@@ -84,12 +93,11 @@ func (s *DaemonServer) InstallJVMRules(ctx context.Context,
 			source := fmt.Sprintf("%s/lib/%s", bytemanHome, jar)
 			dest := fmt.Sprintf("/usr/local/byteman/lib/%s", jar)
 
-			output, err = copyFileAcrossNS(ctx, source, dest, pid)
-			if err != nil {
+			if err := copyFileAcrossNS(ctx, source, dest, pid); err != nil {
 				return nil, err
 			}
 
-			log.Info("copy", "jar name", jar, "from source", source, "to destination", dest, "output", string(output))
+			log.Info("copy", "jar name", jar, "from source", source, "to destination", dest)
 		}
 	}
 
@@ -214,19 +222,27 @@ func writeDataIntoFile(data string, filename string) (string, error) {
 	return tmpfile.Name(), err
 }
 
-func copyFileAcrossNS(ctx context.Context, source string, dest string, pid uint32) ([]byte, error) {
+// copyFileAcrossNS copies a host-side file into the target container by writing
+// directly through /proc/<pid>/root. Avoids spawning sh / cat inside the target
+// mount namespace, which is unavailable on distroless containers.
+func copyFileAcrossNS(ctx context.Context, source string, dest string, pid uint32) error {
 	sourceFile, err := os.Open(source)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer sourceFile.Close()
 
-	processBuilder := bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("cat > %s", dest)).SetContext(ctx)
-	processBuilder = processBuilder.SetNS(pid, bpm.MountNS).SetStdin(sourceFile)
-	output, err := processBuilder.Build(ctx).CombinedOutput()
-	if err != nil {
-		return nil, err
+	hostDest := filepath.Join(fmt.Sprintf("/proc/%d/root", pid), dest)
+	if err := os.MkdirAll(filepath.Dir(hostDest), 0o755); err != nil {
+		return errors.Wrap(err, "create dest dir in container")
 	}
-
-	return output, nil
+	destFile, err := os.OpenFile(hostDest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return errors.Wrap(err, "open dest in container")
+	}
+	defer destFile.Close()
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		return errors.Wrap(err, "copy file into container")
+	}
+	return nil
 }

--- a/pkg/chaosdaemon/jvm_server.go
+++ b/pkg/chaosdaemon/jvm_server.go
@@ -36,7 +36,11 @@ import (
 // be distroless (no /bin/sh, no /bin/mkdir), so we cannot rely on nsexec'ing
 // any binary into the target mount namespace.
 func mkdirInContainer(pid uint32, dir string) error {
-	return os.MkdirAll(filepath.Join(fmt.Sprintf("/proc/%d/root", pid), dir), 0o755)
+	return os.MkdirAll(filepath.Join(containerRootPath(pid), dir), 0o755)
+}
+
+var containerRootPath = func(pid uint32) string {
+	return fmt.Sprintf("/proc/%d/root", pid)
 }
 
 const (
@@ -83,21 +87,8 @@ func (s *DaemonServer) InstallJVMRules(ctx context.Context,
 	// target mount namespace fails with exit 101. Operate on the container
 	// rootfs from chaos-daemon directly through /proc/<pid>/root instead.
 	if req.EnterNS {
-		if err := mkdirInContainer(pid, fmt.Sprintf("%s/lib", bytemanHome)); err != nil {
-			return nil, errors.Wrap(err, "create byteman lib dir in container")
-		}
-
-		jars := []string{"byteman.jar", "byteman-helper.jar", "chaos-agent.jar"}
-
-		for _, jar := range jars {
-			source := fmt.Sprintf("%s/lib/%s", bytemanHome, jar)
-			dest := fmt.Sprintf("/usr/local/byteman/lib/%s", jar)
-
-			if err := copyFileAcrossNS(ctx, source, dest, pid); err != nil {
-				return nil, err
-			}
-
-			log.Info("copy", "jar name", jar, "from source", source, "to destination", dest)
+		if err := copyBytemanJarsIntoContainer(ctx, bytemanHome, pid); err != nil {
+			return nil, err
 		}
 	}
 
@@ -222,6 +213,23 @@ func writeDataIntoFile(data string, filename string) (string, error) {
 	return tmpfile.Name(), err
 }
 
+func copyBytemanJarsIntoContainer(ctx context.Context, bytemanHome string, pid uint32) error {
+	if err := mkdirInContainer(pid, fmt.Sprintf("%s/lib", bytemanHome)); err != nil {
+		return errors.Wrap(err, "create byteman lib dir in container")
+	}
+
+	jars := []string{"byteman.jar", "byteman-helper.jar", "chaos-agent.jar"}
+	for _, jar := range jars {
+		source := fmt.Sprintf("%s/lib/%s", bytemanHome, jar)
+		dest := fmt.Sprintf("/usr/local/byteman/lib/%s", jar)
+
+		if err := copyFileAcrossNS(ctx, source, dest, pid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // copyFileAcrossNS copies a host-side file into the target container by writing
 // directly through /proc/<pid>/root. Avoids spawning sh / cat inside the target
 // mount namespace, which is unavailable on distroless containers.
@@ -232,7 +240,7 @@ func copyFileAcrossNS(ctx context.Context, source string, dest string, pid uint3
 	}
 	defer sourceFile.Close()
 
-	hostDest := filepath.Join(fmt.Sprintf("/proc/%d/root", pid), dest)
+	hostDest := filepath.Join(containerRootPath(pid), dest)
 	if err := os.MkdirAll(filepath.Dir(hostDest), 0o755); err != nil {
 		return errors.Wrap(err, "create dest dir in container")
 	}

--- a/pkg/chaosdaemon/jvm_server_test.go
+++ b/pkg/chaosdaemon/jvm_server_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chaosdaemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("jvm server", func() {
+	var (
+		containerRoot string
+		sourceFile    string
+	)
+
+	BeforeEach(func() {
+		containerRoot = GinkgoT().TempDir()
+		originalContainerRootPath := containerRootPath
+		containerRootPath = func(uint32) string {
+			return containerRoot
+		}
+		DeferCleanup(func() {
+			containerRootPath = originalContainerRootPath
+		})
+
+		sourceFile = filepath.Join(GinkgoT().TempDir(), "source.jar")
+		Expect(os.WriteFile(sourceFile, []byte("jar content"), 0o644)).To(Succeed())
+	})
+
+	Context("mkdirInContainer", func() {
+		It("creates directories through the container root", func() {
+			Expect(mkdirInContainer(123, "/usr/local/byteman/lib")).To(Succeed())
+
+			info, err := os.Stat(filepath.Join(containerRoot, "usr/local/byteman/lib"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+	})
+
+	Context("copyFileAcrossNS", func() {
+		It("copies a host file into the container root", func() {
+			Expect(copyFileAcrossNS(context.Background(), sourceFile, "/usr/local/byteman/lib/byteman.jar", 123)).To(Succeed())
+
+			content, err := os.ReadFile(filepath.Join(containerRoot, "usr/local/byteman/lib/byteman.jar"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(Equal("jar content"))
+		})
+
+		It("returns an error when the source file cannot be opened", func() {
+			err := copyFileAcrossNS(context.Background(), filepath.Join(GinkgoT().TempDir(), "missing.jar"), "/usr/local/byteman/lib/byteman.jar", 123)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when the destination directory cannot be created", func() {
+			Expect(os.WriteFile(filepath.Join(containerRoot, "usr"), []byte("not a directory"), 0o644)).To(Succeed())
+
+			err := copyFileAcrossNS(context.Background(), sourceFile, "/usr/local/byteman/lib/byteman.jar", 123)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("create dest dir in container"))
+		})
+
+		It("returns an error when the destination file cannot be opened", func() {
+			destDir := filepath.Join(containerRoot, "usr/local/byteman/lib/byteman.jar")
+			Expect(os.MkdirAll(destDir, 0o755)).To(Succeed())
+
+			err := copyFileAcrossNS(context.Background(), sourceFile, "/usr/local/byteman/lib/byteman.jar", 123)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("open dest in container"))
+		})
+	})
+
+	Context("copyBytemanJarsIntoContainer", func() {
+		It("copies byteman jars without using target-rootfs shell commands", func() {
+			bytemanHome := GinkgoT().TempDir()
+			Expect(os.MkdirAll(filepath.Join(bytemanHome, "lib"), 0o755)).To(Succeed())
+			for _, jar := range []string{"byteman.jar", "byteman-helper.jar", "chaos-agent.jar"} {
+				Expect(os.WriteFile(filepath.Join(bytemanHome, "lib", jar), []byte(jar), 0o644)).To(Succeed())
+			}
+
+			Expect(copyBytemanJarsIntoContainer(context.Background(), bytemanHome, 123)).To(Succeed())
+
+			for _, jar := range []string{"byteman.jar", "byteman-helper.jar", "chaos-agent.jar"} {
+				content, err := os.ReadFile(filepath.Join(containerRoot, "usr/local/byteman/lib", jar))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(jar))
+			}
+			_, err := os.Stat(filepath.Join(containerRoot, bytemanHome, "lib"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## What problem does this PR solve?

Addresses one specific failure mode reported in #4256: `JVMChaos` cannot install the byteman agent into target containers built on distroless / scratch-based Java base images (e.g. `gcr.io/distroless/java*`, jib- or CNB-built images). On those images every retry fails with:

```
rpc error: code = Unknown desc = exit status 101
```

and the chaos never reaches `phase: Injected`.

Root cause: `pkg/chaosdaemon/jvm_server.go` enters the target container's mount namespace and shells out to `mkdir` / `cat`:

```go
bpm.DefaultProcessBuilder("sh", "-c", "mkdir -p ...").SetNS(pid, bpm.MountNS)
bpm.DefaultProcessBuilder("sh", "-c", "cat > ...").SetNS(pid, bpm.MountNS)
```

This requires `/bin/sh` + `/bin/mkdir` + `/bin/cat` to exist in the *target* rootfs. Distroless Java images ship only `/usr/bin/java` — any binary nsexec'd into them fails with exit 101. @STRRL's quick workaround in the issue thread (drop the `sh -c` wrapper, leave bare `mkdir`) helps when `/bin/sh` is missing but `/bin/mkdir` exists; it doesn't help when neither does, which is the common case for production distroless images.

## What's changed and how does it work?

Stop entering the target mount namespace for these two filesystem operations. chaos-daemon already runs privileged in the host PID namespace and can see the container's rootfs at `/proc/<pid>/root`, so the same effect can be achieved from chaos-daemon's own view with plain Go `os.*` APIs:

- New helper `mkdirInContainer(pid, dir)` → `os.MkdirAll(filepath.Join("/proc/<pid>/root", dir), 0o755)`. Used by `InstallJVMRules` for the `$BYTEMAN_HOME/lib/` directory.
- `copyFileAcrossNS` rewritten to `os.OpenFile` + `io.Copy` on `/proc/<pid>/root/<dest>` instead of `sh -c "cat > $dest"` over `SetNS(pid, bpm.MountNS)`.

The shell-based agent-attach and rule-submit paths (`bminstall.sh`, `bmsubmit.sh`) are unchanged — those run in chaos-daemon's own container where `sh` is guaranteed to exist. No new capabilities required; chaos-daemon already traverses `/proc/<pid>/...` elsewhere.

No behavior change for non-distroless target containers — `os.MkdirAll` on `/proc/<pid>/root/<dir>` is idempotent and produces the same directory tree the previous `sh -c "mkdir -p"` did. File mode `0644` for copied jars and `0755` for the lib dir match the effective mode the previous flow produced (default umask 0022 in the privileged chaos-daemon container).

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [x] release-2.8
- [x] release-2.7

(The bug exists on every release that ships `pkg/chaosdaemon/jvm_server.go` with the `SetNS(pid, MountNS)` calls — confirmed reproducible on 2.8.x and present in current `master`.)

## Checklist

### CHANGELOG

- [x] I have updated the CHANGELOG.md

### Tests

- [x] Manual test

Validated against the Oracle Coherence Helidon `carts` service from the [sock-shop](https://github.com/oracle/coherence-helidon-sockshop-sample) sample (distroless, `/usr/bin` contains only `java`):

Before this PR:
```
rpc error: code = Unknown desc = exit status 101
(infinite retry, phase: Not Injected)
```

After this PR:
```yaml
status:
  experiment:
    containerRecords:
    - events:
      - operation: Apply
        type: Succeeded
      phase: Injected
      injectedCount: 1
```

And in the target JVM stderr (byteman):
```
Rule.execute called for com...CartResource-getItems-exception-...
Rule.execute called for com...CartResource-getItems-exception-...
```

i.e. the rule is actually firing on every invocation of the targeted method.

I'm happy to add a unit test for `copyFileAcrossNS` / `mkdirInContainer` (e.g. with a fake `/proc/<pid>/root` rooted at a tmpdir) if reviewers would like — let me know which side of the testability/scope tradeoff is preferred here.

## Other call sites affected by the same root cause

While preparing this PR I audited the other `SetNS(pid, bpm.MountNS)` call sites in `pkg/chaosdaemon/` to see which share this failure mode:

| Call site | Spawned binary | Same bug? |
|---|---|---|
| `dns_server.go` (3 sites, backup/replace/restore of `/etc/resolv.conf`) | `sh -c "ls/cp/sed/cat …"` | **Yes** — same `sh` + coreutils dependency on target rootfs. Should be rewritable along the same `/proc/<pid>/root` lines (with a small Go-side regex replace for the `nameserver` line). |
| `iochaos_server.go` (toda) | `todaBin` (chaos-mesh-shipped binary) | Same symptom, different cause — `toda` is not in the target rootfs, so `/proc/<pid>/root` doesn't help; would need a different approach (e.g. bind-mount or run from chaos-daemon view). |
| `blockchaos_server_linux.go` (`normalizeVolumeName`) | `SetNS(1, …)` targets host, not container — unaffected. |
| `jvm_server.go` (`bminstall.sh` / `bmsubmit.sh`) | gated on `NetNS` only or `EnableLocalMnt()`; `sh` resolves in chaos-daemon's own rootfs — unaffected. |

To keep this PR focused on #4256's reported `JVMChaos` failure and easy to review, I've intentionally **not** touched DNS chaos here. Happy to follow up with a second PR for DNS chaos (and possibly a separate proposal for the toda case) if reviewers prefer that split, or to expand this PR to cover DNS in one go — let me know which you'd like.
