### PR TITLE
controllers: return Requeue for non-NotFound errors in reconcilers

### DIFF
--- a/controllers/common/finalizers/controller.go
+++ b/controllers/common/finalizers/controller.go
@@ -64,8 +64,8 @@ func (r *InitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("chaos not found")
 		} else {
-			// TODO: handle this error
 			r.Log.Error(err, "unable to get chaos")
+			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, nil
 	}
@@ -94,8 +94,8 @@ func (r *CleanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("chaos not found")
 		} else {
-			// TODO: handle this error
 			r.Log.Error(err, "unable to get chaos")
+			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, nil
 	}
@@ -133,13 +133,12 @@ func updateFinalizer(r ReconcilerMeta, obj v1alpha1.InnerObject, req ctrl.Reques
 		return r.Client.Update(context.TODO(), obj)
 	})
 	if updateError != nil {
-		// TODO: handle this error
 		r.Log.Error(updateError, "fail to update")
 		r.Recorder.Event(obj, recorder.Failed{
 			Activity: "update finalizer",
 			Err:      "updateError.Error()",
 		})
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	r.Recorder.Event(obj, recorder.Updated{

--- a/controllers/common/records/controller.go
+++ b/controllers/common/records/controller.go
@@ -67,8 +67,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("chaos not found")
 		} else {
-			// TODO: handle this error
 			r.Log.Error(err, "unable to get chaos")
+			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
## Summary

- Handle previously unhandled errors in `InitReconciler`, `CleanReconciler` (finalizers), and `Reconciler` (records) by returning `ctrl.Result{Requeue: true}` for non-NotFound errors
- This enables controller-runtime's exponential backoff retry mechanism for transient failures

## Problem

Three reconciler locations had `// TODO: handle this error` comments where non-NotFound errors from `r.Client.Get()` were logged but swallowed. This meant transient API server errors would not be retried proactively - the controller would have to wait for the next watch event to re-trigger reconciliation.

## Solution

Following the project's [controller design principles](controllers/README.md):
> Use `ctrl.Result{Requeue: true}, nil` for retriable errors to leverage exponential backoff

Changed the three error-handling locations to return `ctrl.Result{Requeue: true}, nil` instead of `ctrl.Result{}, nil`, enabling automatic exponential backoff retry for transient failures.

### Files changed
- `controllers/common/finalizers/controller.go`: 3 error handling locations (InitReconciler, CleanReconciler, updateFinalizer)
- `controllers/common/records/controller.go`: 1 error handling location (Reconciler)