### PR TITLE
fix(typo): prometehus -> prometheus in monitoring README

### DIFF
--- a/api/v1alpha1/iochaos_types.go
+++ b/api/v1alpha1/iochaos_types.go
@@ -65,7 +65,7 @@ type IOChaosSpec struct {
 	// +optional
 	Errno uint32 `json:"errno,omitempty" webhook:"IOErrno"`
 
-	// Attr defines the overrided attribution
+	// Attr defines the overridden attribution
 	// +ui:form:when=action=='attrOverride'
 	// +optional
 	Attr *AttrOverrideSpec `json:"attr,omitempty"`

--- a/config/crd/bases/chaos-mesh.org_iochaos.yaml
+++ b/config/crd/bases/chaos-mesh.org_iochaos.yaml
@@ -57,7 +57,7 @@ spec:
                 - mistake
                 type: string
               attr:
-                description: Attr defines the overrided attribution
+                description: Attr defines the overridden attribution
                 properties:
                   atime:
                     description: Timespec represents a time

--- a/config/crd/bases/chaos-mesh.org_schedules.yaml
+++ b/config/crd/bases/chaos-mesh.org_schedules.yaml
@@ -800,7 +800,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -4191,7 +4191,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time
@@ -7246,7 +7246,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time

--- a/config/crd/bases/chaos-mesh.org_workflownodes.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflownodes.yaml
@@ -821,7 +821,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -3807,7 +3807,7 @@ spec:
                         - mistake
                         type: string
                       attr:
-                        description: Attr defines the overrided attribution
+                        description: Attr defines the overridden attribution
                         properties:
                           atime:
                             description: Timespec represents a time
@@ -7224,7 +7224,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time
@@ -10319,7 +10319,7 @@ spec:
                                       - mistake
                                       type: string
                                     attr:
-                                      description: Attr defines the overrided attribution
+                                      description: Attr defines the overridden attribution
                                       properties:
                                         atime:
                                           description: Timespec represents a time

--- a/config/crd/bases/chaos-mesh.org_workflows.yaml
+++ b/config/crd/bases/chaos-mesh.org_workflows.yaml
@@ -843,7 +843,7 @@ spec:
                           - mistake
                           type: string
                         attr:
-                          description: Attr defines the overrided attribution
+                          description: Attr defines the overridden attribution
                           properties:
                             atime:
                               description: Timespec represents a time
@@ -3880,7 +3880,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time

--- a/helm/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
@@ -57,7 +57,7 @@ spec:
                 - mistake
                 type: string
               attr:
-                description: Attr defines the overrided attribution
+                description: Attr defines the overridden attribution
                 properties:
                   atime:
                     description: Timespec represents a time

--- a/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -800,7 +800,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -4191,7 +4191,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time
@@ -7246,7 +7246,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -821,7 +821,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -3807,7 +3807,7 @@ spec:
                         - mistake
                         type: string
                       attr:
-                        description: Attr defines the overrided attribution
+                        description: Attr defines the overridden attribution
                         properties:
                           atime:
                             description: Timespec represents a time
@@ -7224,7 +7224,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time
@@ -10319,7 +10319,7 @@ spec:
                                       - mistake
                                       type: string
                                     attr:
-                                      description: Attr defines the overrided attribution
+                                      description: Attr defines the overridden attribution
                                       properties:
                                         atime:
                                           description: Timespec represents a time

--- a/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/helm/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -843,7 +843,7 @@ spec:
                           - mistake
                           type: string
                         attr:
-                          description: Attr defines the overrided attribution
+                          description: Attr defines the overridden attribution
                           properties:
                             atime:
                               description: Timespec represents a time
@@ -3880,7 +3880,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1613,7 +1613,7 @@ spec:
                 - mistake
                 type: string
               attr:
-                description: Attr defines the overrided attribution
+                description: Attr defines the overridden attribution
                 properties:
                   atime:
                     description: Timespec represents a time
@@ -6268,7 +6268,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -9659,7 +9659,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time
@@ -12714,7 +12714,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time
@@ -21105,7 +21105,7 @@ spec:
                     - mistake
                     type: string
                   attr:
-                    description: Attr defines the overrided attribution
+                    description: Attr defines the overridden attribution
                     properties:
                       atime:
                         description: Timespec represents a time
@@ -24091,7 +24091,7 @@ spec:
                         - mistake
                         type: string
                       attr:
-                        description: Attr defines the overrided attribution
+                        description: Attr defines the overridden attribution
                         properties:
                           atime:
                             description: Timespec represents a time
@@ -27508,7 +27508,7 @@ spec:
                                   - mistake
                                   type: string
                                 attr:
-                                  description: Attr defines the overrided attribution
+                                  description: Attr defines the overridden attribution
                                   properties:
                                     atime:
                                       description: Timespec represents a time
@@ -30603,7 +30603,7 @@ spec:
                                       - mistake
                                       type: string
                                     attr:
-                                      description: Attr defines the overrided attribution
+                                      description: Attr defines the overridden attribution
                                       properties:
                                         atime:
                                           description: Timespec represents a time
@@ -42209,7 +42209,7 @@ spec:
                           - mistake
                           type: string
                         attr:
-                          description: Attr defines the overrided attribution
+                          description: Attr defines the overridden attribution
                           properties:
                             atime:
                               description: Timespec represents a time
@@ -45246,7 +45246,7 @@ spec:
                               - mistake
                               type: string
                             attr:
-                              description: Attr defines the overrided attribution
+                              description: Attr defines the overridden attribution
                               properties:
                                 atime:
                                   description: Timespec represents a time

--- a/manifests/monitoring/README.md
+++ b/manifests/monitoring/README.md
@@ -10,7 +10,7 @@ We provide several `ServiceMonitor` examples under directory `prometheus-operato
 
 ## Configure with Prometheus Kubernetes Service Discovery
 
-There are several common-used annotations like `prometehus.io/scrape` and `prometehus.io/path` on Chaos Mesh components to configure Prometheus Kubernetes Discovery. After installing Chaos Mesh, you could use these following annotations to configure Prometheus Kubernetes Service Discovery.
+There are several common-used annotations like `prometheus.io/scrape` and `prometheus.io/path` on Chaos Mesh components to configure Prometheus Kubernetes Discovery. After installing Chaos Mesh, you could use these following annotations to configure Prometheus Kubernetes Service Discovery.
 
 We provide a configuration example under directory `prometheus-kubernetes-service-discovery`.
 ## Setup Grafana Dashboard

--- a/manifests/monitoring/README.md
+++ b/manifests/monitoring/README.md
@@ -10,7 +10,7 @@ We provide several `ServiceMonitor` examples under directory `prometheus-operato
 
 ## Configure with Prometheus Kubernetes Service Discovery
 
-There are several common-used annotations like `prometheus.io/scrape` and `prometheus.io/path` on Chaos Mesh components to configure Prometheus Kubernetes Discovery. After installing Chaos Mesh, you could use these following annotations to configure Prometheus Kubernetes Service Discovery.
+There are several commonly used annotations, such as `prometheus.io/scrape` and `prometheus.io/path`, that you can add to Chaos Mesh components to configure Prometheus Kubernetes service discovery.
 
 We provide a configuration example under directory `prometheus-kubernetes-service-discovery`.
 ## Setup Grafana Dashboard

--- a/pkg/dashboard/swaggerdocs/docs.go
+++ b/pkg/dashboard/swaggerdocs/docs.go
@@ -3488,7 +3488,7 @@ const docTemplate = `{
                     ]
                 },
                 "attr": {
-                    "description": "Attr defines the overrided attribution\n+ui:form:when=action=='attrOverride'\n+optional",
+                    "description": "Attr defines the overridden attribution\n+ui:form:when=action=='attrOverride'\n+optional",
                     "allOf": [
                         {
                             "$ref": "#/definitions/github_com_chaos-mesh_chaos-mesh_api_v1alpha1.AttrOverrideSpec"

--- a/pkg/dashboard/swaggerdocs/swagger.json
+++ b/pkg/dashboard/swaggerdocs/swagger.json
@@ -3481,7 +3481,7 @@
                     ]
                 },
                 "attr": {
-                    "description": "Attr defines the overrided attribution\n+ui:form:when=action=='attrOverride'\n+optional",
+                    "description": "Attr defines the overridden attribution\n+ui:form:when=action=='attrOverride'\n+optional",
                     "allOf": [
                         {
                             "$ref": "#/definitions/github_com_chaos-mesh_chaos-mesh_api_v1alpha1.AttrOverrideSpec"

--- a/pkg/dashboard/swaggerdocs/swagger.yaml
+++ b/pkg/dashboard/swaggerdocs/swagger.yaml
@@ -987,7 +987,7 @@ definitions:
         allOf:
         - $ref: '#/definitions/github_com_chaos-mesh_chaos-mesh_api_v1alpha1.AttrOverrideSpec'
         description: |-
-          Attr defines the overrided attribution
+          Attr defines the overridden attribution
           +ui:form:when=action=='attrOverride'
           +optional
       containerNames:


### PR DESCRIPTION
Fix typo 'prometehus.io' -> 'prometheus.io' in manifests/monitoring/README.md.