### PR TITLE
test: use customized logger with GinkgoWriter in tests

### DIFF
--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -28,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -46,7 +47,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func(ctx SpecContext) {
 
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(log.NewZapLoggerWithWriter(GinkgoWriter))
 
 	By("bootstrapping test environment")
 	t := true

--- a/controllers/statuscheck/suite_test.go
+++ b/controllers/statuscheck/suite_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
@@ -61,7 +60,7 @@ func TestStatusCheck(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx SpecContext) {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(log.NewZapLoggerWithWriter(GinkgoWriter))
 	By("bootstrapping test environment")
 	t := true
 	if os.Getenv("USE_EXISTING_CLUSTER") == "true" {


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)
- [x] Test cases

## What this PR does / why we need it:

Fixes #2892 

This PR refines the logging in integration tests by replacing the default `controller-runtime` zap logger with the custom Chaos Mesh logger (`pkg/log.NewZapLoggerWithWriter(GinkgoWriter)`). 

This ensures that the `GinkgoWriter` is correctly used for logging output during testing, keeping the test output clean (only printing when a test fails).

### Changes made:
* Updated `api/v1alpha1/suite_test.go` to use `pkg/log.NewZapLoggerWithWriter`
* Updated `controllers/statuscheck/suite_test.go` to use `pkg/log.NewZapLoggerWithWriter`

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**.
- [x] Check that your code additions will not fail our CI checks (`make check`).
- [x] Ensure that your commit messages follow our contributing guidelines and are signed off (`git commit -s`).