### PR TITLE
fix(ui): Dashboard CRASH FIX:workflow topology null crash and Workflow-schedule/composite-node config crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Add missing NodeType for workflows api in dashboard [#4834](https://github.com/chaos-mesh/chaos-mesh/pull/4834)
+- Fix Dashboard crash when opening Serial/Parallel workflow node configuration due to null topology children [#5001](https://github.com/chaos-mesh/chaos-mesh/pull/5001)
 
 ### Security
 

--- a/ui/app/src/components/ObjectConfiguration/Node.tsx
+++ b/ui/app/src/components/ObjectConfiguration/Node.tsx
@@ -151,6 +151,11 @@ const NodeConfiguration: ReactFCWithChildren<NodeConfigurationProps> = ({ templa
       case 'Suspend':
       case 'StatusCheck':
       case 'Schedule':
+      case 'Serial':
+      case 'Parallel':
+        // Serial/Parallel are composite nodes with no chaos spec (and thus no selector), so
+        // render the simple name/type/deadline view rather than ObjectConfiguration, which
+        // expects a chaos kind.
         return <SimpleNode template={t} />
       case 'Task':
         return <Custom template={t} />

--- a/ui/app/src/components/ObjectConfiguration/index.tsx
+++ b/ui/app/src/components/ObjectConfiguration/index.tsx
@@ -110,13 +110,13 @@ const ObjectConfiguration: ReactFCWithChildren<ObjectConfigurationProps> = ({
           </Grid>
         )}
 
-        {(hasAddress || experiment.selector) && (
+        {(hasAddress || experiment?.selector) && (
           <Grid item xs={vertical ? 12 : 3}>
             <Typography variant="subtitle2" gutterBottom>
               {i18n('newE.steps.scope')}
             </Typography>
 
-            {experiment.selector && <Selector data={experiment.selector} />}
+            {experiment?.selector && <Selector data={experiment.selector} />}
 
             {hasAddress && (
               <Table>

--- a/ui/app/src/lib/cytoscape.ts
+++ b/ui/app/src/lib/cytoscape.ts
@@ -26,10 +26,11 @@ type RecursiveNodeDefinition = NodeDefinition | Array<string | RecursiveNodeDefi
 
 function generateWorkflowNodes(detail: WorkflowSingle) {
   const { entry, topology } = detail
-  if (!topology.nodes.length) {
+  // `nodes` is a Go slice that serializes to `null` (not `[]`) when empty, so guard with `?.`.
+  if (!topology.nodes?.length) {
     return []
   }
-  let entryNode: Node
+  let entryNode: Node | undefined
   const nodeMap = new Map(
     topology.nodes.map((n) => {
       if (n.template === entry) {
@@ -39,17 +40,22 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
       return [n.name, n]
     }),
   )
+  // Keep only child references that point at a node we actually have, so the recursion below
+  // never receives an undefined node (e.g. branches not yet spawned, or stale references).
+  const resolvable = (d: { name: string }) => d.name && nodeMap.has(d.name)
   function toCytoscapeNode(node: Node): RecursiveNodeDefinition {
     const { name, type, state, template } = node
 
-    if (type === 'SerialNode' && node.serial!.length) {
-      return [type, node.serial!.filter((d) => d.name).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
-    } else if (type === 'ParallelNode' && node.parallel!.length) {
-      return [type, node.parallel!.filter((d) => d.name).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
+    // `serial` / `parallel` / `conditional_branches` are nil-able Go slices and arrive as `null`
+    // for the node types that don't use them, so every length check must be null-safe (`?.`).
+    if (type === 'SerialNode' && node.serial?.length) {
+      return [type, node.serial.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
+    } else if (type === 'ParallelNode' && node.parallel?.length) {
+      return [type, node.parallel.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
     } else if (type === 'TaskNode' && node.conditional_branches?.length) {
       return [
         type,
-        node.conditional_branches!.filter((d) => d.name).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)),
+        node.conditional_branches.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)),
         node.name,
       ]
     } else {
@@ -65,7 +71,11 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
     }
   }
 
-  return [toCytoscapeNode(entryNode!)]
+  if (!entryNode) {
+    return []
+  }
+
+  return [toCytoscapeNode(entryNode)]
 }
 
 function mergeStates(nodes: NodeDefinition[]) {

--- a/ui/app/src/lib/cytoscape.ts
+++ b/ui/app/src/lib/cytoscape.ts
@@ -26,7 +26,8 @@ type RecursiveNodeDefinition = NodeDefinition | Array<string | RecursiveNodeDefi
 
 function generateWorkflowNodes(detail: WorkflowSingle) {
   const { entry, topology } = detail
-  // `nodes` is a Go slice that serializes to `null` (not `[]`) when empty, so guard with `?.`.
+  // `nodes` is a nil-able Go slice: a nil slice serializes to `null` (rather than `[]`), so
+  // guard the length check with `?.`.
   if (!topology.nodes?.length) {
     return []
   }
@@ -44,7 +45,7 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
   // yet spawned, so their name is still empty, or stale references) so the recursion below never
   // receives an undefined node. Keeping the lookup and the guard together avoids relying on a
   // non-null assertion that a separate filter would have to keep in sync.
-  const childNodes = (children: Array<{ name: string }>): RecursiveNodeDefinition[] =>
+  const childNodes = (children: Array<{ name?: string | null }>): RecursiveNodeDefinition[] =>
     children.flatMap((d) => {
       if (!d.name) {
         return []

--- a/ui/app/src/lib/cytoscape.ts
+++ b/ui/app/src/lib/cytoscape.ts
@@ -42,7 +42,7 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
   )
   // Keep only child references that point at a node we actually have, so the recursion below
   // never receives an undefined node (e.g. branches not yet spawned, or stale references).
-  const resolvable = (d: { name: string }) => d.name && nodeMap.has(d.name)
+  const resolvable = (d: { name: string }) => Boolean(d.name) && nodeMap.has(d.name)
   function toCytoscapeNode(node: Node): RecursiveNodeDefinition {
     const { name, type, state, template } = node
 

--- a/ui/app/src/lib/cytoscape.ts
+++ b/ui/app/src/lib/cytoscape.ts
@@ -41,11 +41,14 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
     }),
   )
   // Resolve child references to their nodes, dropping any that aren't present (e.g. branches not
-  // yet spawned, or stale references) so the recursion below never receives an undefined node.
-  // Keeping the lookup and the guard together avoids relying on a non-null assertion that a
-  // separate filter would have to keep in sync.
+  // yet spawned, so their name is still empty, or stale references) so the recursion below never
+  // receives an undefined node. Keeping the lookup and the guard together avoids relying on a
+  // non-null assertion that a separate filter would have to keep in sync.
   const childNodes = (children: Array<{ name: string }>): RecursiveNodeDefinition[] =>
     children.flatMap((d) => {
+      if (!d.name) {
+        return []
+      }
       const child = nodeMap.get(d.name)
       return child ? [toCytoscapeNode(child)] : []
     })
@@ -53,13 +56,17 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
     const { name, type, state, template } = node
 
     // `serial` / `parallel` / `conditional_branches` are nil-able Go slices and arrive as `null`
-    // for the node types that don't use them, so every length check must be null-safe (`?.`).
-    if (type === 'SerialNode' && node.serial?.length) {
-      return [type, childNodes(node.serial), node.name]
-    } else if (type === 'ParallelNode' && node.parallel?.length) {
-      return [type, childNodes(node.parallel), node.name]
-    } else if (type === 'TaskNode' && node.conditional_branches?.length) {
-      return [type, childNodes(node.conditional_branches), node.name]
+    // for the node types that don't use them, so normalize to an array before using them.
+    const serial = node.serial ?? []
+    const parallel = node.parallel ?? []
+    const conditionalBranches = node.conditional_branches ?? []
+
+    if (type === 'SerialNode' && serial.length) {
+      return [type, childNodes(serial), node.name]
+    } else if (type === 'ParallelNode' && parallel.length) {
+      return [type, childNodes(parallel), node.name]
+    } else if (type === 'TaskNode' && conditionalBranches.length) {
+      return [type, childNodes(conditionalBranches), node.name]
     } else {
       return {
         data: {

--- a/ui/app/src/lib/cytoscape.ts
+++ b/ui/app/src/lib/cytoscape.ts
@@ -40,24 +40,26 @@ function generateWorkflowNodes(detail: WorkflowSingle) {
       return [n.name, n]
     }),
   )
-  // Keep only child references that point at a node we actually have, so the recursion below
-  // never receives an undefined node (e.g. branches not yet spawned, or stale references).
-  const resolvable = (d: { name: string }) => Boolean(d.name) && nodeMap.has(d.name)
+  // Resolve child references to their nodes, dropping any that aren't present (e.g. branches not
+  // yet spawned, or stale references) so the recursion below never receives an undefined node.
+  // Keeping the lookup and the guard together avoids relying on a non-null assertion that a
+  // separate filter would have to keep in sync.
+  const childNodes = (children: Array<{ name: string }>): RecursiveNodeDefinition[] =>
+    children.flatMap((d) => {
+      const child = nodeMap.get(d.name)
+      return child ? [toCytoscapeNode(child)] : []
+    })
   function toCytoscapeNode(node: Node): RecursiveNodeDefinition {
     const { name, type, state, template } = node
 
     // `serial` / `parallel` / `conditional_branches` are nil-able Go slices and arrive as `null`
     // for the node types that don't use them, so every length check must be null-safe (`?.`).
     if (type === 'SerialNode' && node.serial?.length) {
-      return [type, node.serial.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
+      return [type, childNodes(node.serial), node.name]
     } else if (type === 'ParallelNode' && node.parallel?.length) {
-      return [type, node.parallel.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)), node.name]
+      return [type, childNodes(node.parallel), node.name]
     } else if (type === 'TaskNode' && node.conditional_branches?.length) {
-      return [
-        type,
-        node.conditional_branches.filter(resolvable).map((d) => toCytoscapeNode(nodeMap.get(d.name)!)),
-        node.name,
-      ]
+      return [type, childNodes(node.conditional_branches), node.name]
     } else {
       return {
         data: {


### PR DESCRIPTION
This PR fixes two crashes on the workflow detail page in the dashboard UI. Both manifest as an "Unexpected Application Error!" that blanks the whole page via the react-router error boundary.

## 1. Topology graph crash — `Cannot read properties of null (reading 'length')`

Thrown while building the topology graph when the page loads.

**Root cause:** `topology.nodes[].serial` / `.parallel` / `.conditional_branches` are nil-able Go slices (`Node.Serial` / `Parallel` / `ConditionalBranches` in `pkg/dashboard/core/workflow.go`) that serialize to JSON `null` for the node types that don't use them. `generateWorkflowNodes` (`ui/app/src/lib/cytoscape.ts`) already guarded the `TaskNode` branch with `?.` (#2308) but still used non-null assertions `node.serial!.length` / `node.parallel!.length`, so any `SerialNode` / `ParallelNode` whose slice came back `null` threw. The top-level `topology.nodes` check and the `entryNode` lookup were unguarded too.

**Fix:**
- optional chaining for the `serial` / `parallel` / `topology.nodes` length checks
- a single `childNodes` helper that resolves each child via `nodeMap` and drops the ones that aren't present, so the recursion never receives an undefined node and no non-null assertion is needed
- return `[]` when the entry node can't be found instead of dereferencing a possibly-undefined value

## 2. Object config crash — `Cannot read properties of undefined (reading 'selector')`

Thrown when opening the configuration for an object whose template/schedule type has no chaos field — reproduced by clicking a **Workflow-type Schedule** on the Schedules page, and reachable the same way for `Serial`/`Parallel` workflow nodes.

**Root cause:** `ObjectConfiguration` (`ui/app/src/components/ObjectConfiguration/index.tsx`) computes `experiment = spec[templateTypeToFieldName(type)]`. `templateTypeToFieldName()` only maps the chaos kinds, so for a schedule with `spec.type: Workflow` (or a `Serial`/`Parallel` workflow node) it returns `undefined`, leaving `experiment` undefined — and `experiment.selector` then threw.

**Fix:**
- defensively guard `experiment?.selector` in `ObjectConfiguration` so a non-chaos type (Workflow schedule, composite workflow node, etc.) no longer crashes the scope section
- additionally route `Serial`/`Parallel` workflow nodes to the simple name/type/deadline view in `NodeConfiguration`, since they have no chaos spec or selector

## Testing

Ran the dashboard UI from source (`pnpm exec vite`) against a live cluster and confirmed both the workflow topology and the Serial/Parallel node config modals render instead of crashing. `tsc --noEmit` and `eslint` pass for the changed files.
