### PR TITLE
fix(podhttpchaos): use configured TLS secret namespace and name when fetching secret

### DIFF
--- a/controllers/podhttpchaos/controller.go
+++ b/controllers/podhttpchaos/controller.go
@@ -160,7 +160,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Namespace: tlsKeys.SecretNamespace,
 			},
 		}
-		if err := r.Client.Get(context.TODO(), req.NamespacedName, &secret); err != nil {
+		if err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      tlsKeys.SecretName,
+			Namespace: tlsKeys.SecretNamespace,
+		}, &secret); err != nil {
 			r.Log.Error(err, "unable to get secret")
 			return ctrl.Result{}, nil
 		}

--- a/controllers/podhttpchaos/controller.go
+++ b/controllers/podhttpchaos/controller.go
@@ -160,12 +160,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Namespace: tlsKeys.SecretNamespace,
 			},
 		}
-		if err := r.Client.Get(context.TODO(), types.NamespacedName{
+		if err = r.Client.Get(ctx, types.NamespacedName{
 			Name:      tlsKeys.SecretName,
 			Namespace: tlsKeys.SecretNamespace,
 		}, &secret); err != nil {
 			r.Log.Error(err, "unable to get secret")
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, err
 		}
 
 		cert, ok := secret.Data[tlsKeys.CertName]


### PR DESCRIPTION
The reconciler was fetching the TLS secret using req.NamespacedName, which holds the namespace and name of the PodHttpChaos object — not the secret itself.
As a result, Kubernetes looked for the secret at the wrong location, couldn't find it, and the entire TLS chaos injection silently failed with no meaningful error.
The fix passes the correct NamespacedName built from tlsKeys.SecretName and tlsKeys.SecretNamespace — which is where the secret actually lives.