### PR TITLE
docs(readme): add interactive Killercoda playground link to Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ You can get the full list of CRD objects and their specifications in the [Chaos 
 
 See [Quick Start](https://chaos-mesh.org/docs/quick-start) and [Install Chaos Mesh using Helm](https://chaos-mesh.org/docs/production-installation-using-helm/).
 
+Prefer to try it without setting up a cluster? Run the [interactive Killercoda playground](https://killercoda.com/saiyampathak/scenario/chaos-mesh) in your browser: install Chaos Mesh on a real 2-node Kubernetes cluster, run PodChaos and NetworkChaos experiments, explore the Dashboard, and chain a Workflow - in about 20 minutes.
+
 ## Contributing
 
 See the [contributing guide](./CONTRIBUTING.md) and [development guide](https://chaos-mesh.org/docs/developer-guide-overview).


### PR DESCRIPTION
## What problem does this PR solve?

There is currently no zero-setup way for someone evaluating Chaos Mesh to try it hands-on: the Quick start section links to installation docs, which require a cluster. An in-browser playground removes that friction entirely.

## What's changed and how does it work?

Adds one sentence to the **Quick start** section of the README linking to a free interactive Killercoda playground: https://killercoda.com/saiyampathak/scenario/chaos-mesh

The 5-step scenario (~20 minutes, real 2-node kubeadm cluster in the browser) covers:

1. Installing Chaos Mesh 2.8.3 with Helm, wired to containerd (`chaosDaemon.runtime`/`socketPath`)
2. PodChaos `pod-kill` via `kubectl apply`, with the audit trail in `kubectl describe`
3. NetworkChaos `delay` (200ms) with live latency measurements before/during/after, and instant revert by deleting the CRD
4. The Chaos Dashboard through Killercoda's exposed port, creating a `pod-failure` experiment from the UI
5. A serial `Workflow` chaining PodChaos and NetworkChaos

Scenario source: https://github.com/saiyam1814/katacoda-scenarios/tree/main/chaos-mesh

The playground currently lives under my personal Killercoda profile. If the maintainers prefer project-owned hosting, I am glad to donate the scenario source to a chaos-mesh org repo backed by a project-controlled Killercoda account - the README link change is one line.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs) - happy to open a follow-up PR linking the playground from the website docs if desired
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog" (documentation-only README change - I cannot apply labels myself, please add it)

### Tests

- [ ] Unit test
- [ ] E2E test
- [x] Manual test - the playground itself was validated end-to-end on Killercoda (fresh sessions): Helm install on containerd, PodChaos kill + ReplicaSet recovery, NetworkChaos 200ms delay measured via curl (ms -> hundreds of ms -> ms after revert), dashboard reachable on port 2333, and the serial Workflow completing with the app healthy

### Side effects

None - documentation-only change.
