### PR TITLE
refactor(e2e-test): integrate gherkin in CI and migrate namespace setup

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -177,8 +177,10 @@ jobs:
           mkdir -p ./e2e-test/image/e2e/bin
           mv ./output/e2e-binary/ginkgo ./e2e-test/image/e2e/bin/ginkgo
           mv ./output/e2e-binary/e2e.test ./e2e-test/image/e2e/bin/e2e.test
+          mv ./output/e2e-binary/e2e-gherkin.test ./e2e-test/image/e2e/bin/e2e-gherkin.test
           chmod +x ./e2e-test/image/e2e/bin/ginkgo
           chmod +x ./e2e-test/image/e2e/bin/e2e.test
+          chmod +x ./e2e-test/image/e2e/bin/e2e-gherkin.test
 
       - name: Setup minikube
         uses: medyagh/setup-minikube@latest
@@ -210,6 +212,11 @@ jobs:
         run: |
           export ESCAPED_FOCUS=$(echo $FOCUS | sed -e 's/\[/\\\[/g' | sed -e 's/\]/\\\]/g' | sed -e 's/\-/\\\-/g')
           KUBECONFIG=~/.kube/config ./e2e-test/image/e2e/bin/ginkgo -focus="${ESCAPED_FOCUS}" ./e2e-test/image/e2e/bin/e2e.test -- --e2e-image ghcr.io/chaos-mesh/e2e-helper:latest
+
+      - name: e2e gherkin tests
+        if: matrix.focus == '[Basic] [PodChaos]'
+        run: |
+          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config ../../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
       - name: post run - extract profile info from kubernetes
         if: always()
         env:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -216,7 +216,7 @@ jobs:
       - name: e2e gherkin tests
         if: matrix.focus == '[Basic] [PodChaos]'
         run: |
-          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config ../../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
+          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config ../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
       - name: post run - extract profile info from kubernetes
         if: always()
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade e2e k8s versions to 1.35.2, 1.34.5 and 1.33.9 [#4872](https://github.com/chaos-mesh/chaos-mesh/pull/4872)
 - Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4910](https://github.com/chaos-mesh/chaos-mesh/pull/4910)
 - ci: extract Build Chaos Mesh Build Env step into composite action [#5000](https://github.com/chaos-mesh/chaos-mesh/pull/5000)
+- Integrate Gherkin BDD runner in CI and migrate namespace setup to Kubernetes E2E framework [#5029](https://github.com/chaos-mesh/chaos-mesh/pull/5029)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Upgrade e2e k8s versions to 1.35.2, 1.34.5 and 1.33.9 [#4872](https://github.com/chaos-mesh/chaos-mesh/pull/4872)
 - Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in e2e tests [#4910](https://github.com/chaos-mesh/chaos-mesh/pull/4910)
 - ci: extract Build Chaos Mesh Build Env step into composite action [#5000](https://github.com/chaos-mesh/chaos-mesh/pull/5000)
-- Integrate Gherkin BDD runner in CI and migrate namespace setup to Kubernetes E2E framework [#5029](https://github.com/chaos-mesh/chaos-mesh/pull/5029)
+- Integrate Gherkin BDD runner in CI and migrate namespace setup to Kubernetes E2E framework [#5028](https://github.com/chaos-mesh/chaos-mesh/pull/5028)
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,13 @@ e2e-test/image/e2e/bin/e2e.test: SHELL:=$(RUN_IN_DEV_SHELL)
 e2e-test/image/e2e/bin/e2e.test: images/dev-env/.dockerbuilt
 	cd e2e-test && $(GO) test -c  -o ./image/e2e/bin/e2e.test ./e2e
 
-e2e-build: e2e-test/image/e2e/bin/ginkgo e2e-test/image/e2e/bin/e2e.test ## Build e2e test binary
+CLEAN_TARGETS+=e2e-test/image/e2e/bin/e2e-gherkin.test
+e2e-test/image/e2e/bin/e2e-gherkin.test: SHELL:=$(RUN_IN_DEV_SHELL)
+e2e-test/image/e2e/bin/e2e-gherkin.test: images/dev-env/.dockerbuilt
+	mkdir -p e2e-test/image/e2e/bin
+	cd e2e-test && $(GO) test -c  -o ./image/e2e/bin/e2e-gherkin.test ./e2e-gherkin
+
+e2e-build: e2e-test/image/e2e/bin/ginkgo e2e-test/image/e2e/bin/e2e.test e2e-test/image/e2e/bin/e2e-gherkin.test ## Build e2e test binary
 
 bin/chaos-builder: SHELL:=$(RUN_IN_DEV_SHELL)
 bin/chaos-builder: images/dev-env/.dockerbuilt

--- a/e2e-test/e2e-gherkin/features/podchaos.feature
+++ b/e2e-test/e2e-gherkin/features/podchaos.feature
@@ -18,14 +18,14 @@ Feature: PodChaos Simulation
   Scenario: PodKill once then delete
     Given a namespace is prepared
     And a single pod named "nginx" is running
-    When a "PodKill" chaos named "nginx-kill" is applied to pods with label "app=nginx"
+    When a "PodKill" chaos named "nginx-kill" with mode "one" is applied to pods with label "app=nginx"
     Then the pod named "nginx" should eventually not be found
 
   Scenario: PodKill pause does not trigger further kills
     Given a namespace is prepared
     And a deployment named "nginx" with 3 replicas is running
     When the initial pod UIDs are recorded
-    And a "PodKill" chaos named "nginx-kill" is applied to pods with label "app=nginx"
+    And a "PodKill" chaos named "nginx-kill" with mode "one" is applied to pods with label "app=nginx"
     Then at least one pod should be replaced with a different UID
     When the chaos experiment "nginx-kill" is paused
     Then no further pods should be killed within 1 minute

--- a/e2e-test/e2e-gherkin/steps/common_steps.go
+++ b/e2e-test/e2e-gherkin/steps/common_steps.go
@@ -17,12 +17,20 @@ package steps
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
 type TestContext struct {
@@ -41,28 +49,44 @@ func (tc *TestContext) RegisterSteps(ctx *godog.ScenarioContext) {
 	// Hook to clean up namespace after scenario runs
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
 		if tc.Namespace != "" {
-			_ = tc.KubeCli.CoreV1().Namespaces().Delete(context.Background(), tc.Namespace, metav1.DeleteOptions{})
+			_ = tc.KubeCli.CoreV1().Namespaces().Delete(ctx, tc.Namespace, metav1.DeleteOptions{})
+			// Wait for namespace deletion without using Ginkgo-dependent framework function
+			_ = wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+				_, err := tc.KubeCli.CoreV1().Namespaces().Get(ctx, tc.Namespace, metav1.GetOptions{})
+				if err != nil && apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, nil
+			})
 		}
 		return ctx, nil
 	})
 }
 
 func (tc *TestContext) aNamespaceIsPrepared() error {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "e2e-gherkin-",
-			Labels: map[string]string{
-				"e2e-framework":                      "chaos-mesh",
-				"pod-security.kubernetes.io/enforce": "privileged",
-				"pod-security.kubernetes.io/warn":    "privileged",
-				"pod-security.kubernetes.io/audit":   "privileged",
-			},
-		},
+	labels := map[string]string{
+		"e2e-framework":                      "chaos-mesh",
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/warn":    "privileged",
+		"pod-security.kubernetes.io/audit":   "privileged",
 	}
-	createdNs, err := tc.KubeCli.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	createdNs, err := framework.CreateTestingNS(context.TODO(), "e2e-gherkin", tc.KubeCli, labels)
 	if err != nil {
 		return err
 	}
 	tc.Namespace = createdNs.Name
 	return nil
+}
+
+func (tc *TestContext) parseChaosMode(mode string) (v1alpha1.SelectorMode, error) {
+	switch strings.ToLower(mode) {
+	case "one":
+		return v1alpha1.OneMode, nil
+	case "all":
+		return v1alpha1.AllMode, nil
+	case "fixed", "fixed-percent", "random-max-percent":
+		return "", fmt.Errorf("chaos mode %q requires a value which is not yet supported in Gherkin steps", mode)
+	default:
+		return "", fmt.Errorf("unsupported chaos mode: %s", mode)
+	}
 }

--- a/e2e-test/e2e-gherkin/steps/podchaos_steps.go
+++ b/e2e-test/e2e-gherkin/steps/podchaos_steps.go
@@ -36,7 +36,7 @@ import (
 
 func (tc *TestContext) RegisterPodChaosSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^a single pod named "([^"]*)" is running$`, tc.aSinglePodNamedIsRunning)
-	ctx.Step(`^a "([^"]*)" chaos named "([^"]*)" is applied to pods with label "([^"]*)"$`, tc.aChaosNamedIsAppliedToPodsWithLabel)
+	ctx.Step(`^a "([^"]*)" chaos named "([^"]*)" with mode "([^"]*)" is applied to pods with label "([^"]*)"$`, tc.aChaosNamedWithModeIsAppliedToPodsWithLabel)
 	ctx.Step(`^the pod named "([^"]*)" should eventually not be found$`, tc.thePodNamedShouldEventuallyNotBeFound)
 	ctx.Step(`^a deployment named "([^"]*)" with (\d+) replicas is running$`, tc.aDeploymentNamedWithReplicasIsRunning)
 	ctx.Step(`^the initial pod UIDs are recorded$`, tc.theInitialPodUIDsAreRecorded)
@@ -67,7 +67,7 @@ func (tc *TestContext) parsePodChaosAction(action string) (v1alpha1.PodChaosActi
 	}
 }
 
-func (tc *TestContext) aChaosNamedIsAppliedToPodsWithLabel(action, name, labelKeyVal string) error {
+func (tc *TestContext) aChaosNamedWithModeIsAppliedToPodsWithLabel(action, name, modeStr, labelKeyVal string) error {
 	parts := strings.Split(labelKeyVal, "=")
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
@@ -76,6 +76,11 @@ func (tc *TestContext) aChaosNamedIsAppliedToPodsWithLabel(action, name, labelKe
 	labelVal := parts[1]
 
 	normalizedAction, err := tc.parsePodChaosAction(action)
+	if err != nil {
+		return err
+	}
+
+	mode, err := tc.parseChaosMode(modeStr)
 	if err != nil {
 		return err
 	}
@@ -97,7 +102,7 @@ func (tc *TestContext) aChaosNamedIsAppliedToPodsWithLabel(action, name, labelKe
 							},
 						},
 					},
-					Mode: v1alpha1.OneMode,
+					Mode: mode,
 				},
 			},
 		},
@@ -106,8 +111,8 @@ func (tc *TestContext) aChaosNamedIsAppliedToPodsWithLabel(action, name, labelKe
 }
 
 func (tc *TestContext) thePodNamedShouldEventuallyNotBeFound(name string) error {
-	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
-		_, err = tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		_, err = tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -144,8 +149,8 @@ func (tc *TestContext) atLeastOnePodShouldBeReplacedWithDifferentUID() error {
 			"app": "nginx",
 		}).String(),
 	}
-	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
-		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
 		if err != nil {
 			return false, nil
 		}
@@ -153,8 +158,7 @@ func (tc *TestContext) atLeastOnePodShouldBeReplacedWithDifferentUID() error {
 	})
 }
 
-func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
-	ctx := context.TODO()
+func (tc *TestContext) theChaosExperimentIsPaused(ctx context.Context, name string) error {
 	chaos := &v1alpha1.PodChaos{}
 	err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, chaos)
 	if err != nil {
@@ -174,10 +178,12 @@ func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
 		pollTimeout = 5 * time.Minute
 	}
 
-	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, pollTimeout, false, func(ctx context.Context) (done bool, err error) {
-		err = tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, chaos)
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, pollTimeout, true, func(innerCtx context.Context) (done bool, err error) {
+		err = tc.Client.Get(innerCtx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, chaos)
 		if err != nil {
-			return false, err
+			// API errors here are usually transient (or caused by the poll
+			// deadline being close); keep polling instead of aborting.
+			return false, nil
 		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
@@ -186,7 +192,11 @@ func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
 	})
 
 	if isOneShot {
-		if err == context.DeadlineExceeded {
+		// wait.Interrupted covers every way the poll can end because of its
+		// deadline: context.DeadlineExceeded, the legacy ErrWaitTimeout, and
+		// wrapped forms like the client-go rate limiter error that surfaces
+		// when the remaining deadline is shorter than the next request slot.
+		if wait.Interrupted(err) {
 			return nil
 		}
 		if err == nil {
@@ -198,19 +208,19 @@ func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
 	return err
 }
 
-func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) error {
+func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(ctx context.Context, duration int) error {
 	listOption := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app": "nginx",
 		}).String(),
 	}
-	pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
+	pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
 	if err != nil {
 		return err
 	}
 
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Duration(duration)*time.Minute, false, func(ctx context.Context) (done bool, err error) {
-		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Duration(duration)*time.Minute, true, func(innerCtx context.Context) (done bool, err error) {
+		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(innerCtx, listOption)
 		if err != nil {
 			return false, nil
 		}
@@ -219,7 +229,7 @@ func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) er
 		}
 		return false, nil
 	})
-	if err == context.DeadlineExceeded {
+	if wait.Interrupted(err) {
 		return nil
 	}
 	if err == nil {
@@ -229,8 +239,8 @@ func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) er
 }
 
 func (tc *TestContext) waitPodRunning(name string) error {
-	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
-		pod, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pod, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
## What problem does this PR solve?

Part of the #4902. 

It addresses mentor feedback from PR 1:
1. Integrates Gherkin E2E tests into the GitHub Actions CI pipeline.
2. Migrates manual namespace setup to use the official Kubernetes E2E framework.
3. Adds explicit chaos execution mode declaration (`mode: one` / `mode: all`) to the BDD steps.

## What's changed and how does it work?

* Add Gherkin E2E tests compilation to `Makefile` and run them conditionally in `e2e_test.yml` on PodChaos jobs.
* Migrate namespace setup to use the E2E framework's `CreateTestingNS` helper.
* Implement a standalone namespace deletion wait to avoid Ginkgo spec-context panics in the teardown hook.
* Support parsing and applying chaos execution modes dynamically from Gherkin feature steps.

## Test Result

```bash
2 scenarios (2 passed)
11 steps (11 passed)
2m23.796446029s
--- PASS: TestFeatures (143.80s)
    --- PASS: TestFeatures/PodKill_once_then_delete (38.74s)
    --- PASS: TestFeatures/PodKill_pause_does_not_trigger_further_kills (105.05s)
PASS
ok  	github.com/chaos-mesh/chaos-mesh/e2e-test/e2e-gherkin	143.837s
?   	github.com/chaos-mesh/chaos-mesh/e2e-test/e2e-gherkin/steps	[no test files]
```

<details>
<summary><b>Click to view detailed BDD step execution logs</b></summary>

  ```bash
Feature: PodChaos Simulation
=== RUN   TestFeatures/PodKill_once_then_delete

  Scenario: PodKill once then delete                                                                    # features/podchaos.feature:18
    Given a namespace is prepared                                                                       # common_steps.go:47 -> *TestContext
    And a single pod named "nginx" is running                                                           # podchaos_steps.go:38 -> *TestContext
    When a "PodKill" chaos named "nginx-kill" with mode "one" is applied to pods with label "app=nginx" # podchaos_steps.go:39 -> *TestContext
    Then the pod named "nginx" should eventually not be found                                           # podchaos_steps.go:40 -> *TestContext
=== RUN   TestFeatures/PodKill_pause_does_not_trigger_further_kills

  Scenario: PodKill pause does not trigger further kills                                               # features/podchaos.feature:24
    Given a namespace is prepared                                                                      # common_steps.go:47 -> *TestContext
    And a deployment named "nginx" with 3 replicas is running                                          # podchaos_steps.go:41 -> *TestContext
    When the initial pod UIDs are recorded                                                             # podchaos_steps.go:42 -> *TestContext
    And a "PodKill" chaos named "nginx-kill" with mode "one" is applied to pods with label "app=nginx" # podchaos_steps.go:39 -> *TestContext
    Then at least one pod should be replaced with a different UID                                      # podchaos_steps.go:43 -> *TestContext
    When the chaos experiment "nginx-kill" is paused                                                   # podchaos_steps.go:44 -> *TestContext
    Then no further pods should be killed within 1 minute  
  ```
  
</details>

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [x] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
