### PR TITLE
fix(controllers): match ChaosImpl pair controllers by base name in enabledControllers

### DIFF
--- a/controllers/common/condition/step.go
+++ b/controllers/common/condition/step.go
@@ -24,10 +24,10 @@ import (
 
 func Step(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-condition")
-	name := ctx.Object.Name + "-condition"
-	if !config.ShouldSpawnController(name) {
+	if !config.ShouldSpawnController(ctx.Object.Name) {
 		return nil
 	}
+	name := ctx.Object.Name + "-condition"
 
 	setupLog.Info("setting up controller", "name", name)
 

--- a/controllers/common/desiredphase/step.go
+++ b/controllers/common/desiredphase/step.go
@@ -24,10 +24,10 @@ import (
 
 func Step(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-desiredphase")
-	name := ctx.Object.Name + "-desiredphase"
-	if !config.ShouldSpawnController(name) {
+	if !config.ShouldSpawnController(ctx.Object.Name) {
 		return nil
 	}
+	name := ctx.Object.Name + "-desiredphase"
 
 	setupLog.Info("setting up controller", "name", name)
 

--- a/controllers/common/finalizers/step.go
+++ b/controllers/common/finalizers/step.go
@@ -24,10 +24,10 @@ import (
 
 func InitStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-initFinalizers")
-	name := ctx.Object.Name + "-initFinalizers"
-	if !config.ShouldSpawnController(name) {
+	if !config.ShouldSpawnController(ctx.Object.Name) {
 		return nil
 	}
+	name := ctx.Object.Name + "-initFinalizers"
 
 	setupLog.Info("setting up controller", "name", name)
 
@@ -43,10 +43,10 @@ func InitStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 
 func CleanStep(ctx *pipeline.PipelineContext) reconcile.Reconciler {
 	setupLog := ctx.Logger.WithName("setup-cleanFinalizers")
-	name := ctx.Object.Name + "-cleanFinalizers"
-	if !config.ShouldSpawnController(name) {
+	if !config.ShouldSpawnController(ctx.Object.Name) {
 		return nil
 	}
+	name := ctx.Object.Name + "-cleanFinalizers"
 
 	setupLog.Info("setting up controller", "name", name)
 

--- a/controllers/common/fx.go
+++ b/controllers/common/fx.go
@@ -64,9 +64,9 @@ func Bootstrap(params Params) error {
 
 	setupLog := logger.WithName("setup-common")
 	for _, pair := range pairs {
-		name := pair.Name + "-records"
-		if !config.ShouldSpawnController(name) {
-			return nil
+		if !config.ShouldSpawnController(pair.Name) {
+			setupLog.Info("skipping disabled controller", "resource-name", pair.Name)
+			continue
 		}
 
 		setupLog.Info("setting up controller", "resource-name", pair.Name)


### PR DESCRIPTION
## What problem does this PR solve?

Closes #4753                                                                                                        

`controllerManager.enabledControllers` cannot selectively enable ChaosImpl-based controllers (e.g. `awschaos`, `networkchaos`, `podchaos`). The only working value is `"*"`. Specifying any controller by name silently starts zero ChaosImpl controllers.

## What's changed and how does it work?

Three bugs in the same code path:

1. **Name mismatch** — `Bootstrap()` in `controllers/common/fx.go` checked `ShouldSpawnController(pair.Name + "-records")`, but users specify the base name (e.g. `"awschaos"`, not `"awschaos-records"`). Fixed to check `pair.Name` directly.

2. **Early return** — The same function used `return nil` instead of `continue` when a pair didn't match, aborting the entire loop. All subsequent pairs were skipped even if they matched. Fixed to `continue`.

3. **Pipeline steps had the same suffix problem** — `finalizers/step.go`, `desiredphase/step.go`, and `condition/step.go` all checked suffixed names like `"awschaos-initFinalizers"`. Fixed to check `ctx.Object.Name` (the base name).

This makes ChaosImpl controllers consistent with non-ChaosImpl controllers (`podhttpchaos`, `workflow`, `schedule-cron`, etc.) which already check their base name.

### Verified manually                                     

- Deployed with `enabledControllers: [awschaos, podchaos]`
- Before fix: 0 controllers registered
- After fix: only `awschaos` and `podchaos` registered with all pipeline steps                                                          

## Related changes                                                                                                                      

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [x] release-2.8                                        
- [ ] release-2.7

## Checklist

### CHANGELOG

- [ ] I have updated the `CHANGELOG.md`                                                                                                 
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**