### PR TITLE
fix: reject descending status code ranges

### DIFF
--- a/api/v1alpha1/statuscheck_webhook.go
+++ b/api/v1alpha1/statuscheck_webhook.go
@@ -87,23 +87,28 @@ func (in *StatusCode) Validate(root interface{}, path *field.Path) field.ErrorLi
 			return packError(errors.New("not a single number or a range"))
 		}
 
-		validateRange := func(codeStr string) error {
+		validateRange := func(codeStr string) (int, error) {
 			code, err := strconv.Atoi(codeStr)
 			if err != nil {
-				return err
+				return 0, err
 			}
 			if !validateHTTPStatusCode(code) {
-				return errors.Errorf("invalid status code range, code: %d", code)
+				return 0, errors.Errorf("invalid status code range, code: %d", code)
 			}
-			return nil
+			return code, nil
 		}
 		start := codeStr[:index]
 		end := codeStr[index+1:]
-		if err := validateRange(start); err != nil {
+		startCode, err := validateRange(start)
+		if err != nil {
 			return packError(err)
 		}
-		if err := validateRange(end); err != nil {
+		endCode, err := validateRange(end)
+		if err != nil {
 			return packError(err)
+		}
+		if startCode > endCode {
+			return packError(errors.Errorf("invalid status code range, start code %d is greater than end code %d", startCode, endCode))
 		}
 	}
 	return nil

--- a/api/v1alpha1/statuscheck_webhook_test.go
+++ b/api/v1alpha1/statuscheck_webhook_test.go
@@ -18,9 +18,11 @@ package v1alpha1
 import (
 	"context"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var _ = Describe("statuscheck_webhook", func() {
@@ -133,6 +135,23 @@ var _ = Describe("statuscheck_webhook", func() {
 					},
 					expect: "incorrect status code format",
 				},
+				{
+					name: "invalid descending status code range",
+					statusCheck: StatusCheck{
+						Spec: StatusCheckSpec{
+							Type: TypeHTTP,
+							EmbedStatusCheck: &EmbedStatusCheck{
+								HTTPStatusCheck: &HTTPStatusCheck{
+									RequestUrl: "http://1.1.1.1",
+									Criteria: HTTPCriteria{
+										StatusCode: "400-200",
+									},
+								},
+							},
+						},
+					},
+					expect: "start code 400 is greater than end code 200",
+				},
 			}
 
 			for _, tc := range tcs {
@@ -147,3 +166,15 @@ var _ = Describe("statuscheck_webhook", func() {
 		})
 	})
 })
+
+func TestStatusCodeValidateRejectsDescendingRange(t *testing.T) {
+	statusCode := StatusCode("400-200")
+
+	allErrs := statusCode.Validate(nil, field.NewPath("statusCode"))
+	if len(allErrs) == 0 {
+		t.Fatal("expected descending status code range to be rejected")
+	}
+	if !strings.Contains(allErrs.ToAggregate().Error(), "start code 400 is greater than end code 200") {
+		t.Fatalf("expected descending range error, got: %s", allErrs.ToAggregate().Error())
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

`StatusCheck` accepts `criteria.statusCode: "400-200"`. Tiny footgun: the CRD allows any string, the webhook only checked both ends are valid codes, then runtime matching does `resp >= start && resp <= end`. So this range can never match, no matter what the endpoint returns.

Repro:
1. Create an HTTP StatusCheck with `criteria.statusCode: "400-200"`.
2. Before this patch, admission accepts it.
3. The check always misses, because no status code can be both `>= 400` and `<= 200`.

No cloud quota or hard resource limit blocks this. It is plain user input, so yeah, actually triggerable.

Related: #4749, but this does not close it.

## What's changed and how does it work?

Reject ranges where the start code is greater than the end code. Existing single codes and normal ranges like `200-400` keep working. Added unit coverage for the bad range.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog". Need maintainer help here, no label perms.

### Tests

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

Signed-off commit included.

Tested:
- `cd api && go test ./v1alpha1 -run TestStatusCodeValidateRejectsDescendingRange -count=1`
- `go test ./controllers/statuscheck/http -run Test_validateStatusCode -count=1`

Note: `cd api && go test ./v1alpha1 -run TestAPIs/statuscheck_webhook -count=1` needs local envtest binaries and fails here because `/usr/local/kubebuilder/bin/etcd` is missing.