### PR TITLE
fix(typo): overrided -> overridden in iochaos_types.go comment

### DIFF
--- a/api/v1alpha1/iochaos_types.go
+++ b/api/v1alpha1/iochaos_types.go
@@ -65,7 +65,7 @@ type IOChaosSpec struct {
 	// +optional
 	Errno uint32 `json:"errno,omitempty" webhook:"IOErrno"`
 
-	// Attr defines the overrided attribution
+	// Attr defines the overridden attribution
 	// +ui:form:when=action=='attrOverride'
 	// +optional
 	Attr *AttrOverrideSpec `json:"attr,omitempty"`


### PR DESCRIPTION
Fix typo in API type comment in api/v1alpha1/iochaos_types.go.