### PR TITLE
fix(dashboard): TypeError crash on Workflow schedule details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add missing schedule types in dashboard collector [#4840](https://github.com/chaos-mesh/chaos-mesh/pull/4840)
 - Fix nil pointer dereference in StressChaos Apply when Stressors is nil and StressngStressors is empty [#4936](https://github.com/chaos-mesh/chaos-mesh/pull/4936)
 - Fix dashboard subpath serving by adding base path to Vite config [#5016](https://github.com/chaos-mesh/chaos-mesh/pull/5016)
+- Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 
 ### Security
 

--- a/ui/app/src/components/ObjectConfiguration/index.tsx
+++ b/ui/app/src/components/ObjectConfiguration/index.tsx
@@ -110,13 +110,13 @@ const ObjectConfiguration: ReactFCWithChildren<ObjectConfigurationProps> = ({
           </Grid>
         )}
 
-        {(hasAddress || experiment.selector) && (
+        {(hasAddress || experiment?.selector) && (
           <Grid item xs={vertical ? 12 : 3}>
             <Typography variant="subtitle2" gutterBottom>
               {i18n('newE.steps.scope')}
             </Typography>
 
-            {experiment.selector && <Selector data={experiment.selector} />}
+            {experiment?.selector && <Selector data={experiment.selector} />}
 
             {hasAddress && (
               <Table>


### PR DESCRIPTION
> [!IMPORTANT]
> Thank you for contributing to Chaos Mesh! Please fill out the template below to help us review your PR.
>
> If you are new to Chaos Mesh, please read the [contributing guide](https://github.com/chaos-mesh/chaos-mesh/blob/master/CONTRIBUTING.md) first.
>
> Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing the PR title and commit messages.

## What problem does this PR solve?

Accessing `experiment.selector` throws a `TypeError: Cannot read properties of undefined (reading 'selector')` when viewing the details of a `Workflow`-type schedule. This happens because `Workflow` does not map to any standard chaos experiment type, resulting in the `experiment` object being `undefined`.

Closes #5031

## What's changed and how does it work?

Applied optional chaining (`experiment?.selector`) when checking and rendering the selector component in `ui/app/src/components/ObjectConfiguration/index.tsx`. This safely prevents rendering/accessing the selector if `experiment` is undefined.

### How to test
1. Create a YAML configuration file named `z-local/schedule-verification.yaml` with the following content:
   <details>
   <summary>Click to expand Workflow Schedule YAML</summary>

   ```yaml
   apiVersion: chaos-mesh.org/v1alpha1
   kind: Schedule
   metadata:
     name: schedule-verification
     namespace: default
   spec:
     schedule: '*/3 * * * *'
     concurrencyPolicy: Forbid
     historyLimit: 4
     type: Workflow
     workflow:
       entry: the-entry
       templates:
         - name: the-entry
           templateType: Serial
           deadline: 160s
           children:
             - pod-chaos
         - name: pod-chaos
           deadline: 60s
           templateType: PodChaos
           podChaos:
             action: pod-kill
             mode: all
             selector:
               namespaces:
                 - default
   ```
   </details>
2. Apply the schedule to the cluster:
   ```bash
   kubectl apply -f schedule-verification.yaml
   ```
3. Build and run the local dashboard:
   ```bash
   cd ui && pnpm install && pnpm build && cd ..
   ./hack/embed_ui_assets.sh
   UI=1 make local/chaos-dashboard
   ./bin/chaos-dashboard
   ```
4. Navigate to the **Schedules** tab, select the Workflow schedule, and verify that the detail page loads without crashing.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
