### PR TITLE
fix: handle non-200 HTTP status in chart download and return error in stresschaos recovery

### DIFF
--- a/controllers/chaosimpl/stresschaos/impl.go
+++ b/controllers/chaosimpl/stresschaos/impl.go
@@ -139,7 +139,7 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	}
 	if _, err = pbClient.CancelStressors(ctx, req); err != nil {
 		impl.Log.Error(err, "cancel stressors")
-		return v1alpha1.Injected, nil
+		return v1alpha1.Injected, err
 	}
 	delete(stresschaos.Status.Instances, records[index].Id)
 	return v1alpha1.NotInjected, nil

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -77,7 +77,7 @@ func DownloadChaosMeshChartTgz(ctx context.Context, version string) (string, err
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", errors.Wrapf(err, "download helm chart from %s", url)
+		return "", errors.Errorf("download helm chart from %s failed with status %s", url, response.Status)
 	}
 	target, err := os.CreateTemp("", fmt.Sprintf("chaos-mesh-%s-*.tgz", version))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix silent nil error when Helm chart download returns non-200 HTTP status
- Return error in stresschaos CancelStressors to enable controller retry

## Changes
- `pkg/helm/chart.go`: Use `errors.Errorf` instead of `errors.Wrapf(err, ...)` when status code is not 200, since `err` is nil in this case (the HTTP request succeeded, just returned a bad status)
- `controllers/chaosimpl/stresschaos/impl.go`: Return the error from `CancelStressors` instead of nil, allowing the controller to retry the recovery operation

## Impact
Without the chart fix, a failed download returns `("", nil)` causing confusing downstream errors. Without the stresschaos fix, stress injection can become permanently stuck on a pod if CancelStressors fails.
