### PR TITLE
fix(chaosdaemon): handle ignored errors and resource leaks

### DIFF
--- a/pkg/chaosdaemon/httpchaos_server.go
+++ b/pkg/chaosdaemon/httpchaos_server.go
@@ -156,6 +156,7 @@ func (s *DaemonServer) applyHttpChaos(ctx context.Context, in *pb.ApplyHttpChaos
 	if err != nil {
 		return nil, errors.Wrap(err, "send http request")
 	}
+	defer resp.Body.Close()
 
 	log.Info("http chaos applied")
 

--- a/pkg/chaosdaemon/iptables_server.go
+++ b/pkg/chaosdaemon/iptables_server.go
@@ -181,10 +181,13 @@ func (iptables *iptablesClient) initializeEnv() error {
 			return err
 		}
 
-		iptables.ensureRule(&iptablesChain{
+		err = iptables.ensureRule(&iptablesChain{
 			Name:  direction,
 			Rules: []string{},
 		}, "-A "+direction+" -j "+chainName)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/grpc/utils.go
+++ b/pkg/grpc/utils.go
@@ -76,7 +76,9 @@ func (it *FileProvider) getCredentialOption() (grpc.DialOption, error) {
 		return nil, err
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("failed to append CA certificate to pool")
+	}
 
 	clientCert, err := tls.LoadX509KeyPair(it.file.Cert, it.file.Key)
 	if err != nil {
@@ -93,7 +95,9 @@ func (it *FileProvider) getCredentialOption() (grpc.DialOption, error) {
 
 func (it *RawProvider) getCredentialOption() (grpc.DialOption, error) {
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(it.raw.CaCert)
+	if !caCertPool.AppendCertsFromPEM(it.raw.CaCert) {
+		return nil, errors.New("failed to append CA certificate to pool")
+	}
 
 	clientCert, err := tls.X509KeyPair(it.raw.Cert, it.raw.Key)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes three resource leak and error handling issues in the chaos-daemon:

### 1. Unchecked `ensureRule` error in iptables initialization (`iptables_server.go:184`)

In `initializeEnv()`, the return value of `ensureRule()` was discarded. If adding the jump rule (`-A INPUT -j CHAOS-INPUT`) failed, the error was silently ignored and the function returned success, leaving the iptables environment in a partially initialized state.

### 2. HTTP response body leak (`httpchaos_server.go:155`)

After `transport.RoundTrip(req)`, the `resp.Body` was read but never closed. This leaks the underlying TCP connection on every `ApplyHttpChaos` call. Added `defer resp.Body.Close()` immediately after the error check.

### 3. Ignored `AppendCertsFromPEM` return values (`grpc/utils.go:79,96`)

Both `FileProvider.getCredentialOption()` and `RawProvider.getCredentialOption()` called `AppendCertsFromPEM()` without checking the boolean return. If the PEM data was malformed or empty, the cert pool would be empty, leading to TLS connections that silently fail to verify the server certificate. Both call sites now return an error if no certificates were appended.