### PR TITLE
fix(ui): resolve token validation and lockout loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Optimize RBAC Token Generator copy buttons in Dashboard UI [#4941](https://github.com/chaos-mesh/chaos-mesh/pull/4941)
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
+- Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
 
 ### Security
 

--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -37,6 +37,15 @@ export const applyErrorHandling = ({
     (response) => response,
     (error: AxiosError<ErrorData>) => {
       if (error.response?.status === 401) {
+        const data = error.response?.data
+
+        if (
+          data &&
+          (data.type === 'error.api.no_cluster_privilege' || data.type === 'error.api.no_namespace_privilege')
+        ) {
+          return Promise.reject(error)
+        }
+
         openAlert({
           type: 'error',
           message: 'Unauthorized. Please check the validity of the token',

--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -36,6 +36,17 @@ export const applyErrorHandling = ({
   http.interceptors.response.use(
     (response) => response,
     (error: AxiosError<ErrorData>) => {
+      if (error.response?.status === 401) {
+        openAlert({
+          type: 'error',
+          message: 'Unauthorized. Please check the validity of the token',
+        })
+        resetAPIAuthentication()
+        removeToken()
+
+        return Promise.reject(error)
+      }
+
       const data = error.response?.data
 
       if (data) {
@@ -43,12 +54,30 @@ export const applyErrorHandling = ({
         const type = data.type.slice(10)
 
         switch (type) {
+          case 'bad_request':
+            if (data.message.includes('token') || data.message.includes('Unauthorized')) {
+              openAlert({
+                type: 'error',
+                message: 'Unauthorized. Please check the validity of the token',
+              })
+              resetAPIAuthentication()
+              removeToken()
+            } else {
+              openAlert({
+                type: 'error',
+                message: data.message || 'An unknown error occurred',
+              })
+            }
+
+            break
           case 'invalid_request':
             if (data.message.includes('Unauthorized')) {
               openAlert({
                 type: 'error',
                 message: 'Please check the validity of the token',
               })
+              resetAPIAuthentication()
+              removeToken()
             }
 
             break

--- a/ui/app/src/api/interceptors.ts
+++ b/ui/app/src/api/interceptors.ts
@@ -36,82 +36,31 @@ export const applyErrorHandling = ({
   http.interceptors.response.use(
     (response) => response,
     (error: AxiosError<ErrorData>) => {
-      if (error.response?.status === 401) {
-        const data = error.response?.data
+      const data = error.response?.data
+      const type = data?.type.slice(10) // slice(10): error.api.xxx => xxx
+      const message = data?.message ?? ''
+      const isPrivilegeError = type === 'no_cluster_privilege' || type === 'no_namespace_privilege'
+      const isTokenError =
+        error.response?.status === 401 ||
+        (type === 'bad_request' && (message.includes('token') || message.includes('Unauthorized'))) ||
+        (type === 'internal_server_error' && message.includes('Unauthorized'))
 
-        if (
-          data &&
-          (data.type === 'error.api.no_cluster_privilege' || data.type === 'error.api.no_namespace_privilege')
-        ) {
-          return Promise.reject(error)
-        }
-
-        openAlert({
-          type: 'error',
-          message: 'Unauthorized. Please check the validity of the token',
-        })
-        resetAPIAuthentication()
-        removeToken()
-
+      if (isPrivilegeError) {
         return Promise.reject(error)
       }
 
-      const data = error.response?.data
-
-      if (data) {
-        // slice(10): error.api.xxx => xxx
-        const type = data.type.slice(10)
-
-        switch (type) {
-          case 'bad_request':
-            if (data.message.includes('token') || data.message.includes('Unauthorized')) {
-              openAlert({
-                type: 'error',
-                message: 'Unauthorized. Please check the validity of the token',
-              })
-              resetAPIAuthentication()
-              removeToken()
-            } else {
-              openAlert({
-                type: 'error',
-                message: data.message || 'An unknown error occurred',
-              })
-            }
-
-            break
-          case 'invalid_request':
-            if (data.message.includes('Unauthorized')) {
-              openAlert({
-                type: 'error',
-                message: 'Please check the validity of the token',
-              })
-              resetAPIAuthentication()
-              removeToken()
-            }
-
-            break
-          case 'internal_server_error':
-            if (data.message.includes('Unauthorized')) {
-              openAlert({
-                type: 'error',
-                message: 'Unauthorized. Please check the validity of the token',
-              })
-
-              resetAPIAuthentication()
-              removeToken()
-            }
-
-            break
-          case 'no_cluster_privilege':
-          case 'no_namespace_privilege':
-          default:
-            openAlert({
-              type: 'error',
-              message: data.message || 'An unknown error occurred',
-            })
-
-            break
-        }
+      if (isTokenError) {
+        openAlert({
+          type: 'error',
+          message: 'Please check the validity of the token',
+        })
+        resetAPIAuthentication()
+        removeToken()
+      } else if (data) {
+        openAlert({
+          type: 'error',
+          message: data.message || 'An unknown error occurred',
+        })
       }
 
       return Promise.reject(error)

--- a/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
+++ b/ui/app/src/components/NewWorkflowNext/SubmitWorkflow.tsx
@@ -40,7 +40,7 @@ const validationSchema = Yup.object({
   deadline: Yup.string().trim().required(),
 })
 
-interface WorkflowBasic {
+export interface WorkflowBasic {
   name: string
   namespace: string
   deadline: string

--- a/ui/app/src/components/RBACGenerator/index.tsx
+++ b/ui/app/src/components/RBACGenerator/index.tsx
@@ -47,7 +47,6 @@ const RBACGenerator = () => {
 
   const { data: namespaces } = useGetCommonChaosAvailableNamespaces({
     query: {
-      enabled: false,
       staleTime: Stale.DAY,
     },
   })
@@ -110,7 +109,7 @@ const RBACGenerator = () => {
                   helperText={i18n('common.chooseNamespace')}
                   disabled={clustered}
                 >
-                  {namespaces!.map((n) => (
+                  {namespaces?.map((n) => (
                     <MenuItem key={n} value={n}>
                       {n}
                     </MenuItem>

--- a/ui/app/src/components/T/index.tsx
+++ b/ui/app/src/components/T/index.tsx
@@ -28,7 +28,7 @@ import { FormattedMessage } from 'react-intl'
 import type { IntlShape } from 'react-intl'
 
 // https://github.com/microsoft/TypeScript/issues/24929
-function i18n(id: string): Exclude<React.ReactChild, number> // DEPRECATED, but preserve for backward compatibility.
+function i18n(id: string): Exclude<React.ReactNode, number> // DEPRECATED, but preserve for backward compatibility.
 function i18n(id: string, intl: IntlShape): string
 function i18n(id: string, intl?: IntlShape) {
   return intl ? intl.formatMessage({ id }) : <FormattedMessage id={id} />

--- a/ui/app/src/components/Token/index.tsx
+++ b/ui/app/src/components/Token/index.tsx
@@ -84,6 +84,15 @@ const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
       .catch((error) => {
         const data = error.response?.data
 
+        if (
+          data &&
+          (data.type === 'error.api.no_cluster_privilege' || data.type === 'error.api.no_namespace_privilege')
+        ) {
+          restSteps()
+
+          return
+        }
+
         setFieldError('token', data?.message || 'Please check the validity of the token')
 
         resetAPIAuthentication()

--- a/ui/app/src/components/Token/index.tsx
+++ b/ui/app/src/components/Token/index.tsx
@@ -84,15 +84,9 @@ const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
       .catch((error) => {
         const data = error.response?.data
 
-        if (data && data.code === 'error.api.invalid_request' && data.message.includes('Unauthorized')) {
-          setFieldError('token', 'Please check the validity of the token')
+        setFieldError('token', data?.message || 'Please check the validity of the token')
 
-          resetAPIAuthentication()
-
-          return
-        }
-
-        restSteps()
+        resetAPIAuthentication()
       })
   }
 

--- a/ui/app/src/components/Token/index.tsx
+++ b/ui/app/src/components/Token/index.tsx
@@ -27,16 +27,6 @@ import i18n from '@/components/T'
 
 import { validateName } from '@/lib/formikhelpers'
 
-function validateToken(value: string) {
-  let error
-
-  if (value === '') {
-    error = i18n('settings.addToken.tokenValidation') as unknown as string
-  }
-
-  return error
-}
-
 export interface TokenFormValues {
   name: string
   token: string
@@ -48,6 +38,11 @@ interface TokenProps {
 
 const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
   const intl = useIntl()
+  const validateToken = (value: string) => {
+    if (value === '') {
+      return i18n('settings.addToken.tokenValidation', intl)
+    }
+  }
 
   const { setAlert } = useComponentActions()
   const tokens = useAuthStore((state) => state.tokens)
@@ -73,7 +68,9 @@ const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
     function restSteps() {
       saveToken(values)
 
-      typeof onSubmitCallback === 'function' && onSubmitCallback(values)
+      if (typeof onSubmitCallback === 'function') {
+        onSubmitCallback(values)
+      }
 
       resetForm()
     }
@@ -93,7 +90,7 @@ const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
           return
         }
 
-        setFieldError('token', data?.message || 'Please check the validity of the token')
+        setFieldError('token', 'Please check the validity of the token')
 
         resetAPIAuthentication()
       })
@@ -107,7 +104,7 @@ const Token: ReactFCWithChildren<TokenProps> = ({ onSubmitCallback }) => {
             <TextField
               name="name"
               label={i18n('common.name')}
-              validate={validateName(i18n('settings.addToken.nameValidation') as unknown as string)}
+              validate={validateName(i18n('settings.addToken.nameValidation', intl))}
               helperText={errors.name && touched.name ? errors.name : i18n('settings.addToken.nameHelper')}
               error={errors.name && touched.name ? true : false}
             />

--- a/ui/app/src/components/TopContainer/index.tsx
+++ b/ui/app/src/components/TopContainer/index.tsx
@@ -119,10 +119,15 @@ const TopContainer = () => {
 
       if (token && tokenName) {
         const tokens: TokenFormValues[] = JSON.parse(token)
+        const activeToken = tokens.find(({ name }) => name === tokenName)
 
-        applyAPIAuthentication(tokens.find(({ name }) => name === tokenName)!.token)
-        setTokens(tokens)
-        setTokenName(tokenName)
+        if (activeToken && activeToken.token) {
+          applyAPIAuthentication(activeToken.token)
+          setTokens(tokens)
+          setTokenName(tokenName)
+        } else {
+          setAuthOpen(true)
+        }
       } else {
         setAuthOpen(true)
       }
@@ -157,19 +162,23 @@ const TopContainer = () => {
   return (
     <>
       <CssBaseline />
-      <Root open={openDrawer}>
-        <Sidebar open={openDrawer} />
-        <Box component="main" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-          <Navbar openDrawer={openDrawer} handleDrawerToggle={handleDrawerToggle} />
-          <Divider />
+      {loading ? (
+        <Loading />
+      ) : authOpen ? (
+        <Auth open={authOpen} />
+      ) : (
+        <Root open={openDrawer}>
+          <Sidebar open={openDrawer} />
+          <Box component="main" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+            <Navbar openDrawer={openDrawer} handleDrawerToggle={handleDrawerToggle} />
+            <Divider />
 
-          <Container maxWidth="xl" disableGutters sx={{ flexGrow: 1, p: 6 }}>
-            {loading ? <Loading /> : <Outlet />}
-          </Container>
-        </Box>
-      </Root>
-
-      <Auth open={authOpen} />
+            <Container maxWidth="xl" disableGutters sx={{ flexGrow: 1, p: 6 }}>
+              <Outlet />
+            </Container>
+          </Box>
+        </Root>
+      )}
 
       <Portal>
         <Snackbar

--- a/ui/app/src/components/TopContainer/index.tsx
+++ b/ui/app/src/components/TopContainer/index.tsx
@@ -162,23 +162,19 @@ const TopContainer = () => {
   return (
     <>
       <CssBaseline />
-      {loading ? (
-        <Loading />
-      ) : authOpen ? (
-        <Auth open={authOpen} />
-      ) : (
-        <Root open={openDrawer}>
-          <Sidebar open={openDrawer} />
-          <Box component="main" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-            <Navbar openDrawer={openDrawer} handleDrawerToggle={handleDrawerToggle} />
-            <Divider />
+      <Root open={openDrawer}>
+        <Sidebar open={openDrawer} />
+        <Box component="main" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+          <Navbar openDrawer={openDrawer} handleDrawerToggle={handleDrawerToggle} />
+          <Divider />
 
-            <Container maxWidth="xl" disableGutters sx={{ flexGrow: 1, p: 6 }}>
-              <Outlet />
-            </Container>
-          </Box>
-        </Root>
-      )}
+          <Container maxWidth="xl" disableGutters sx={{ flexGrow: 1, p: 6 }}>
+            {loading ? <Loading /> : <Outlet />}
+          </Container>
+        </Box>
+      </Root>
+
+      <Auth open={authOpen} />
 
       <Portal>
         <Snackbar

--- a/ui/app/src/components/TopContainer/index.tsx
+++ b/ui/app/src/components/TopContainer/index.tsx
@@ -169,7 +169,7 @@ const TopContainer = () => {
           <Divider />
 
           <Container maxWidth="xl" disableGutters sx={{ flexGrow: 1, p: 6 }}>
-            {loading ? <Loading /> : <Outlet />}
+            {loading || authOpen ? <Loading /> : <Outlet />}
           </Container>
         </Box>
       </Root>

--- a/ui/app/src/lib/formikhelpers.ts
+++ b/ui/app/src/lib/formikhelpers.ts
@@ -23,7 +23,7 @@ import _ from 'lodash'
 import { podPhases } from '@/components/AutoForm/data'
 import { Experiment, ExperimentKind, Frame, Scope } from '@/components/NewExperiment/types'
 import basicData from '@/components/NewExperimentNext/data/basic'
-import { WorkflowBasic } from '@/components/NewWorkflow'
+import type { WorkflowBasic } from '@/components/NewWorkflowNext/SubmitWorkflow'
 import { ScheduleSpecific } from '@/components/Schedule/types'
 
 import { arrToObjBySep, sanitize } from './utils'


### PR DESCRIPTION
## What problem does this PR solve?

Closes #3909

When a user's token expires, is deleted, or is set to empty in local storage, the Chaos Dashboard UI enters an infinite lockout loop of stackable error toast alerts (such as `error.api.internal_server_error: Unauthorized` or `error.api.bad_request: token is empty`). The UI fails to clear the invalid token, and background API queries (workflows, schedules, events) keep executing every 10 seconds, locking up the user session.

## What's changed and how does it work?

1. **TopContainer Gating**: Render the `Root` dashboard layout (which initiates queries) only when both `loading` and `authOpen` are `false`. 
2. **Empty Token Local Redirect**: Check that `activeToken.token` is non-empty before authenticating. Empty tokens now trigger `setAuthOpen(true)` immediately and redirect silently to login on page load without sending background requests.
3. **Axios Response Interceptor Updates**: 
   * Handled HTTP `401` status globally to clear tokens and redirect.
   * Handled token-related `bad_request` errors specifically, clearing the token and redirecting.
   * Added token cleanup routines for `invalid_request` failures.
4. **Token Validation Comparison Fix**: Fixed a comparison bug where `data.code` (integer status) was compared to a string `'error.api.invalid_request'`, allowing invalid tokens to pass pre-validation.

### How to test

1. Build and package the UI changes locally:
   ```bash
   UI=1 make ui
   UI=1 make local/chaos-dashboard
   ```
2. Run the local backend dashboard:
   ```bash
   ./bin/chaos-dashboard
   ```
3. Set the Local Storage `token` key value to `[{"name":"chaos-test","token":""}]` and refresh. Verify that the UI redirects silently to login without error toasts.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
