### PR TITLE
feat(dashboard): support serving UI under a configurable subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
-- Make the dashboard UI build relocatable so it can be served from a non-root subpath behind a prefix-rewriting ingress, with an optional `VITE_BASE` build-time override for absolute bases [#4968](https://github.com/chaos-mesh/chaos-mesh/issues/4968)
+- Make the dashboard UI build relocatable so it can be served from a non-root subpath; combine with the new `UI_BASE_PATH` env / `dashboard.uiBasePath` helm value when the ingress does not prefix-rewrite [#4968](https://github.com/chaos-mesh/chaos-mesh/issues/4968)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
-- Make the dashboard UI build relocatable so it can be served from a non-root subpath behind a prefix-rewriting ingress [#4968](https://github.com/chaos-mesh/chaos-mesh/issues/4968)
+- Make the dashboard UI build relocatable so it can be served from a non-root subpath behind a prefix-rewriting ingress, with an optional `VITE_BASE` build-time override for absolute bases [#4968](https://github.com/chaos-mesh/chaos-mesh/issues/4968)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
+- Make the dashboard UI build relocatable so it can be served from a non-root subpath behind a prefix-rewriting ingress [#4968](https://github.com/chaos-mesh/chaos-mesh/issues/4968)
 
 ### Security
 

--- a/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -100,6 +100,8 @@ spec:
               value: "{{ .Values.dnsServer.create }}"
             - name: ROOT_URL
               value: "{{ tpl .Values.dashboard.rootUrl . }}"
+            - name: UI_BASE_PATH
+              value: {{ .Values.dashboard.uiBasePath | quote }}
             - name: ENABLE_PROFILING
               value: "{{ .Values.enableProfiling }}"
             {{- if .Values.dashboard.databaseSecretName }}

--- a/helm/chaos-mesh/values.schema.json
+++ b/helm/chaos-mesh/values.schema.json
@@ -533,6 +533,9 @@
                 "rootUrl": {
                     "type": "string"
                 },
+                "uiBasePath": {
+                    "type": "string"
+                },
                 "securityContext": {
                     "type": "object"
                 },

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -272,6 +272,12 @@ dashboard:
   databaseSecretName: ""
   # rootUrl specify the base url for openid/oauth2 (like GCP Auth Integration) callback URL.
   rootUrl: http://localhost:2333
+  # uiBasePath is the URL prefix the dashboard is served under, when behind an
+  # ingress or reverse-proxy that does NOT strip the prefix before forwarding.
+  # Example: "/chaos-mesh". Leave empty when serving at the root, or when the
+  # ingress already rewrites the prefix to "/". The server strips this prefix
+  # from incoming request paths so UI assets and /api routes match unchanged.
+  uiBasePath: ""
   # securityContext if needed
   securityContext: {}
   # running chaos-dashboard on host network

--- a/pkg/config/dashboard.go
+++ b/pkg/config/dashboard.go
@@ -48,6 +48,14 @@ type ChaosDashboardConfig struct {
 
 	RootUrl string `envconfig:"ROOT_URL" default:"http://localhost:2333" json:"root_path"`
 
+	// UIBasePath is the URL prefix the dashboard is served under, when behind an
+	// ingress / reverse-proxy that does NOT strip the prefix before forwarding.
+	// Example: "/chaos-mesh". Leave empty (the default) when serving at the root,
+	// or when the ingress already rewrites the prefix to "/". The server strips
+	// this prefix from incoming request paths so the embedded UI assets and the
+	// /api routes match unchanged.
+	UIBasePath string `envconfig:"UI_BASE_PATH" default:"" json:"ui_base_path"`
+
 	// enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon
 	EnableProfiling bool `envconfig:"ENABLE_PROFILING" default:"true" json:"-"`
 

--- a/pkg/dashboard/apiserver/server.go
+++ b/pkg/dashboard/apiserver/server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
@@ -60,6 +61,10 @@ func register(r *gin.Engine, conf *config.ChaosDashboardConfig) {
 func newEngine(config *config.ChaosDashboardConfig) *gin.Engine {
 	r := gin.Default()
 
+	if prefix := normalizeBasePath(config.UIBasePath); prefix != "" {
+		r.Use(stripBasePath(prefix))
+	}
+
 	if config.EnableProfiling {
 		// default is "/debug/pprof"
 		pprof.Register(r)
@@ -99,4 +104,35 @@ func newAPIRouter(r *gin.Engine) *gin.RouterGroup {
 	api.GET("/swagger/*any", swaggerserver.Handler)
 
 	return api
+}
+
+// normalizeBasePath returns the prefix with a single leading "/" and no trailing
+// "/", or an empty string if the input represents the root ("" or "/"). The
+// returned prefix is the form used for path matching by stripBasePath.
+func normalizeBasePath(p string) string {
+	p = "/" + strings.Trim(p, "/")
+	if p == "/" {
+		return ""
+	}
+	return p
+}
+
+// stripBasePath returns gin middleware that removes prefix from incoming
+// request paths so the rest of the router (UI assets and /api routes) can match
+// unchanged. The prefix must be a normalized base path produced by
+// normalizeBasePath. Paths that do not start with prefix (followed by "/" or
+// end-of-path) are passed through untouched, so the same binary continues to
+// work when the ingress already strips the prefix or when the dashboard is
+// served at the root.
+func stripBasePath(prefix string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p := c.Request.URL.Path
+		switch {
+		case p == prefix:
+			c.Request.URL.Path = "/"
+		case strings.HasPrefix(p, prefix+"/"):
+			c.Request.URL.Path = strings.TrimPrefix(p, prefix)
+		}
+		c.Next()
+	}
 }

--- a/pkg/dashboard/apiserver/server_test.go
+++ b/pkg/dashboard/apiserver/server_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestNormalizeBasePath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/", ""},
+		{"chaos-mesh", "/chaos-mesh"},
+		{"/chaos-mesh", "/chaos-mesh"},
+		{"/chaos-mesh/", "/chaos-mesh"},
+		{"chaos-mesh/", "/chaos-mesh"},
+		{"/a/b/c/", "/a/b/c"},
+	}
+	for _, tc := range cases {
+		if got := normalizeBasePath(tc.in); got != tc.want {
+			t.Errorf("normalizeBasePath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStripBasePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name    string
+		prefix  string
+		reqPath string
+		want    string
+	}{
+		{"exact prefix becomes root", "/chaos-mesh", "/chaos-mesh", "/"},
+		{"prefix with trailing slash becomes root", "/chaos-mesh", "/chaos-mesh/", "/"},
+		{"asset under prefix is stripped", "/chaos-mesh", "/chaos-mesh/assets/index.js", "/assets/index.js"},
+		{"api under prefix is stripped", "/chaos-mesh", "/chaos-mesh/api/experiments", "/api/experiments"},
+		{"unrelated path is untouched", "/chaos-mesh", "/assets/index.js", "/assets/index.js"},
+		{"sibling sharing prefix substring is untouched", "/chaos-mesh", "/chaos-mesh-other/foo", "/chaos-mesh-other/foo"},
+		{"root is untouched", "/chaos-mesh", "/", "/"},
+		{"nested prefix is stripped", "/a/b", "/a/b/c/d", "/c/d"},
+		{"nested prefix sibling is untouched", "/a/b", "/a/bc", "/a/bc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen string
+			r := gin.New()
+			r.Use(stripBasePath(tc.prefix))
+			r.NoRoute(func(c *gin.Context) {
+				seen = c.Request.URL.Path
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tc.reqPath, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if seen != tc.want {
+				t.Errorf("path after middleware = %q, want %q", seen, tc.want)
+			}
+		})
+	}
+}

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="The official, comprehensive Chaos Mesh dashboard user interface" />
     <title>Chaos Mesh</title>
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="%BASE_URL%favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />

--- a/ui/app/vite.config.ts
+++ b/ui/app/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
   return {
+    // Relative base so the built bundle is relocatable under any subpath
+    // (e.g. dashboard hosted at /chaos-mesh/ behind a prefix-rewriting ingress).
+    // See https://vite.dev/guide/build.html#public-base-path
+    base: './',
     resolve: {
       alias: {
         // https://github.com/react-dnd/react-dnd/issues/3416

--- a/ui/app/vite.config.ts
+++ b/ui/app/vite.config.ts
@@ -4,14 +4,19 @@ import { defineConfig, loadEnv } from 'vite'
 import svgr from 'vite-plugin-svgr'
 
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
+  // For production builds, default to a relative base ('./') so the bundle is
+  // relocatable under any subpath (e.g. dashboard hosted at /chaos-mesh/ behind
+  // a prefix-rewriting ingress). Downstream builders that need an absolute base
+  // (e.g. assets on a different origin) can override with VITE_BASE.
+  // Dev mode keeps the default '/' so HMR and /@vite/client work as expected.
+  // See https://vite.dev/guide/build.html#public-base-path
+  const base = command === 'build' ? env.VITE_BASE || './' : '/'
+
   return {
-    // Relative base so the built bundle is relocatable under any subpath
-    // (e.g. dashboard hosted at /chaos-mesh/ behind a prefix-rewriting ingress).
-    // See https://vite.dev/guide/build.html#public-base-path
-    base: './',
+    base,
     resolve: {
       alias: {
         // https://github.com/react-dnd/react-dnd/issues/3416


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #4968.

The chaos-dashboard UI cannot be hosted at a non-root path (e.g. `https://example.com/chaos-mesh/`). The browser fetches `index.html` successfully but then fails to load the JS bundles because they are referenced at absolute `/assets/...` paths with no `/chaos-mesh` prefix.

There are actually two distinct deployment shapes affected:

1. **Ingress prefix-rewrites** (`/chaos-mesh → /`) before forwarding to the pod. Common with Contour/HTTPProxy, nginx-ingress rewrite rules, etc. The dashboard always sees `/`, `/assets/...`, `/api/...`. Today this still fails because the embedded `index.html` has absolute `/assets/...` URLs — fine when the browser is at `/`, broken when it's at `/chaos-mesh/`.
2. **Ingress passes the prefix through** to the pod. The dashboard sees `/chaos-mesh/`, `/chaos-mesh/assets/...`, `/chaos-mesh/api/...`. Today this fails because the server has no way to know the deployed prefix, so neither the UI handler nor `/api` routes match.

The root cause is that the Vite build uses the default `base: '/'`, which bakes absolute `/assets/...` URLs into both `index.html` and the lazy-load chunk imports. The built assets are then compiled into the `chaos-dashboard` binary via `vfsgen` in `tools/assets_generate`, so no runtime knob can change them after build. None of the existing knobs (`dashboard.rootUrl` / `ROOT_URL`, `dashboard.env.*`, `dashboard.ingress.paths`) affect the embedded HTML payload — they only touch OAuth callbacks and the chart-generated Ingress object.

## What's changed and how does it work?

Two layers, working together to cover both deployment shapes with the same Docker image:

### 1. Relocatable client bundle (build-side)

**`ui/app/vite.config.ts`** — switch the production base to relative (`'./'`), gated to `command === 'build'` so dev-mode HMR and `/@vite/client` keep using `base: '/'` as before. Add an optional `VITE_BASE` env var so downstream builders that need an absolute base (e.g. assets on a different origin / CDN) can override at build time.

**`ui/app/index.html`** — change the one hand-written absolute path (`/favicon.ico`) to `%BASE_URL%favicon.ico` so it is also base-aware.

Verified after `pnpm build`:

```html
<link rel="icon" href="./favicon.ico" />
<script type="module" crossorigin src="./assets/index-<hash>.js"></script>
```

Lazy-load chunks in the main bundle also use relative specifiers (`import("./PodChaos-<hash>.js")`, etc.), which the ES module loader resolves against the importing chunk's URL. With `VITE_BASE=/chaos-mesh/ pnpm build`, all paths become absolute as expected.

This layer alone fixes the **prefix-rewriting ingress** case — `./assets/...` and `./favicon.ico` resolve against `document.baseURI`, which is whatever subpath the user opened.

### 2. Runtime base path (server-side)

For the **passthrough ingress** case the client bundle isn't enough — the server still needs to recognise its prefix so the embedded UI handler and the `/api` group can match.

**`pkg/config/dashboard.go`** — new `UIBasePath` field (env var `UI_BASE_PATH`, default empty).

**`pkg/dashboard/apiserver/server.go`** — when `UI_BASE_PATH` is non-empty, register a gin middleware in `newEngine` that strips the configured prefix from `c.Request.URL.Path` before route matching. The matcher is exact: `/foo` matches `/foo` and `/foo/...` but **not** `/foo-bar`, so sibling paths and unrelated URLs are never disturbed. A small `normalizeBasePath` helper accepts user inputs like `chaos-mesh`, `/chaos-mesh`, `/chaos-mesh/` and folds them all to `/chaos-mesh` — and treats `""` / `"/"` as "no prefix" (no middleware registered).

**`pkg/dashboard/apiserver/server_test.go`** — new table-driven tests covering both `normalizeBasePath` and the middleware's stripping behavior.

### 3. Helm chart wiring

- **`helm/chaos-mesh/values.yaml`** — new `dashboard.uiBasePath` value (default `""`) with explanatory comment.
- **`helm/chaos-mesh/templates/chaos-dashboard-deployment.yaml`** — wires the value to the container's `UI_BASE_PATH` env var.
- **`helm/chaos-mesh/values.schema.json`** — schema entry for the new value.

### What the API client and router already do (no changes needed)

- `ui/app/src/api/http.ts` already configures axios with the relative `baseURL: 'api'` (no leading slash), so XHRs resolve against `document.baseURI` and automatically pick up the subpath.
- `ui/app/src/router.tsx` uses `createHashRouter`, so client-side routes live entirely after `#` and never modify the URL path. (This also means the "deep link breaks assets" failure mode of `base: './'` on browser-router SPAs doesn't apply here.)

## Behaviour matrix — same image, three deployments

| Scenario | `UI_BASE_PATH` | Ingress behavior | What happens |
|---|---|---|---|
| Default — dashboard at root | unset | n/a | Identical to today |
| Prefix-rewriting ingress | unset | rewrites `/chaos-mesh → /` | Relative bundle resolves correctly; server unchanged |
| Passthrough ingress | `/chaos-mesh` | passes prefix through | Middleware strips prefix; relative bundle resolves against doc base |

This is strictly **additive** — existing deployments see no behavior change.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8

## Checklist

### CHANGELOG

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Unit test
- [ ] E2E test
- [x] Manual test

Tests added/performed:
- Unit tests in `pkg/dashboard/apiserver/server_test.go` covering `normalizeBasePath` (input variants → canonical form) and `stripBasePath` middleware (prefix match, exact-segment safety, root passthrough, unrelated paths). `go test ./pkg/dashboard/apiserver/ -run 'TestNormalizeBasePath|TestStripBasePath'` passes.
- Manual: `pnpm build` and inspected `dist/index.html` to confirm assets are referenced as `./assets/...` and the favicon as `./favicon.ico`. Re-ran with `VITE_BASE=/chaos-mesh/ pnpm build` and confirmed paths become `/chaos-mesh/assets/...`. Grepped the produced main chunk to confirm lazy-load chunk imports are emitted as relative specifiers.

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

All commits are signed off per the contributing guide.