### PR TITLE
ci: extract Build Chaos Mesh Build Env step into composite action

### DIFF
--- a/.github/actions/build-chaos-mesh-build-env/action.yml
+++ b/.github/actions/build-chaos-mesh-build-env/action.yml
@@ -1,0 +1,30 @@
+name: 'Build Chaos Mesh Build Env'
+description: 'Builds the Chaos Mesh build environment image'
+inputs:
+  use-docker-cache:
+    description: 'Whether to use Docker cache during build'
+    required: false
+    default: 'false'
+runs:
+  using: "composite"
+  steps:
+    - name: Build Chaos Mesh Build Env
+      shell: bash
+      env:
+        IMAGE_BUILD_ENV_BUILD: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') || false }}
+        USE_DOCKER_CACHE: ${{ inputs.use-docker-cache }}
+      run: |
+        if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
+          export IMAGE_BUILD_ENV_BUILD=1;
+        else
+          export IMAGE_BUILD_ENV_BUILD=0;
+        fi
+        if [ "${USE_DOCKER_CACHE}" = "true" ] ; then
+          make \
+            DOCKER_CACHE=1 \
+            DOCKER_CACHE_DIR="$GITHUB_WORKSPACE/cache" \
+            GO_BUILD_CACHE="$GITHUB_WORKSPACE/cache" \
+            image-build-env
+        else
+          make image-build-env
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
               - go.*
               - '**.go'
               - 'helm/**'
+              - '.github/actions/build-chaos-mesh-build-env/**'
             ui:
               - 'ui/pnpm-lock.yaml'
               - '**.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build Chaos Mesh Build Env
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-
-          make image-build-env
+        uses: ./.github/actions/build-chaos-mesh-build-env
 
       - name: Build Chaos Mesh Dev Env
         env:

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -27,6 +27,7 @@ jobs:
               - go.*
               - '**.go'
               - 'helm/**'
+              - '.github/actions/build-chaos-mesh-build-env/**'
             ui:
               - 'ui/pnpm-lock.yaml'
               - '**.js'

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -27,7 +27,6 @@ jobs:
               - go.*
               - '**.go'
               - 'helm/**'
-              - '.github/actions/build-chaos-mesh-build-env/**'
             ui:
               - 'ui/pnpm-lock.yaml'
               - '**.js'

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -45,15 +45,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Build Chaos Mesh Build Env
         if: ${{ github.event.pull_request }}
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-          make image-build-env
+        uses: ./.github/actions/build-chaos-mesh-build-env
       - name: Build Chaos Mesh Dev Env
         if: ${{ github.event.pull_request }}
         env:
@@ -111,15 +103,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Build Chaos Mesh Build Env
         if: ${{ github.event.pull_request }}
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-          make image-build-env
+        uses: ./.github/actions/build-chaos-mesh-build-env
       - name: Build Chaos Mesh Dev Env
         if: ${{ github.event.pull_request }}
         env:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -33,6 +33,7 @@ jobs:
             test/integration_test/**
             .github/**
             !.github/workflows/e2e_test.yml
+            !.github/actions/build-chaos-mesh-build-env/**
       - name: Show outputs
         run: echo "${{ toJSON(steps.filter.outputs) }}"
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -46,16 +46,7 @@ jobs:
 
       - name: Build Chaos Mesh Build Env
         if: ${{ github.event.pull_request }}
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-
-          make image-build-env
+        uses: ./.github/actions/build-chaos-mesh-build-env
 
       - name: Build Chaos Mesh Dev Env
         if: ${{ github.event.pull_request }}

--- a/.github/workflows/upload_image_pr.yml
+++ b/.github/workflows/upload_image_pr.yml
@@ -29,20 +29,9 @@ jobs:
           DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --use --name chaos-mesh-builder
 
       - name: Build Chaos Mesh Build Env
-        env:
-          IMAGE_BUILD_ENV_BUILD: ${{ contains(github.event.pull_request.labels.*.name, 'rebuild-build-env-image') }}
-        run: |
-          if [ "${IMAGE_BUILD_ENV_BUILD}" = "true" ] ; then
-            export IMAGE_BUILD_ENV_BUILD=1;
-          else
-            export IMAGE_BUILD_ENV_BUILD=0;
-          fi
-
-          make \
-            DOCKER_CACHE=1 \
-            DOCKER_CACHE_DIR=$GITHUB_WORKSPACE/cache \
-            GO_BUILD_CACHE=$GITHUB_WORKSPACE/cache \
-            image-build-env
+        uses: ./.github/actions/build-chaos-mesh-build-env
+        with:
+          use-docker-cache: 'true'
 
       - name: Build Chaos Mesh Dev Env
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Bump go to 1.25.8 [#4867](https://github.com/chaos-mesh/chaos-mesh/pull/4867)
 - Upgrade e2e k8s versions to 1.35.2, 1.34.5 and 1.33.9 [#4872](https://github.com/chaos-mesh/chaos-mesh/pull/4872)
 - Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4910](https://github.com/chaos-mesh/chaos-mesh/pull/4910)
+- ci: extract Build Chaos Mesh Build Env step into composite action [#5000](https://github.com/chaos-mesh/chaos-mesh/pull/5000)
 
 ### Deprecated
 


### PR DESCRIPTION
## What problem does this PR solve?

The "Build Chaos Mesh Build Env" step was duplicated across 5 workflow files (`ci.yml`, `e2e_test.yml` x2, `integration_test.yml`, `upload_image_pr.yml`), making it hard to maintain. Any change to the step required updating all 5 files.

Closes #3265

## What's changed and how does it work?

Extracts the duplicated step into a composite action at `.github/actions/build-chaos-mesh-build-env/action.yml` as suggested by @STRRL.

The composite action accepts a `use-docker-cache` boolean input (default: `false`) to handle the docker cache variant used in `upload_image_pr.yml`. All 5 workflow files now reference the action via `uses: ./.github/actions/build-chaos-mesh-build-env`.

## Related changes
- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)
- [ ] release-2.8
- [ ] release-2.7

## Checklist
### CHANGELOG
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests
- [x] Manual test

### Side effects
- [ ] **Breaking backward compatibility**