### PR TITLE
fix(security): patch CRITICAL/HIGH CVEs in container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Upgrade go packages to fix vulnerabilities [#4830](https://github.com/chaos-mesh/chaos-mesh/issues/4830)
 - Upgrade ui packages to fix vulnerabilities [#4838](https://github.com/chaos-mesh/chaos-mesh/pull/4838)
+- Patch CRITICAL/HIGH CVEs in the container images [#4996](https://github.com/chaos-mesh/chaos-mesh/pull/4996)
 
 ## [2.8.0] - 2025-09-30
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/chaos-mesh/chaos-mesh/api
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137

--- a/e2e-test/cmd/e2e_helper/Dockerfile
+++ b/e2e-test/cmd/e2e_helper/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine3.23
+FROM golang:1.25-alpine3.23
 
 WORKDIR /src
 

--- a/e2e-test/cmd/e2e_helper/go.mod
+++ b/e2e-test/cmd/e2e_helper/go.mod
@@ -1,6 +1,6 @@
 module github.com/chaos-mesh/chaos-mesh/test/cmd/e2e_helper
 
-go 1.25.8
+go 1.25.11
 
 require github.com/containerd/cgroups/v3 v3.0.5
 

--- a/e2e-test/go.mod
+++ b/e2e-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/chaos-mesh/chaos-mesh/e2e-test
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/chaos-mesh/chaos-mesh v0.0.0-00010101000000-000000000000
@@ -80,7 +80,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/e2e-test/go.sum
+++ b/e2e-test/go.sum
@@ -149,8 +149,8 @@ github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3v
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chaos-mesh/chaos-mesh
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
@@ -19,7 +19,7 @@ require (
 	github.com/chaos-mesh/fx-logr v0.1.0
 	github.com/chaos-mesh/k8s_dns_chaos v0.2.0
 	github.com/containerd/cgroups v1.1.0
-	github.com/containerd/containerd v1.7.30
+	github.com/containerd/containerd v1.7.32
 	github.com/creachadair/jrpc2 v1.3.5
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/gin-contrib/pprof v1.3.0
@@ -205,7 +205,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -229,7 +229,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaD
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
@@ -449,8 +449,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
-github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
@@ -545,8 +545,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=

--- a/images/build-env/Dockerfile
+++ b/images/build-env/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install -g pnpm@9
 
 ARG TARGET_PLATFORM=amd64
 
-RUN curl -fsS https://dl.google.com/go/go1.25.8.linux-$TARGET_PLATFORM.tar.gz | tar -xz -C /usr/local
+RUN curl -fsS https://dl.google.com/go/go1.25.11.linux-$TARGET_PLATFORM.tar.gz | tar -xz -C /usr/local
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOCACHE=/tmp/go-build
 ENV GOPATH=/tmp/go

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -29,7 +29,7 @@ RUN case "$TARGET_PLATFORM" in \
     esac; \
     curl -L https://github.com/chaos-mesh/nsexec/releases/download/v0.1.6/nsexec-$NSEXEC_ARCH-unknown-linux-gnu.tar.gz | tar xz -C /tmp/bin; \
     curl -L https://github.com/chaos-mesh/chaos-tproxy/releases/download/v0.5.3/tproxy-$NSEXEC_ARCH.tar.gz | tar xz -C /tmp/bin; \
-    curl -L https://github.com/chaos-mesh/memStress/releases/download/v0.3/memStress_v0.3-$NSEXEC_ARCH-linux-gnu.tar.gz | tar xz -C /tmp/bin
+    curl -L https://github.com/chaos-mesh/memStress/releases/download/v0.3.1/memStress_v0.3.1-$NSEXEC_ARCH-linux-gnu.tar.gz | tar xz -C /tmp/bin
 
 # ---
 FROM debian:bookworm-slim
@@ -43,7 +43,7 @@ ENV https_proxy=$HTTPS_PROXY
 RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
     apt update --allow-releaseinfo-change && apt upgrade -y && \
-    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-17-jre && \
+    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-17-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \

--- a/images/chaos-mesh/Dockerfile
+++ b/images/chaos-mesh/Dockerfile
@@ -3,6 +3,6 @@ FROM alpine:3.23
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
 
-RUN apk add tzdata --no-cache
+RUN apk upgrade --no-cache && apk add tzdata --no-cache
 
 COPY bin/chaos-controller-manager /usr/local/bin/chaos-controller-manager


### PR DESCRIPTION
## What this PR does

Fixes the **CRITICAL/HIGH** container-image CVEs that are within this repo's
control, as a basis for the next patch release.

## How the CVEs were found

Pulled the released **v2.8.2** images (`linux/amd64`) from `ghcr.io/chaos-mesh`
and scanned them with **Trivy 0.71.0** (`--scanners vuln`, OS + lang packages).

| Image | Base | CRITICAL | HIGH | Dominant source |
|---|---|---:|---:|---|
| `chaos-mesh` | alpine 3.21.6 | 2 | 27 | Go stdlib + alpine openssl |
| `chaos-daemon` | debian 12.13 | 18 | 124 | `memStress` (Go 1.16) = 120 CVEs |
| `chaos-dashboard` | debian 12.13 | 7 | 34 | Go stdlib + debian openssl |

## Fixes in this PR

| Change | CVEs addressed |
|---|---|
| **Go toolchain `1.25.8 → 1.25.11`** (`build-env` + all three `go` directives) | 17 Go **stdlib** CVEs across all 4 binaries (incl. **2 CRITICAL** in `chaos-mesh`). Verified `go1.25.11` fixes all 17. |
| **`containerd` `1.7.30 → 1.7.32`** | CVE-2026-46680 (HIGH); pulls `moby/spdystream 0.5.1` transitively |
| **`memStress` release `v0.3 → v0.3.1`** | The v0.3 binary was built with **Go 1.16**; v0.3.1 is the same source rebuilt with a modern Go toolchain + refreshed deps (see **chaos-mesh/memStress#10**). Removes **~120** CVEs (**5 CRITICAL + 57 HIGH** stdlib + 1 MEDIUM `x/sys`) from `chaos-daemon`. |
| **`apk upgrade`** in `chaos-mesh` image | `libssl3`/`libcrypto3` (**2 CRITICAL**) + `musl`/`zlib` (HIGH) |
| Existing `apt upgrade` on rebuild (`chaos-daemon`, `chaos-dashboard`) | `openssl`/`libssl3`/`libgnutls30` (CRITICAL), `openjdk-17`, `libcap2`, `libtiff6`, `libgdk-pixbuf`, … (HIGH) |

## ⚠️ Dependency / ordering

The `chaos-daemon` image now downloads **memStress v0.3.1**, which does not exist
yet. It is produced by **chaos-mesh/memStress#10** — that PR must merge and the
`v0.3.1` tag be pushed (the new release workflow publishes the tarballs) **before**
the `chaos-daemon` image build here will succeed. This PR is kept as a **draft**
until then.

## Known remaining items (out of scope / no fix available)

- **`github.com/docker/docker` v28.5.2** — the only fixed advisory targets the
  unreleased **v29.3.1** (a major bump, not yet tagged on moby); the remaining
  HIGH advisories have no fix. These are docker-daemon-side issues and are very
  likely not reachable via Chaos Mesh's client-only usage. Deferred.
- **Debian "won't-fix" CVEs** inherent to the `bookworm` base. The daemon needs a
  full distro (iptables/ebtables/ipset/jvm), so distroless is not an option here.

## Notes

- Verified locally: `go mod verify`, `chaos-controller-manager`/`chaos-dashboard`
  compile, and the `containerd` crclient packages cross-compile for `linux/amd64`.
- Targeted at `master`. If a **v2.8.3** backport is desired, these changes can be
  cherry-picked onto `release-2.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
