### PR TITLE
fix: support DNSChaos injection on distroless containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Fixed DNSChaos injection failure on minimal/distroless containers by manipulating `resolv.conf` through `/proc/<pid>/root` instead of shell commands inside the target mount namespace [#4986](https://github.com/chaos-mesh/chaos-mesh/pull/4986)
 - Fixed NetworkChaos recovery failure when target container is in CrashLoopBackOff by falling back to sandbox (pause) container PID for network namespace operations
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)

--- a/pkg/chaosdaemon/dns_server.go
+++ b/pkg/chaosdaemon/dns_server.go
@@ -19,16 +19,16 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
-	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/util"
 )
 
-const (
+var (
 	// DNSServerConfFile is the default config file for DNS server
 	DNSServerConfFile = "/etc/resolv.conf"
 )
@@ -46,6 +46,12 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 		return nil, err
 	}
 
+	targetResolvPath := DNSServerConfFile
+	if req.EnterNS {
+		targetResolvPath = fmt.Sprintf("/proc/%d/root%s", pid, DNSServerConfFile)
+	}
+	backupPath := targetResolvPath + ".chaos.bak"
+
 	if req.Enable {
 		// set dns server to the chaos dns server's address
 
@@ -53,53 +59,64 @@ func (s *DaemonServer) SetDNSServer(ctx context.Context,
 			return nil, ErrInvalidDNSServer
 		}
 
-		// backup the /etc/resolv.conf
-		processBuilder := bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("ls %s.chaos.bak || cp %s %s.chaos.bak", DNSServerConfFile, DNSServerConfFile, DNSServerConfFile)).SetContext(ctx)
-		if req.EnterNS {
-			processBuilder = processBuilder.SetNS(pid, bpm.MountNS)
+		content, err := os.ReadFile(targetResolvPath)
+		if err != nil {
+			log.Error(err, "read resolv.conf error")
+			return nil, errors.Wrap(err, "read resolv.conf error")
 		}
 
-		cmd := processBuilder.Build(ctx)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, util.EncodeOutputToError(output, err)
-		}
-		if len(output) != 0 {
-			log.Info("command output", "output", string(output))
+		// backup the /etc/resolv.conf
+		if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+			err = os.WriteFile(backupPath, content, 0644)
+			if err != nil {
+				log.Error(err, "backup resolv.conf error")
+				return nil, errors.Wrap(err, "backup resolv.conf error")
+			}
+			log.Info("backup resolv.conf successfully", "path", backupPath)
 		}
 
 		// add chaos dns server to the first line of /etc/resolv.conf
-		// Note: can not replace the /etc/resolv.conf like `mv resolv_conf_dnschaos_temp resolv.conf`, will execute with error `Device or resource busy`
-		processBuilder = bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("cp %s /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver %s/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > %s && rm /etc/resolv_conf_dnschaos_temp", DNSServerConfFile, req.DnsServer, DNSServerConfFile)).SetContext(ctx)
-		if req.EnterNS {
-			processBuilder = processBuilder.SetNS(pid, bpm.MountNS)
+
+		lines := strings.Split(string(content), "\n")
+		nameserverLine := fmt.Sprintf("nameserver %s", req.DnsServer)
+		var newLines []string
+		replaced := false
+
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "nameserver") {
+				newLines = append(newLines, nameserverLine)
+				replaced = true
+			} else {
+				newLines = append(newLines, line)
+			}
+		}
+		if !replaced {
+			newLines = append([]string{nameserverLine}, newLines...)
 		}
 
-		cmd = processBuilder.Build(ctx)
-		output, err = cmd.CombinedOutput()
+		newContent := strings.Join(newLines, "\n")
+		err = os.WriteFile(targetResolvPath, []byte(newContent), 0644)
 		if err != nil {
-			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, util.EncodeOutputToError(output, err)
+			log.Error(err, "write resolv.conf error")
+			return nil, errors.Wrap(err, "write resolv.conf error")
 		}
-		if len(output) != 0 {
-			log.Info("command output", "output", string(output))
-		}
+		log.Info("write resolv.conf successfully", "path", targetResolvPath)
 	} else {
 		// recover the dns server's address
-		processBuilder := bpm.DefaultProcessBuilder("sh", "-c", fmt.Sprintf("ls %s.chaos.bak && cat %s.chaos.bak > %s || true", DNSServerConfFile, DNSServerConfFile, DNSServerConfFile)).SetContext(ctx)
-		if req.EnterNS {
-			processBuilder = processBuilder.SetNS(pid, bpm.MountNS)
-		}
-
-		cmd := processBuilder.Build(ctx)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			log.Error(err, "execute command error", "command", cmd.String(), "output", output)
-			return nil, util.EncodeOutputToError(output, err)
-		}
-		if len(output) != 0 {
-			log.Info("command output", "output", string(output))
+		if _, err := os.Stat(backupPath); err == nil {
+			content, err := os.ReadFile(backupPath)
+			if err != nil {
+				log.Error(err, "read backup resolv.conf error")
+				return nil, errors.Wrap(err, "read backup resolv.conf error")
+			}
+			err = os.WriteFile(targetResolvPath, content, 0644)
+			if err != nil {
+				log.Error(err, "restore resolv.conf error")
+				return nil, errors.Wrap(err, "restore resolv.conf error")
+			}
+			_ = os.Remove(backupPath)
+			log.Info("restore resolv.conf successfully", "path", targetResolvPath)
 		}
 	}
 

--- a/pkg/chaosdaemon/dns_server_test.go
+++ b/pkg/chaosdaemon/dns_server_test.go
@@ -198,4 +198,3 @@ func Test_SetDNSServer_Enable_EnterNS(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(string(backupContent)).To(Equal(initialContent))
 }
-

--- a/pkg/chaosdaemon/dns_server_test.go
+++ b/pkg/chaosdaemon/dns_server_test.go
@@ -17,7 +17,8 @@ package chaosdaemon_test
 
 import (
 	"context"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -33,16 +34,17 @@ import (
 func Test_SetDNSServer_Enable(t *testing.T) {
 	g := NewWithT(t)
 
-	type mockCmd struct {
-		cmd  string
-		args []string
-	}
-	var executedCommands []mockCmd
+	// Create a temp directory for testing
+	tmpDir := t.TempDir()
+	tempResolvConf := filepath.Join(tmpDir, "resolv.conf")
+	initialContent := "nameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:5\n"
+	err := os.WriteFile(tempResolvConf, []byte(initialContent), 0644)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
-		executedCommands = append(executedCommands, mockCmd{cmd, args})
-		return exec.Command("echo", "mock command")
-	})
+	// Override the configuration file path
+	originalConfFile := chaosdaemon.DNSServerConfFile
+	chaosdaemon.DNSServerConfFile = tempResolvConf
+	defer func() { chaosdaemon.DNSServerConfFile = originalConfFile }()
 
 	mock.With("MockContainerdClient", &test.MockClient{})
 
@@ -62,21 +64,22 @@ func Test_SetDNSServer_Enable(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res).NotTo(BeNil())
 
-	g.Expect(executedCommands).To(Equal([]mockCmd{
-		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak || cp /etc/resolv.conf /etc/resolv.conf.chaos.bak"}},
-		{cmd: "sh", args: []string{"-c", "cp /etc/resolv.conf /etc/resolv_conf_dnschaos_temp && sed -i 's/.*nameserver.*/nameserver 8.6.4.2/' /etc/resolv_conf_dnschaos_temp && cat /etc/resolv_conf_dnschaos_temp > /etc/resolv.conf && rm /etc/resolv_conf_dnschaos_temp"}},
-	}))
+	// Verify target resolv.conf contents
+	modifiedContent, err := os.ReadFile(tempResolvConf)
+	g.Expect(err).NotTo(HaveOccurred())
+	expectedContent := "nameserver 8.6.4.2\nnameserver 8.6.4.2\noptions ndots:5\n"
+	g.Expect(string(modifiedContent)).To(Equal(expectedContent))
+
+	// Verify backup file exists and has original contents
+	backupContent, err := os.ReadFile(tempResolvConf + ".chaos.bak")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(backupContent)).To(Equal(initialContent))
 }
 
 func Test_SetDNSServer_Enable_InvalidIP(t *testing.T) {
 	g := NewWithT(t)
 
 	cases := []string{"", "127.0.0.b", " 127.0.0.1", "127.0.0.1 ", ":g:1", "127.0.0.1;"}
-
-	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
-		g.Fail("no process should be executed")
-		return exec.Command("echo", "mock command")
-	})
 
 	mock.With("MockContainerdClient", &test.MockClient{})
 
@@ -102,16 +105,22 @@ func Test_SetDNSServer_Enable_InvalidIP(t *testing.T) {
 func Test_SetDNSServer_Disable(t *testing.T) {
 	g := NewWithT(t)
 
-	type mockCmd struct {
-		cmd  string
-		args []string
-	}
-	var executedCommands []mockCmd
+	// Create a temp directory for testing
+	tmpDir := t.TempDir()
+	tempResolvConf := filepath.Join(tmpDir, "resolv.conf")
+	initialContent := "nameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:5\n"
+	err := os.WriteFile(tempResolvConf, []byte("nameserver 8.6.4.2\noptions ndots:5\n"), 0644)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
-		executedCommands = append(executedCommands, mockCmd{cmd, args})
-		return exec.Command("echo", "mock command")
-	})
+	// Create the backup file
+	backupResolvConf := tempResolvConf + ".chaos.bak"
+	err = os.WriteFile(backupResolvConf, []byte(initialContent), 0644)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Override the configuration file path
+	originalConfFile := chaosdaemon.DNSServerConfFile
+	chaosdaemon.DNSServerConfFile = tempResolvConf
+	defer func() { chaosdaemon.DNSServerConfFile = originalConfFile }()
 
 	mock.With("MockContainerdClient", &test.MockClient{})
 
@@ -131,7 +140,62 @@ func Test_SetDNSServer_Disable(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res).NotTo(BeNil())
 
-	g.Expect(executedCommands).To(Equal([]mockCmd{
-		{cmd: "sh", args: []string{"-c", "ls /etc/resolv.conf.chaos.bak && cat /etc/resolv.conf.chaos.bak > /etc/resolv.conf || true"}},
-	}))
+	// Verify target resolv.conf contents are restored
+	restoredContent, err := os.ReadFile(tempResolvConf)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(restoredContent)).To(Equal(initialContent))
+
+	// Verify backup file has been deleted
+	_, err = os.Stat(backupResolvConf)
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
 }
+
+func Test_SetDNSServer_Enable_EnterNS(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a temp directory for testing
+	tmpDir := t.TempDir()
+	tempResolvConf := filepath.Join(tmpDir, "resolv.conf")
+	initialContent := "nameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:5\n"
+	err := os.WriteFile(tempResolvConf, []byte(initialContent), 0644)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Override the configuration file path
+	originalConfFile := chaosdaemon.DNSServerConfFile
+	chaosdaemon.DNSServerConfFile = tempResolvConf
+	defer func() { chaosdaemon.DNSServerConfFile = originalConfFile }()
+
+	mock.With("MockContainerdClient", &test.MockClient{})
+
+	// Mock the PID returned by MockContainerdClient to be the current process PID
+	myPid := os.Getpid()
+	mock.With("pid", myPid)
+
+	crc, err := crclients.CreateContainerRuntimeInfoClient(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	server := chaosdaemon.NewDaemonServerWithCRClient(crc, nil, logr.Discard())
+
+	res, err := server.SetDNSServer(context.TODO(), &pb.SetDNSServerRequest{
+		ContainerId: "containerd://foo",
+		DnsServer:   "8.6.4.2",
+		Enable:      true,
+		EnterNS:     true, // Test the new EnterNS logic using procfs path interpolation
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).NotTo(BeNil())
+
+	// Verify target resolv.conf contents
+	modifiedContent, err := os.ReadFile(tempResolvConf)
+	g.Expect(err).NotTo(HaveOccurred())
+	expectedContent := "nameserver 8.6.4.2\nnameserver 8.6.4.2\noptions ndots:5\n"
+	g.Expect(string(modifiedContent)).To(Equal(expectedContent))
+
+	// Verify backup file exists and has original contents
+	backupContent, err := os.ReadFile(tempResolvConf + ".chaos.bak")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(backupContent)).To(Equal(initialContent))
+}
+


### PR DESCRIPTION
## What problem does this PR solve?

Closes #4985

DNSChaos injection currently fails on minimal/distroless containers because the existing implementation depends on executing shell/coreutils binaries inside the target container mount namespace.

The current flow:
- enters the target mount namespace using `SetNS(pid, bpm.MountNS)`
- executes shell commands through `bpm`
- relies on binaries such as:

```sh
sh
cp
sed
cat
rm
```

inside the target container filesystem.

Minimal/distroless containers do not contain these binaries, causing DNSChaos injection to fail during command execution.

---

## What's changed and how does it work?

This PR removes the dependency on namespace shell execution for DNSChaos injection.

Previously the implementation:
- used `bpm` + `nsexec`
- entered the target mount namespace
- modified `/etc/resolv.conf` through shell commands

The new implementation:
- resolves the target container PID through `s.crClient`
- accesses the target container filesystem directly through:

```text
/proc/<pid>/root/etc/resolv.conf
```

- performs backup/restore and resolv.conf mutation using native Go filesystem APIs instead of shell utilities

This avoids:
- shell execution inside target MountNS
- dependency on container userspace tooling
- failures on distroless/minimal images

The unit tests were also updated from command-construction validation to actual filesystem behavior validation using temporary resolv.conf files.

This follows the direction discussed in #4985 around manipulating the target filesystem through `/proc/<pid>/root`.

---

## Related changes

- [ ] This change also requires further updates to the website (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**