### PR TITLE
fix(controllers): add logs for Client.Get errors

### DIFF
--- a/controllers/chaosimpl/httpchaos/impl.go
+++ b/controllers/chaosimpl/httpchaos/impl.go
@@ -148,7 +148,6 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 		}
 		err = impl.Client.Get(ctx, namespacedName, podhttpchaos)
 		if err != nil {
-			// TODO: handle this error
 			if k8sError.IsNotFound(err) {
 				return v1alpha1.NotInjected, nil
 			}
@@ -159,6 +158,7 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 				}
 			}
 
+			impl.Log.Error(err, "fail to get podhttpchaos", "namespacedName", namespacedName)
 			return waitForRecoverSync, err
 		}
 
@@ -181,10 +181,10 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	var pod v1.Pod
 	err = impl.Client.Get(ctx, podId, &pod)
 	if err != nil {
-		// TODO: handle this error
 		if k8sError.IsNotFound(err) {
 			return v1alpha1.NotInjected, nil
 		}
+		impl.Log.Error(err, "fail to get pod", "podId", podId)
 		return v1alpha1.Injected, err
 	}
 

--- a/controllers/chaosimpl/iochaos/impl.go
+++ b/controllers/chaosimpl/iochaos/impl.go
@@ -157,10 +157,10 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 		}
 		err = impl.Client.Get(ctx, namespacedName, podiochaos)
 		if err != nil {
-			// TODO: handle this error
 			if k8sError.IsNotFound(err) {
 				return v1alpha1.NotInjected, nil
 			}
+			impl.Log.Error(err, "fail to get podiochaos", "namespacedName", namespacedName)
 			return waitForRecoverSync, err
 		}
 
@@ -183,10 +183,10 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	var pod v1.Pod
 	err = impl.Client.Get(ctx, podId, &pod)
 	if err != nil {
-		// TODO: handle this error
 		if k8sError.IsNotFound(err) {
 			return v1alpha1.NotInjected, nil
 		}
+		impl.Log.Error(err, "fail to get pod", "podId", podId)
 		return v1alpha1.Injected, err
 	}
 


### PR DESCRIPTION
## What problem does this PR solve?

This PR addresses an issue where Kubernetes API errors were returned without logging during the recovery phase in `httpchaos` and `iochaos` controllers. Previously, there were `TODO: handle this error` comments for unhandled errors when fetching `PodHttpChaos`, `PodIoChaos`, or `Pod` objects failed for reasons other than `IsNotFound`. This made it difficult to trace failures when the controller was unable to fetch the necessary resources during recovery.

## What's changed and how does it work?

- Added `impl.Log.Error(...)` calls in `controllers/chaosimpl/httpchaos/impl.go` to properly log errors when fetching `podhttpchaos` or `pod` objects fails.
- Added `impl.Log.Error(...)` calls in `controllers/chaosimpl/iochaos/impl.go` to properly log errors when fetching `podiochaos` or `pod` objects fails.
- Removed the old `// TODO: handle this error` comments.
By explicitly logging these errors with their associated `namespacedName` or `podId`, it will be much easier to debug and trace unexpected Kubernetes API failures.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**