### PR TITLE
fix(ui): show errors without API responses

### DIFF
--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -49,6 +49,11 @@ export const applyErrorHandling = ({
                 type: 'error',
                 message: 'Please check the validity of the token',
               })
+            } else {
+              openAlert({
+                type: 'error',
+                message: data.message || 'An unknown error occurred',
+              })
             }
 
             break
@@ -61,6 +66,11 @@ export const applyErrorHandling = ({
 
               resetAPIAuthentication()
               removeToken()
+            } else {
+              openAlert({
+                type: 'error',
+                message: data.message || 'An unknown error occurred',
+              })
             }
 
             break

--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -56,10 +56,10 @@ export const applyErrorHandling = ({
         })
         resetAPIAuthentication()
         removeToken()
-      } else if (data) {
+      } else {
         openAlert({
           type: 'error',
-          message: data.message || 'An unknown error occurred',
+          message: data?.message || 'An unknown error occurred',
         })
       }
 

--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -37,6 +37,11 @@ export const applyErrorHandling = ({
     (response) => response,
     (error: AxiosError<ErrorData>) => {
       const data = error.response?.data
+      const showAPIError = () =>
+        openAlert({
+          type: 'error',
+          message: data?.message || 'An unknown error occurred',
+        })
 
       if (data) {
         // slice(10): error.api.xxx => xxx
@@ -50,10 +55,7 @@ export const applyErrorHandling = ({
                 message: 'Please check the validity of the token',
               })
             } else {
-              openAlert({
-                type: 'error',
-                message: data.message || 'An unknown error occurred',
-              })
+              showAPIError()
             }
 
             break
@@ -67,23 +69,19 @@ export const applyErrorHandling = ({
               resetAPIAuthentication()
               removeToken()
             } else {
-              openAlert({
-                type: 'error',
-                message: data.message || 'An unknown error occurred',
-              })
+              showAPIError()
             }
 
             break
           case 'no_cluster_privilege':
           case 'no_namespace_privilege':
           default:
-            openAlert({
-              type: 'error',
-              message: data.message || 'An unknown error occurred',
-            })
+            showAPIError()
 
             break
         }
+      } else {
+        showAPIError()
       }
 
       return Promise.reject(error)


### PR DESCRIPTION
## What problem does this PR solve?

Dashboard's global API interceptor silently drops errors without a response body, such as network or CORS failures. Users receive no visible feedback when those requests fail.

## What's changed and how does it work?

Preserve current token and privilege-error handling. For other errors, show the backend message when available and a generic fallback when Axios has no response body.

## Repro

1. Open the dashboard.
2. Trigger an API request that fails before returning a response body.
3. Dashboard now displays `An unknown error occurred` instead of failing silently.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

Maintainer action: apply `no-need-update-changelog` (external contributors cannot set upstream labels).

### Tests

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

Validation:

- `pnpm -F @ui/app exec eslint src/api/interceptors.ts`
- `pnpm exec prettier --check app/src/api/interceptors.ts`
- `pnpm build`
- `pnpm test` (9 tests passed)
- `git diff --check`

### Side effects

- [ ] **Breaking backward compatibility**
