### PR TITLE
fix(chaosdaemon): remove unused CopyTaskMap function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade byteman-helper to v4.0.22 [#4299](https://github.com/chaos-mesh/chaos-mesh/pull/4299)
 - GCP auth is changed to object with additional key `existingSecret` in helm chart values [#4303](https://github.com/chaos-mesh/chaos-mesh/pull/4303)
 - Add context to the http request to download the chart [#4304](https://github.com/chaos-mesh/chaos-mesh/pull/4304)
+- Remove unused `CopyTaskMap` function [#4983](https://github.com/chaos-mesh/chaos-mesh/pull/4983)
 
 ### Deprecated
 

--- a/pkg/chaosdaemon/tasks/task_manager.go
+++ b/pkg/chaosdaemon/tasks/task_manager.go
@@ -99,14 +99,6 @@ func (cm TaskManager) CopyTaskConfigManager() TaskConfigManager {
 	return tm
 }
 
-func (cm TaskManager) CopyTaskMap() map[IsID]Injectable {
-	pm := make(map[IsID]Injectable)
-	for pid, chaosOnProcess := range cm.taskMap {
-		cm.taskMap[pid] = chaosOnProcess
-	}
-	return pm
-}
-
 func (cm TaskManager) GetConfigWithUID(id TaskID) (TaskConfig, error) {
 	return cm.taskConfigManager.GetConfigWithUID(id)
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

CopyTaskMap was writing to cm.taskMap instead of the destination map pm, Causing the returned copy to always be empty

## What's changed and how does it work?

None

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [x] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
