### PR TITLE
build(images): migrate chaos-dashboard and chaos-dlv base images from debian to alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Changed
 
+- Migrate chaos-dashboard and chaos-dlv container base images from debian to alpine [#5027](https://github.com/chaos-mesh/chaos-mesh/pull/5027)
 - Upgrade gorm to v2 [#4630](https://github.com/chaos-mesh/chaos-mesh/pull/4630)
 - Allow customization of controller client-go QPS and BURST [#4779](https://github.com/chaos-mesh/chaos-mesh/pull/4779)
 - Use GitHub-managed ARM64 runners for ARM64 builds in upload_env_image workflow [#4794](https://github.com/chaos-mesh/chaos-mesh/pull/4794)

--- a/images/chaos-dashboard/Dockerfile
+++ b/images/chaos-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM alpine:3.23
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
@@ -9,11 +9,7 @@ ENV https_proxy=$HTTPS_PROXY
 ARG UI
 ARG SWAGGER
 
-RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt update --allow-releaseinfo-change && apt upgrade -y && \
-    apt install tzdata ca-certificates -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk upgrade --no-cache && apk add --no-cache tzdata ca-certificates
 
 ENV http_proxy=
 ENV https_proxy=

--- a/images/chaos-dlv/Dockerfile
+++ b/images/chaos-dlv/Dockerfile
@@ -1,13 +1,11 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.25-bookworm AS build-env
+FROM golang:1.25-alpine AS build-env
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 
-FROM debian:bookworm-slim
+FROM alpine:3.23
 
-RUN apt update && \
-    apt install procps -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache procps
 
 COPY --from=build-env /go/bin/dlv /
-CMD ["bash", "-c", "/dlv attach $(ps axf | grep $CMD_NAME | grep -v grep | awk '{print $1}') --listen=:8000 --headless=true --api-version=2 --accept-multiclient --continue"]
+CMD ["sh", "-c", "/dlv attach $(ps axf | grep $CMD_NAME | grep -v grep | awk '{print $1}') --listen=:8000 --headless=true --api-version=2 --accept-multiclient --continue"]


### PR DESCRIPTION
## What problem does this PR solve?

Part of #5014 (debian → alpine base image migration).

This is an incremental first slice covering the two images that need no binary changes.

## What's changed and how does it work?

- **chaos-dashboard**: the binary is built with `CGO_ENABLED=0` since #4800, so it runs on musl without changes. Replaced `debian:bookworm-slim` + apt with `alpine:3.23` + apk (`tzdata`, `ca-certificates`), matching the existing chaos-controller-manager image.
- **chaos-dlv**: dlv is pure Go; build with `golang:1.25-alpine`, run on `alpine:3.23` with `procps`. Switched `CMD` from `bash` to `sh` since alpine ships no bash.

**Intentionally out of scope** (follow-up needed): chaos-daemon (CGO-linked against glibc and bundles glibc-linked vendor binaries — toda, nsexec, chaos-tproxy, memStress — plus openjdk-17 and iptables-legacy alternatives), build-env, dev-env.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Checklist

### CHANGELOG

- [x] I have updated the [CHANGELOG.md](cci:7://file:///Users/saiyam/git/chaos-mesh/CHANGELOG.md:0:0-0:0)

### Tests

- [x] Manual test — both images build locally; `chaos-dashboard --version` and `dlv version` run correctly on alpine; `ps axf` works with procps.

### Side effects

- No breaking backward compatibility. Helm charts reference `/usr/local/bin/chaos-dashboard` and the dlv `CMD_NAME` wiring, both unchanged.
