### PR TITLE
fix(jvmchaos): fix MySQL action for PreparedStatement and add Connect…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Fix JVMChaos MySQL action never firing on PreparedStatement execution paths (null SQL causes silent NPE) [#4454](https://github.com/chaos-mesh/chaos-mesh/issues/4454)
+- Add MySQL Connector/J 9.x support for JVMChaos MySQL action
 - Fixed NetworkChaos recovery failure when target container is in CrashLoopBackOff by falling back to sandbox (pause) container PID for network namespace operations
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
 - Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
+- Add MySQL Connector/J 9.x support for JVMChaos MySQL action [#4454](https://github.com/chaos-mesh/chaos-mesh/issues/4454)
 
 ### Changed
 
@@ -45,7 +46,6 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Fixed
 
 - Fix JVMChaos MySQL action never firing on PreparedStatement execution paths (null SQL causes silent NPE) [#4454](https://github.com/chaos-mesh/chaos-mesh/issues/4454)
-- Add MySQL Connector/J 9.x support for JVMChaos MySQL action
 - Fixed NetworkChaos recovery failure when target container is in CrashLoopBackOff by falling back to sandbox (pause) container PID for network namespace operations
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)

--- a/api/v1alpha1/jvmchaos_types.go
+++ b/api/v1alpha1/jvmchaos_types.go
@@ -140,7 +140,7 @@ type JVMStressCfgSpec struct {
 //	SQL is "select * from test.t1",
 //	only when ((Database == "test" || Database == "") && (Table == "t1" || Table == "") && (SQLType == "select" || SQLType == "")) is true, JVMChaos will inject fault
 type JVMMySQLSpec struct {
-	// the version of mysql-connector-java, only support 5.X.X(set to "5") and 8.X.X(set to "8") now
+	// the version of mysql-connector-java/mysql-connector-j, supports 5.X.X(set to "5"), 8.X.X(set to "8") and 9.X.X(set to "9")
 	MySQLConnectorVersion string `json:"mysqlConnectorVersion,omitempty"`
 
 	// the match database

--- a/api/v1alpha1/jvmchaos_webhook.go
+++ b/api/v1alpha1/jvmchaos_webhook.go
@@ -82,8 +82,8 @@ func (in *JVMChaosSpec) Validate(root interface{}, path *field.Path) field.Error
 	case JVMMySQLAction:
 		if len(in.MySQLConnectorVersion) == 0 {
 			allErrs = append(allErrs, field.Invalid(path, in, "MySQL connector version not provided"))
-		} else if in.MySQLConnectorVersion != "5" && in.MySQLConnectorVersion != "8" {
-			allErrs = append(allErrs, field.Invalid(path, in, "MySQL connector version only support 5.X.X(set to 5) and 8.X.X(set to 8)"))
+		} else if in.MySQLConnectorVersion != "5" && in.MySQLConnectorVersion != "8" && in.MySQLConnectorVersion != "9" {
+			allErrs = append(allErrs, field.Invalid(path, in, "MySQL connector version supports 5.X.X(set to 5), 8.X.X(set to 8) and 9.X.X(set to 9)"))
 		}
 		if len(in.ThrowException) == 0 && in.LatencyDuration == 0 {
 			allErrs = append(allErrs, field.Invalid(path, in, "must set one of exception or latency"))

--- a/controllers/chaosimpl/jvmchaos/impl.go
+++ b/controllers/chaosimpl/jvmchaos/impl.go
@@ -248,19 +248,17 @@ func generateRuleData(spec *v1alpha1.JVMChaosSpec) error {
 	case v1alpha1.JVMMySQLAction:
 		var mysqlException string
 		bytemanTemplateSpec.Helper = SQLHelper
-		// the first parameter of matchDBTable is the database which the SQL execute in, because the SQL may not contain database, for example: select * from t1;
-		// can't get the database information now, so use a "" instead
-		// TODO: get the database information and fill it in matchDBTable function
-		bytemanTemplateSpec.Bind = fmt.Sprintf("flag:boolean=matchDBTable(\"\", $2, \"%s\", \"%s\", \"%s\")", spec.Database, spec.Table, spec.SQLType)
 		bytemanTemplateSpec.Condition = "flag"
 		if spec.MySQLConnectorVersion == "5" {
 			bytemanTemplateSpec.Class = MySQL5InjectClass
 			bytemanTemplateSpec.Method = MySQL5InjectMethod
 			mysqlException = MySQL5Exception
-		} else if spec.MySQLConnectorVersion == "8" {
+			bytemanTemplateSpec.Bind = fmt.Sprintf("flag:boolean=matchDBTable(\"\", $2, \"%s\", \"%s\", \"%s\")", spec.Database, spec.Table, spec.SQLType)
+		} else if spec.MySQLConnectorVersion == "8" || spec.MySQLConnectorVersion == "9" {
 			bytemanTemplateSpec.Class = MySQL8InjectClass
 			bytemanTemplateSpec.Method = MySQL8InjectMethod
 			mysqlException = MySQL8Exception
+			bytemanTemplateSpec.Bind = fmt.Sprintf("sql:String = extractSQL($1, $2), flag:boolean = matchDBTable(\"\", sql, \"%s\", \"%s\", \"%s\")", spec.Database, spec.Table, spec.SQLType)
 		} else {
 			return errors.Errorf("mysql connector version %s is not supported", spec.MySQLConnectorVersion)
 		}

--- a/controllers/chaosimpl/jvmchaos/impl.go
+++ b/controllers/chaosimpl/jvmchaos/impl.go
@@ -248,6 +248,8 @@ func generateRuleData(spec *v1alpha1.JVMChaosSpec) error {
 	case v1alpha1.JVMMySQLAction:
 		var mysqlException string
 		bytemanTemplateSpec.Helper = SQLHelper
+		// the first parameter of matchDBTable is the database the SQL executes in;
+		// it cannot be determined at rule-generation time, so pass "" to match any database
 		bytemanTemplateSpec.Condition = "flag"
 		if spec.MySQLConnectorVersion == "5" {
 			bytemanTemplateSpec.Class = MySQL5InjectClass


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #4454

The `mysql` action in JVMChaos has **never worked** on applications using `PreparedStatement` — which includes every app using MyBatis, Hibernate, HikariCP, Spring Data JPA, Druid, or any connection pool / ORM.

The Byteman rule hooks `NativeSession.execSQL` and reads the SQL from [`$2`](https://github.com/chaos-mesh/chaos-mesh/blob/fb371dc/controllers/chaosimpl/jvmchaos/impl.go#L254), but for `PreparedStatement` paths, `ClientPreparedStatement.executeInternal()` passes **`null`** as `$2` (the SQL is in `$4` `NativePacketPayload` instead). This causes `SQLParser.parseSQL(null)` → `NullPointerException`, the Byteman rule silently fails, and the query proceeds normally.

Additionally, `mysqlConnectorVersion` only accepts `"5"` or `"8"`. Connector/J 9.x (current GA) uses the [same class/method](https://github.com/chaos-mesh/chaos-mesh/blob/fb371dc/controllers/chaosimpl/jvmchaos/impl.go#L81-L82) (`com.mysql.cj.NativeSession.execSQL`) with identical signature but is rejected by the [webhook](https://github.com/chaos-mesh/chaos-mesh/blob/fb371dc/api/v1alpha1/jvmchaos_webhook.go#L85).

## What's changed and how does it work?

### `controllers/chaosimpl/jvmchaos/impl.go`

For Connector/J 8.x/9.x, change the BIND expression from:

```go
bytemanTemplateSpec.Bind = fmt.Sprintf(
    "flag:boolean=matchDBTable(\"\", $2, \"%s\", \"%s\", \"%s\")", ...)
```

To:

```go
bytemanTemplateSpec.Bind = fmt.Sprintf(
    "sql:String = extractSQL($1, $2), flag:boolean = matchDBTable(\"\", sql, \"%s\", \"%s\", \"%s\")", ...)
```

`extractSQL()` is a new method in `SQLHelper` (see dependency below) that returns `$2` directly if non-null (plain `Statement` path), otherwise uses reflection to walk `$1`'s class hierarchy and extract the SQL from `PreparedQuery.getOriginalSql()`. Reflection avoids a compile-time dependency on MySQL Connector/J in the byteman-helper.

Accept `"9"` as a valid `mysqlConnectorVersion` and route it to the same class/method/exception as `"8"` (verified identical from Connector/J 9.7.0 source).

Connector/J 5.x path is unchanged (different class `MysqlIO.sqlQueryDirect`).

### `api/v1alpha1/jvmchaos_webhook.go`

Accept `mysqlConnectorVersion: "9"` in validation.

### `api/v1alpha1/jvmchaos_types.go`

Update doc comment to mention 9.x support.

### Generated Byteman rule (before vs after)

Before:
```
BIND flag:boolean=matchDBTable("", $2, "mydb", "orders", "select");
```

After:
```
BIND sql:String = extractSQL($1, $2), flag:boolean = matchDBTable("", sql, "mydb", "orders", "select");
```

### Dependency: `chaos-mesh/byteman-helper` changes

This PR depends on adding `extractSQL()` to `SQLHelper` and hardening `SQLParser` (null guards, unqualified-table matching, value equality) in the `byteman-helper` repo. The implementation is here: [OperationsPAI/byteman-helper@7cc8b63](https://github.com/OperationsPAI/byteman-helper/commit/7cc8b63) + [@92c89f0](https://github.com/OperationsPAI/byteman-helper/commit/92c89f0) ([full diff](https://github.com/chaos-mesh/byteman-helper/compare/main...OperationsPAI:byteman-helper:main)).

I wasn't able to open a PR on `chaos-mesh/byteman-helper` directly (not a collaborator). @STRRL @WangXiangUSTC could you either merge the byteman-helper change or add me as a collaborator so I can open a PR there? Happy to adjust the approach if you prefer a different solution.

### Testing

Tested end-to-end on a microservice running Connector/J 9.7.0 + HikariCP + Hibernate + Spring Data JPA:

```
extractSQL: recovered SQL from PreparedQuery: select fo1_0.id,fo1_0.food_name,...from food_order fo1_0
database: , sql: select fo1_0.id,..., filterDatabase: , filterTable: , sqlType: select
caught ThrowException
ERROR: e2e-test: mysql fault injection via mysqlConnectorVersion 9
java.sql.SQLException: e2e-test: mysql fault injection via mysqlConnectorVersion 9
    at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException
    at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal
    at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery
```

The injected `SQLException` propagates through the full stack: JDBC → HikariCP → Hibernate → Spring Data → application code → HTTP 500.

## Related changes

- [x] This change also requires further updates to `chaos-mesh/byteman-helper` ([diff](https://github.com/chaos-mesh/byteman-helper/compare/main...OperationsPAI:byteman-helper:main))
- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

- [ ] Unit test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**
