### PR TITLE
chore: ready for release 2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- Nothing
+
+### Security
+
+- Nothing
+
+## [2.8.3] - 2026-06-07
+
+### Added
+
+- Nothing
+
+### Changed
+
 - Replace fmt.Errorf with pkg/errors for consistent error handling [#4845](https://github.com/chaos-mesh/chaos-mesh/pull/4845)
 - Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4910](https://github.com/chaos-mesh/chaos-mesh/pull/4910)
 

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -45,7 +45,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "v2.8.2"
+  tag: "v2.8.3"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Prepares the **v2.8.3** patch release, following the [Release Guide](https://github.com/chaos-mesh/chaos-mesh/wiki/Release-Guide) (same shape as the 2.8.1 prep, #4810).

## Changes

- **CHANGELOG.md** — roll the accumulated `[Unreleased]` entries into `## [2.8.3] - 2026-06-07` and add a fresh empty `[Unreleased]` section. The 2.8.3 entry of note is the security patch (#4996 backported via #4997).
- **helm/chaos-mesh/values.yaml** — bump the global image tag `v2.8.2 → v2.8.3`.

## Follow-up after merge (per Release Guide)

1. Create a GitHub Release with tag **`v2.8.3`** on `release-2.8` → CI builds/pushes the images and uploads to the CDN.
2. Tag the Helm chart: `git tag chart-2.8.3 && git push upstream chart-2.8.3`.
3. Sync the CHANGELOG back to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
