### PR TITLE
fix(jvmchaos): add bounded heap memory stress support for JVMChaos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add unit tests for `pkg/chaosdaemon/graph` with 100% coverage [#4906](https://github.com/chaos-mesh/chaos-mesh/pull/4906)
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
 - Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
+- Add bounded heap memory usage support for JVMChaos heap stress experiments
 
 ### Changed
 

--- a/api/v1alpha1/jvmchaos_types.go
+++ b/api/v1alpha1/jvmchaos_types.go
@@ -131,6 +131,10 @@ type JVMStressCfgSpec struct {
 	// the memory type needs to locate, only set it when action is stress, the value can be 'stack' or 'heap'
 	// +optional
 	MemoryType string `json:"memType,omitempty"`
+
+	// the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'
+	// +optional
+	HeapMemoryUsage string `json:"heapMemoryUsage,omitempty"`
 }
 
 // JVMMySQLSpec is the specification of MySQL fault injection in JVM

--- a/api/v1alpha1/jvmchaos_webhook.go
+++ b/api/v1alpha1/jvmchaos_webhook.go
@@ -57,6 +57,18 @@ func (in *JVMChaosSpec) Validate(root interface{}, path *field.Path) field.Error
 				allErrs = append(allErrs, field.Invalid(path, in, "value should be 'stack' or 'heap'"))
 			}
 		}
+
+		if len(in.HeapMemoryUsage) != 0 {
+			if in.CPUCount > 0 {
+				allErrs = append(allErrs, field.Invalid(path, in, "heap memory usage cannot be set with cpu-count"))
+			}
+
+			if in.MemoryType == "" {
+				allErrs = append(allErrs, field.Invalid(path, in, "mem-type must be 'heap' when heap memory usage is set"))
+			} else if in.MemoryType != "heap" {
+				allErrs = append(allErrs, field.Invalid(path, in, "heap memory usage can only be set when mem-type is 'heap'"))
+			}
+		}
 	case JVMGCAction:
 		// do nothing
 	case JVMExceptionAction, JVMReturnAction, JVMLatencyAction:

--- a/api/v1alpha1/jvmchaos_webhook_test.go
+++ b/api/v1alpha1/jvmchaos_webhook_test.go
@@ -265,6 +265,97 @@ var _ = Describe("jvmchaos_webhook", func() {
 					},
 					expect: "error",
 				},
+				{
+					name: "valid heap memory usage",
+					chaos: JVMChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo11",
+						},
+						Spec: JVMChaosSpec{
+							Action: JVMStressAction,
+							JVMParameter: JVMParameter{
+								JVMStressCfgSpec: JVMStressCfgSpec{
+									MemoryType:      "heap",
+									HeapMemoryUsage: "50%",
+								},
+							},
+						},
+					},
+					execute: func(chaos *JVMChaos) error {
+						_, err := chaos.ValidateCreate(context.Background(), chaos)
+						return err
+					},
+					expect: "",
+				},
+				{
+					name: "heap memory usage without memory type",
+					chaos: JVMChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo12",
+						},
+						Spec: JVMChaosSpec{
+							Action: JVMStressAction,
+							JVMParameter: JVMParameter{
+								JVMStressCfgSpec: JVMStressCfgSpec{
+									HeapMemoryUsage: "50%",
+								},
+							},
+						},
+					},
+					execute: func(chaos *JVMChaos) error {
+						_, err := chaos.ValidateCreate(context.Background(), chaos)
+						return err
+					},
+					expect: "error",
+				},
+				{
+					name: "heap memory usage with stack",
+					chaos: JVMChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo13",
+						},
+						Spec: JVMChaosSpec{
+							Action: JVMStressAction,
+							JVMParameter: JVMParameter{
+								JVMStressCfgSpec: JVMStressCfgSpec{
+									MemoryType:      "stack",
+									HeapMemoryUsage: "50%",
+								},
+							},
+						},
+					},
+					execute: func(chaos *JVMChaos) error {
+						_, err := chaos.ValidateCreate(context.Background(), chaos)
+						return err
+					},
+					expect: "error",
+				},
+				{
+					name: "heap memory usage with cpu count",
+					chaos: JVMChaos{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: metav1.NamespaceDefault,
+							Name:      "foo14",
+						},
+						Spec: JVMChaosSpec{
+							Action: JVMStressAction,
+							JVMParameter: JVMParameter{
+								JVMStressCfgSpec: JVMStressCfgSpec{
+									CPUCount:        1,
+									HeapMemoryUsage: "50%",
+								},
+							},
+						},
+					},
+					execute: func(chaos *JVMChaos) error {
+						_, err := chaos.ValidateCreate(context.Background(), chaos)
+						return err
+					},
+					expect: "error",
+				},
 			}
 
 			for _, tc := range tcs {

--- a/config/crd/bases/chaos-mesh.org_jvmchaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_jvmchaos.yaml
@@ -86,6 +86,10 @@ spec:
                   the exception which needs to throw for action `exception`
                   or the exception message needs to throw in action `mysql`
                 type: string
+              heapMemoryUsage:
+                description: 'the heap memory usage target for heap memory stress.
+                  Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                type: string
               latency:
                 description: |-
                   the latency duration for action 'latency', unit ms

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -1109,6 +1109,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -4502,6 +4506,11 @@ spec:
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
                               type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
+                              type: string
                             latency:
                               description: |-
                                 the latency duration for action 'latency', unit ms
@@ -7557,6 +7566,11 @@ spec:
                                   description: |-
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
+                                  type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
                                   type: string
                                 latency:
                                   description: |-

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -1130,6 +1130,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -4117,6 +4121,11 @@ spec:
                         description: |-
                           the exception which needs to throw for action `exception`
                           or the exception message needs to throw in action `mysql`
+                        type: string
+                      heapMemoryUsage:
+                        description: 'the heap memory usage target for heap memory
+                          stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                          ''0.5'''
                         type: string
                       latency:
                         description: |-
@@ -7536,6 +7545,11 @@ spec:
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
                                   type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
+                                  type: string
                                 latency:
                                   description: |-
                                     the latency duration for action 'latency', unit ms
@@ -10631,6 +10645,11 @@ spec:
                                       description: |-
                                         the exception which needs to throw for action `exception`
                                         or the exception message needs to throw in action `mysql`
+                                      type: string
+                                    heapMemoryUsage:
+                                      description: 'the heap memory usage target for
+                                        heap memory stress. Supported examples: ''50%'',
+                                        ''100MB'', ''1GB'', ''0.5'''
                                       type: string
                                     latency:
                                       description: |-

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -1154,6 +1154,11 @@ spec:
                             the exception which needs to throw for action `exception`
                             or the exception message needs to throw in action `mysql`
                           type: string
+                        heapMemoryUsage:
+                          description: 'the heap memory usage target for heap memory
+                            stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                            ''0.5'''
+                          type: string
                         latency:
                           description: |-
                             the latency duration for action 'latency', unit ms
@@ -4190,6 +4195,11 @@ spec:
                               description: |-
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
+                              type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
                               type: string
                             latency:
                               description: |-

--- a/controllers/chaosimpl/jvmchaos/impl.go
+++ b/controllers/chaosimpl/jvmchaos/impl.go
@@ -234,6 +234,8 @@ func generateRuleData(spec *v1alpha1.JVMChaosSpec) error {
 		bytemanTemplateSpec.Condition = "true"
 		if spec.CPUCount > 0 {
 			bytemanTemplateSpec.Do = fmt.Sprintf("injectCPUStress(\"%s\", %d)", spec.Name, spec.CPUCount)
+		} else if len(spec.HeapMemoryUsage) > 0 {
+			bytemanTemplateSpec.Do = fmt.Sprintf("injectLimitedMemStress(\"%s\", \"%s\", \"%s\")", spec.Name, spec.MemoryType, spec.HeapMemoryUsage)
 		} else {
 			bytemanTemplateSpec.Do = fmt.Sprintf("injectMemStress(\"%s\", \"%s\")", spec.Name, spec.MemoryType)
 		}

--- a/controllers/chaosimpl/jvmchaos/impl_test.go
+++ b/controllers/chaosimpl/jvmchaos/impl_test.go
@@ -113,6 +113,22 @@ func TestGenerateRuleData(t *testing.T) {
 		},
 		{
 			&v1alpha1.JVMChaosSpec{
+				Action: v1alpha1.JVMStressAction,
+				JVMParameter: v1alpha1.JVMParameter{
+					Name: "test",
+					JVMCommonSpec: v1alpha1.JVMCommonSpec{
+						Pid: 1234,
+					},
+					JVMStressCfgSpec: v1alpha1.JVMStressCfgSpec{
+						MemoryType:      "heap",
+						HeapMemoryUsage: "50%",
+					},
+				},
+			},
+			"\nRULE test\nCLASS org.chaos_mesh.chaos_agent.TriggerThread\nMETHOD triggerFunc\nHELPER org.chaos_mesh.byteman.helper.StressHelper\nAT ENTRY\nBIND flag:boolean=true;\nIF true\nDO\n\tinjectLimitedMemStress(\"test\", \"heap\", \"50%\");\nENDRULE\n",
+		},
+		{
+			&v1alpha1.JVMChaosSpec{
 				Action: v1alpha1.JVMGCAction,
 				JVMParameter: v1alpha1.JVMParameter{
 					Name: "test",

--- a/helm/chaos-mesh/crds/chaos-mesh.org_jvmchaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_jvmchaos.yaml
@@ -86,6 +86,10 @@ spec:
                   the exception which needs to throw for action `exception`
                   or the exception message needs to throw in action `mysql`
                 type: string
+              heapMemoryUsage:
+                description: 'the heap memory usage target for heap memory stress.
+                  Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                type: string
               latency:
                 description: |-
                   the latency duration for action 'latency', unit ms

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -1109,6 +1109,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -4502,6 +4506,11 @@ spec:
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
                               type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
+                              type: string
                             latency:
                               description: |-
                                 the latency duration for action 'latency', unit ms
@@ -7557,6 +7566,11 @@ spec:
                                   description: |-
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
+                                  type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
                                   type: string
                                 latency:
                                   description: |-

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -1130,6 +1130,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -4117,6 +4121,11 @@ spec:
                         description: |-
                           the exception which needs to throw for action `exception`
                           or the exception message needs to throw in action `mysql`
+                        type: string
+                      heapMemoryUsage:
+                        description: 'the heap memory usage target for heap memory
+                          stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                          ''0.5'''
                         type: string
                       latency:
                         description: |-
@@ -7536,6 +7545,11 @@ spec:
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
                                   type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
+                                  type: string
                                 latency:
                                   description: |-
                                     the latency duration for action 'latency', unit ms
@@ -10631,6 +10645,11 @@ spec:
                                       description: |-
                                         the exception which needs to throw for action `exception`
                                         or the exception message needs to throw in action `mysql`
+                                      type: string
+                                    heapMemoryUsage:
+                                      description: 'the heap memory usage target for
+                                        heap memory stress. Supported examples: ''50%'',
+                                        ''100MB'', ''1GB'', ''0.5'''
                                       type: string
                                     latency:
                                       description: |-

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -1154,6 +1154,11 @@ spec:
                             the exception which needs to throw for action `exception`
                             or the exception message needs to throw in action `mysql`
                           type: string
+                        heapMemoryUsage:
+                          description: 'the heap memory usage target for heap memory
+                            stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                            ''0.5'''
+                          type: string
                         latency:
                           description: |-
                             the latency duration for action 'latency', unit ms
@@ -4190,6 +4195,11 @@ spec:
                               description: |-
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
+                              type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
                               type: string
                             latency:
                               description: |-

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -2060,6 +2060,10 @@ spec:
                   the exception which needs to throw for action `exception`
                   or the exception message needs to throw in action `mysql`
                 type: string
+              heapMemoryUsage:
+                description: 'the heap memory usage target for heap memory stress.
+                  Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                type: string
               latency:
                 description: |-
                   the latency duration for action 'latency', unit ms
@@ -6577,6 +6581,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -9970,6 +9978,11 @@ spec:
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
                               type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
+                              type: string
                             latency:
                               description: |-
                                 the latency duration for action 'latency', unit ms
@@ -13025,6 +13038,11 @@ spec:
                                   description: |-
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
+                                  type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
                                   type: string
                                 latency:
                                   description: |-
@@ -21414,6 +21432,10 @@ spec:
                       the exception which needs to throw for action `exception`
                       or the exception message needs to throw in action `mysql`
                     type: string
+                  heapMemoryUsage:
+                    description: 'the heap memory usage target for heap memory stress.
+                      Supported examples: ''50%'', ''100MB'', ''1GB'', ''0.5'''
+                    type: string
                   latency:
                     description: |-
                       the latency duration for action 'latency', unit ms
@@ -24401,6 +24423,11 @@ spec:
                         description: |-
                           the exception which needs to throw for action `exception`
                           or the exception message needs to throw in action `mysql`
+                        type: string
+                      heapMemoryUsage:
+                        description: 'the heap memory usage target for heap memory
+                          stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                          ''0.5'''
                         type: string
                       latency:
                         description: |-
@@ -27820,6 +27847,11 @@ spec:
                                     the exception which needs to throw for action `exception`
                                     or the exception message needs to throw in action `mysql`
                                   type: string
+                                heapMemoryUsage:
+                                  description: 'the heap memory usage target for heap
+                                    memory stress. Supported examples: ''50%'', ''100MB'',
+                                    ''1GB'', ''0.5'''
+                                  type: string
                                 latency:
                                   description: |-
                                     the latency duration for action 'latency', unit ms
@@ -30915,6 +30947,11 @@ spec:
                                       description: |-
                                         the exception which needs to throw for action `exception`
                                         or the exception message needs to throw in action `mysql`
+                                      type: string
+                                    heapMemoryUsage:
+                                      description: 'the heap memory usage target for
+                                        heap memory stress. Supported examples: ''50%'',
+                                        ''100MB'', ''1GB'', ''0.5'''
                                       type: string
                                     latency:
                                       description: |-
@@ -42520,6 +42557,11 @@ spec:
                             the exception which needs to throw for action `exception`
                             or the exception message needs to throw in action `mysql`
                           type: string
+                        heapMemoryUsage:
+                          description: 'the heap memory usage target for heap memory
+                            stress. Supported examples: ''50%'', ''100MB'', ''1GB'',
+                            ''0.5'''
+                          type: string
                         latency:
                           description: |-
                             the latency duration for action 'latency', unit ms
@@ -45556,6 +45598,11 @@ spec:
                               description: |-
                                 the exception which needs to throw for action `exception`
                                 or the exception message needs to throw in action `mysql`
+                              type: string
+                            heapMemoryUsage:
+                              description: 'the heap memory usage target for heap
+                                memory stress. Supported examples: ''50%'', ''100MB'',
+                                ''1GB'', ''0.5'''
                               type: string
                             latency:
                               description: |-

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -3712,6 +3712,10 @@ const docTemplate = `{
                     "description": "the exception which needs to throw for action ` + "`" + `exception` + "`" + `\nor the exception message needs to throw in action ` + "`" + `mysql` + "`" + `\n+optional",
                     "type": "string"
                 },
+                "heapMemoryUsage": {
+                    "description": "the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'\n+optional",
+                    "type": "string"
+                },
                 "latency": {
                     "description": "the latency duration for action 'latency', unit ms\nor the latency duration in action ` + "`" + `mysql` + "`" + `\n+optional",
                     "type": "integer"

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -3705,6 +3705,10 @@
                     "description": "the exception which needs to throw for action `exception`\nor the exception message needs to throw in action `mysql`\n+optional",
                     "type": "string"
                 },
+                "heapMemoryUsage": {
+                    "description": "the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'\n+optional",
+                    "type": "string"
+                },
                 "latency": {
                     "description": "the latency duration for action 'latency', unit ms\nor the latency duration in action `mysql`\n+optional",
                     "type": "integer"

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -1222,6 +1222,11 @@ definitions:
           or the exception message needs to throw in action `mysql`
           +optional
         type: string
+      heapMemoryUsage:
+        description: |-
+          the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'
+          +optional
+        type: string
       latency:
         description: |-
           the latency duration for action 'latency', unit ms

--- a/ui/app/src/formik/JVMChaos.ts
+++ b/ui/app/src/formik/JVMChaos.ts
@@ -38,6 +38,13 @@ export const actions = ['latency', 'return', 'exception', 'stress', 'gc', 'ruleD
         'Optional. the exception which needs to throw for action `exception` or the exception message needs to throw in action `mysql`',
     },
     {
+      field: 'text',
+      label: 'heapMemoryUsage',
+      value: '',
+      helperText:
+        "Optional. the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'",
+    },
+    {
       field: 'number',
       label: 'latency',
       value: 0,

--- a/ui/app/src/openapi/index.schemas.ts
+++ b/ui/app/src/openapi/index.schemas.ts
@@ -742,6 +742,9 @@ default value is "", means match all database */
 or the exception message needs to throw in action `mysql`
 +optional */
   exception?: string
+  /** the heap memory usage target for heap memory stress. Supported examples: '50%', '100MB', '1GB', '0.5'
++optional */
+  heapMemoryUsage?: string
   /** the latency duration for action 'latency', unit ms
 or the latency duration in action `mysql`
 +optional */


### PR DESCRIPTION

> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

Closes #4665.

JVMChaos heap memory stress currently uses unbounded heap allocation, which keeps consuming heap until the JVM hits OOM or the pod is killed. This makes it hard to test scenarios where an application should run near a controlled heap usage target, such as 50% of max heap or a fixed amount like 1GB.


## What's changed and how does it work?

This PR adds an optional `heapMemoryUsage` field to JVMChaos stress configuration.

When `action: stress`, `memType: heap`, and `heapMemoryUsage` are set, Chaos Mesh generates a Byteman rule that calls:

```java
injectLimitedMemStress(ruleName, "heap", heapMemoryUsage)
```
Example values include:
- 50%
- 100MB
- 1GB
- 0.5

The existing behavior is preserved when heapMemoryUsage is not set:
- CPU stress still uses injectCPUStress
- unbounded memory stress still uses injectMemStress

The webhook validation was also tightened so heapMemoryUsage is only accepted for heap memory stress. Invalid combinations such as heapMemoryUsage with cpuCount, missing memType, or memType: stack are rejected.
Generated CRD, Helm CRD, Swagger, dashboard OpenAPI schema, and JVMChaos form metadata were updated for the new field.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [X] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [X] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [X] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
