### PR TITLE
test(e2e): replace Poll with PollUntilContextTimeout

### DIFF
--- a/api/v1alpha1/timechaos_webhook.go
+++ b/api/v1alpha1/timechaos_webhook.go
@@ -29,8 +29,7 @@ type ClockIds []string
 
 // DefaultClockIds will set default value for empty ClockIds fields
 func (in *ClockIds) Default(root interface{}, field *reflect.StructField) {
-	// in cannot be nil
-	if *in == nil || len(*in) == 0 {
+	if len(*in) == 0 {
 		*in = []string{"CLOCK_REALTIME"}
 	}
 }

--- a/e2e-test/action.go
+++ b/e2e-test/action.go
@@ -103,7 +103,7 @@ func NewOperatorAction(
 func (oa *operatorAction) DeployOperator(info *OperatorConfig) error {
 	klog.Infof("create namespace chaos-mesh")
 	cmd := fmt.Sprintf(`kubectl create ns %s`, e2econst.ChaosMeshNamespace)
-	klog.Infof(cmd)
+	klog.Infof("%s", cmd)
 	output, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
 	if err != nil {
 		return errors.Errorf("failed to create namespace chaos-mesh: %v %s", err, string(output))

--- a/e2e-test/action.go
+++ b/e2e-test/action.go
@@ -124,7 +124,7 @@ func (oa *operatorAction) UpgradeOperator(info *OperatorConfig) error {
 		return errors.Errorf("failed to deploy operator: %v, %s", err, string(res))
 	}
 	klog.Infof("start to waiting chaos-mesh ready")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		ls := &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"app.kubernetes.io/instance": "chaos-mesh",
@@ -203,7 +203,7 @@ func (oa *operatorAction) restartComponent(info *OperatorConfig, prefix string) 
 	}
 
 	klog.Infof("start to waiting chaos-mesh ready")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err := oa.kubeCli.CoreV1().Pods(info.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: l.String()})
 		if err != nil {
 			klog.Errorf("get chaos-mesh pods: %v", err)

--- a/e2e-test/e2e-gherkin/steps/podchaos_steps.go
+++ b/e2e-test/e2e-gherkin/steps/podchaos_steps.go
@@ -106,7 +106,7 @@ func (tc *TestContext) aChaosNamedIsAppliedToPodsWithLabel(action, name, labelKe
 }
 
 func (tc *TestContext) thePodNamedShouldEventuallyNotBeFound(name string) error {
-	return wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		_, err = tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			return true, nil
@@ -144,7 +144,7 @@ func (tc *TestContext) atLeastOnePodShouldBeReplacedWithDifferentUID() error {
 			"app": "nginx",
 		}).String(),
 	}
-	return wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
 		if err != nil {
 			return false, nil
@@ -174,7 +174,7 @@ func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
 		pollTimeout = 5 * time.Minute
 	}
 
-	err = wait.Poll(1*time.Second, pollTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, pollTimeout, false, func(ctx context.Context) (done bool, err error) {
 		err = tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, chaos)
 		if err != nil {
 			return false, err
@@ -186,7 +186,7 @@ func (tc *TestContext) theChaosExperimentIsPaused(name string) error {
 	})
 
 	if isOneShot {
-		if err == wait.ErrWaitTimeout {
+		if err == context.DeadlineExceeded {
 			return nil
 		}
 		if err == nil {
@@ -209,7 +209,7 @@ func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) er
 		return err
 	}
 
-	err = wait.Poll(5*time.Second, time.Duration(duration)*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Duration(duration)*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
 		if err != nil {
 			return false, nil
@@ -219,7 +219,7 @@ func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) er
 		}
 		return false, nil
 	})
-	if err == wait.ErrWaitTimeout {
+	if err == context.DeadlineExceeded {
 		return nil
 	}
 	if err == nil {
@@ -229,7 +229,7 @@ func (tc *TestContext) noFurtherPodsShouldBeKilledWithinMinutes(duration int) er
 }
 
 func (tc *TestContext) waitPodRunning(name string) error {
-	return wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pod, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/e2e-test/e2e/chaos/dnschaos/dns.go
+++ b/e2e-test/e2e/chaos/dnschaos/dns.go
@@ -81,7 +81,7 @@ func TestcaseDNSRandom(
 	framework.ExpectNoError(err, "create dns chaos error")
 
 	for _, domainName := range effectDomainNames {
-		err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 			// get IP of a non exists host, because chaos DNS server will return a random IP,
 			// so err should be nil
 			_, dnsErr := testDNSServer(c, port, domainName)
@@ -145,7 +145,7 @@ func TestcaseDNSError(
 	framework.ExpectNoError(err, "create dns chaos error")
 
 	for _, domainName := range effectDomainNames {
-		err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 			// get IP of some domain names, because chaos DNS server will return error,
 			// so err should not be nil
 			_, dnsErr := testDNSServer(c, port, domainName)

--- a/e2e-test/e2e/chaos/httpchaos/http_abort.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_abort.go
@@ -153,7 +153,9 @@ func TestcaseHttpAbortPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -178,7 +180,9 @@ func TestcaseHttpAbortPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -208,7 +212,9 @@ func TestcaseHttpAbortPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil

--- a/e2e-test/e2e/chaos/httpchaos/http_abort.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_abort.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -156,16 +155,8 @@ func TestcaseHttpAbortPauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		_, err := getPodHttpNoBody(c, port)
@@ -184,21 +175,13 @@ func TestcaseHttpAbortPauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -222,21 +205,13 @@ func TestcaseHttpAbortPauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that http abort is effective again")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err

--- a/e2e-test/e2e/chaos/httpchaos/http_delay.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_delay.go
@@ -164,7 +164,9 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -191,7 +193,9 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -224,7 +228,9 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil

--- a/e2e-test/e2e/chaos/httpchaos/http_delay.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_delay.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -167,16 +166,8 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		_, dur, _ := getPodHttpDelay(c, port)
@@ -197,21 +188,13 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -238,21 +221,13 @@ func TestcaseHttpDelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that http delay is effective again")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err

--- a/e2e-test/e2e/chaos/httpchaos/http_patch.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_patch.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -257,16 +256,8 @@ func TestcaseHttpPatchPauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		resp, err := getPodHttp(c, port, secret, body)
@@ -296,21 +287,13 @@ func TestcaseHttpPatchPauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -346,21 +329,13 @@ func TestcaseHttpPatchPauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that http patch is effective again")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err

--- a/e2e-test/e2e/chaos/httpchaos/http_patch.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_patch.go
@@ -254,7 +254,9 @@ func TestcaseHttpPatchPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -290,7 +292,9 @@ func TestcaseHttpPatchPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -332,7 +336,9 @@ func TestcaseHttpPatchPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -236,7 +236,9 @@ func TestcaseHttpReplacePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -272,7 +274,9 @@ func TestcaseHttpReplacePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -313,7 +317,9 @@ func TestcaseHttpReplacePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -560,7 +566,9 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -596,7 +604,9 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -637,7 +647,9 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get http chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil

--- a/e2e-test/e2e/chaos/httpchaos/http_replace.go
+++ b/e2e-test/e2e/chaos/httpchaos/http_replace.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -239,16 +238,8 @@ func TestcaseHttpReplacePauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		resp, err := getPodHttp(c, port, secret, "")
@@ -278,21 +269,13 @@ func TestcaseHttpReplacePauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -327,21 +310,13 @@ func TestcaseHttpReplacePauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that http replace is effective again")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -587,16 +562,8 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		resp, err := getPodHttp(c, port, secret, body)
@@ -626,21 +593,13 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -675,21 +634,13 @@ func TestcaseHttpReplaceBodyPauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that http replace is effective again")
-	err = wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.HTTPChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get http chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err

--- a/e2e-test/e2e/chaos/httpchaos/misc.go
+++ b/e2e-test/e2e/chaos/httpchaos/misc.go
@@ -42,10 +42,6 @@ func getPodHttp(c HTTPE2EClient, port uint16, secret, body string) (*http.Respon
 	return resp, err
 }
 
-func getPodHttpNoSecret(c HTTPE2EClient, port uint16) (*http.Response, error) {
-	return getPodHttp(c, port, "", "")
-}
-
 func getPodHttpDefaultSecret(c HTTPE2EClient, port uint16, body string) (*http.Response, error) {
 	return getPodHttp(c, port, "foo", body)
 }
@@ -62,5 +58,5 @@ func getPodHttpDelay(c HTTPE2EClient, port uint16) (*http.Response, time.Duratio
 		return nil, 0, err
 	}
 
-	return resp, time.Now().Sub(start), nil
+	return resp, time.Since(start), nil
 }

--- a/e2e-test/e2e/chaos/iochaos/io_delay.go
+++ b/e2e-test/e2e/chaos/iochaos/io_delay.go
@@ -153,7 +153,9 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -180,7 +182,9 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
 			return false, nil
@@ -213,7 +217,9 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 
 		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
 			return false, nil

--- a/e2e-test/e2e/chaos/iochaos/io_delay.go
+++ b/e2e-test/e2e/chaos/iochaos/io_delay.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -156,16 +155,8 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		dur, _ := getPodIODelay(c, port)
@@ -186,21 +177,13 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about pause")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllRecovered {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllRecovered, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err
@@ -227,21 +210,13 @@ func TestcaseIODelayDurationForATimePauseAndUnPause(
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert that io delay is effective again")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
 
-		for _, c := range chaos.GetStatus().Conditions {
-			if c.Type == v1alpha1.ConditionAllInjected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			} else if c.Type == v1alpha1.ConditionSelected {
-				if c.Status != corev1.ConditionTrue {
-					return false, nil
-				}
-			}
+		if !util.ChaosConditionsTrue(chaos.GetStatus(), v1alpha1.ConditionAllInjected, v1alpha1.ConditionSelected) {
+			return false, nil
 		}
 
 		return true, err

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -162,7 +162,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 
 	klog.Info("pause iochaos")
 
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
@@ -188,7 +188,7 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	err = util.UnPauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")

--- a/e2e-test/e2e/chaos/iochaos/io_error.go
+++ b/e2e-test/e2e/chaos/iochaos/io_error.go
@@ -165,7 +165,9 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -191,7 +193,9 @@ func TestcaseIOErrorDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
 			return true, nil
 		}

--- a/e2e-test/e2e/chaos/iochaos/io_mistake.go
+++ b/e2e-test/e2e/chaos/iochaos/io_mistake.go
@@ -82,7 +82,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && res {
+		if res {
 			return true, nil
 		}
 		return false, nil
@@ -98,7 +98,7 @@ func TestcaseIOMistakeDurationForATimeThenRecover(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && !res {
+		if !res {
 			return true, nil
 		}
 		return false, nil
@@ -158,7 +158,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && res {
+		if res {
 			return true, nil
 		}
 		return false, nil
@@ -176,7 +176,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 
 	klog.Info("pause iochaos")
 
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
@@ -193,7 +193,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && !res {
+		if !res {
 			return true, nil
 		}
 		return false, nil
@@ -204,7 +204,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	err = util.UnPauseChaos(ctx, cli, ioChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get io chaos error")
@@ -220,7 +220,7 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && res {
+		if res {
 			return true, nil
 		}
 		return false, nil
@@ -282,7 +282,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && res {
+		if res {
 			return true, nil
 		}
 		return false, nil
@@ -298,7 +298,7 @@ func TestcaseIOMistakeWithSpecifiedContainer(
 		if err != nil {
 			return false, nil
 		}
-		if err == nil && !res {
+		if !res {
 			return true, nil
 		}
 		return false, nil

--- a/e2e-test/e2e/chaos/iochaos/io_mistake.go
+++ b/e2e-test/e2e/chaos/iochaos/io_mistake.go
@@ -179,7 +179,9 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -207,7 +209,9 @@ func TestcaseIOMistakeDurationForATimePauseAndUnPause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.IOChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get io chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
 			return true, nil
 		}

--- a/e2e-test/e2e/chaos/networkchaos/network_delay.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_delay.go
@@ -98,7 +98,7 @@ func TestcaseNetworkDelay(
 	err := cli.Create(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
@@ -113,7 +113,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -139,7 +139,7 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
@@ -153,7 +153,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -178,7 +178,7 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
@@ -192,7 +192,7 @@ func TestcaseNetworkDelay(
 	err = cli.Create(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
@@ -205,7 +205,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, networkDelayWithTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 1 {
 			return false, nil
@@ -218,7 +218,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, evenNetworkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -241,7 +241,7 @@ func TestcaseNetworkDelay(
 	By("Injecting complicate chaos for 0")
 	err = cli.Create(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 3 {
 			return false, nil
@@ -255,7 +255,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, complicateNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -278,7 +278,7 @@ func TestcaseNetworkDelay(
 	By("Injecting both direction chaos for 0")
 	err = cli.Create(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 2 {
 			return false, nil
@@ -292,7 +292,7 @@ func TestcaseNetworkDelay(
 	err = cli.Delete(ctx, bothDirectionNetem.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil

--- a/e2e-test/e2e/chaos/networkchaos/network_partition.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_partition.go
@@ -71,7 +71,7 @@ func TestcaseForbidHostNetwork(
 	framework.ExpectNoError(err, "create network chaos error")
 
 	By("waiting for rejecting for network chaos with hostNetwork")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		err = cli.Get(ctx, types.NamespacedName{
 			Namespace: ns,
 			Name:      "network-chaos-1",
@@ -113,7 +113,7 @@ func TestcaseNetworkPartition(
 	}
 
 	var result map[string][][]int
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -141,7 +141,7 @@ func TestcaseNetworkPartition(
 	err := cli.Create(ctx, baseNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 1 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -155,7 +155,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, baseNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -178,7 +178,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, bothDirectionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 2 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -192,7 +192,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, bothDirectionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -216,7 +216,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, fromDirectionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 1 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -230,7 +230,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, fromDirectionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -254,7 +254,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, bothDirectionWithPartitionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 4 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -268,7 +268,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, bothDirectionWithPartitionNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -293,7 +293,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, anotherNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 30*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 5 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -309,7 +309,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, anotherNetworkPartition.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		klog.Info("retry probeNetworkCondition")
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
@@ -333,7 +333,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, networkPartitionWithoutTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 3 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -348,7 +348,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, networkPartitionWithoutTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		klog.Info("retry probeNetworkCondition")
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
@@ -372,7 +372,7 @@ func TestcaseNetworkPartition(
 	err = cli.Create(ctx, networkPartitionWithoutTarget.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, true)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil
@@ -388,7 +388,7 @@ func TestcaseNetworkPartition(
 	err = cli.Delete(ctx, networkPartitionWithoutTarget.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		klog.Info("retry probeNetworkCondition")
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {

--- a/e2e-test/e2e/chaos/networkchaos/network_peers_crossover.go
+++ b/e2e-test/e2e/chaos/networkchaos/network_peers_crossover.go
@@ -83,7 +83,7 @@ func TestcasePeersCrossover(
 	err := cli.Create(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "create network chaos error")
 
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 4 {
 			return false, nil
@@ -99,7 +99,7 @@ func TestcasePeersCrossover(
 	err = cli.Delete(ctx, networkDelay.DeepCopy())
 	framework.ExpectNoError(err, "delete network chaos error")
 
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		result = probeNetworkCondition(c, networkPeers, ports, false)
 		if len(result[networkConditionBlocked]) != 0 || len(result[networkConditionSlow]) != 0 {
 			return false, nil

--- a/e2e-test/e2e/chaos/podchaos/container_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/container_kill.go
@@ -181,7 +181,7 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	}
 
 	// nginx container is killed as expected
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil
@@ -192,7 +192,7 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	err = util.PauseChaos(ctx, cli, containerKillChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
-	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get pod chaos error")
@@ -207,19 +207,19 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 	containerID = pods.Items[0].Status.ContainerStatuses[0].ContainerID
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait container not killed failed")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 	// resume experiment
 	err = util.UnPauseChaos(ctx, cli, containerKillChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get pod chaos error")
@@ -234,7 +234,7 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
 	containerID = pods.Items[0].Status.ContainerStatuses[0].ContainerID
-	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil

--- a/e2e-test/e2e/chaos/podchaos/container_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/container_kill.go
@@ -183,7 +183,9 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	// nginx container is killed as expected
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get nginx pods error")
+		if err != nil {
+			return false, err
+		}
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil
 	})
 	framework.ExpectNoError(err, "wait container kill failed")
@@ -195,7 +197,9 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get pod chaos error")
+		if err != nil {
+			return false, nil
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -209,7 +213,9 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	containerID = pods.Items[0].Status.ContainerStatuses[0].ContainerID
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get nginx pods error")
+		if err != nil {
+			return false, nil
+		}
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait container not killed failed")
@@ -222,7 +228,9 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get pod chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
 			return true, nil
 		}
@@ -236,7 +244,9 @@ func TestcaseContainerKillPauseThenUnPause(ns string, kubeCli kubernetes.Interfa
 	containerID = pods.Items[0].Status.ContainerStatuses[0].ContainerID
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get nginx pods error")
+		if err != nil {
+			return false, nil
+		}
 		return containerID != newPods.Items[0].Status.ContainerStatuses[0].ContainerID, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "container shouldn't be killed")

--- a/e2e-test/e2e/chaos/podchaos/misc.go
+++ b/e2e-test/e2e/chaos/podchaos/misc.go
@@ -26,7 +26,7 @@ import (
 )
 
 func waitPodRunning(name, namespace string, cli kubernetes.Interface) error {
-	return wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pod, err := cli.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil

--- a/e2e-test/e2e/chaos/podchaos/pod_failure.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_failure.go
@@ -204,7 +204,9 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get pod chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -217,7 +219,9 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	framework.ExpectNoError(err, "get timer pod error")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get timer pod error")
+		if err != nil {
+			return false, err
+		}
 		pod := pods.Items[0]
 		for _, c := range pod.Spec.Containers {
 			if c.Image == config.TestConfig.PauseImage {
@@ -237,7 +241,9 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get pod chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
 			return true, nil
 		}
@@ -248,7 +254,9 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	By("waiting for assert pod failure happens again")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get timer pod error")
+		if err != nil {
+			return false, err
+		}
 		pod := pods.Items[0]
 		for _, c := range pod.Spec.Containers {
 			if c.Image == config.TestConfig.PauseImage {

--- a/e2e-test/e2e/chaos/podchaos/pod_failure.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_failure.go
@@ -84,7 +84,7 @@ func TestcasePodFailureOnceThenDelete(ns string, kubeCli kubernetes.Interface, c
 	framework.ExpectNoError(err, "create pod failure chaos error")
 
 	By("waiting for assertion some pod fall into failure")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err := kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		if err != nil {
 			return false, nil
@@ -107,7 +107,7 @@ func TestcasePodFailureOnceThenDelete(ns string, kubeCli kubernetes.Interface, c
 	framework.ExpectNoError(err, "failed to delete pod failure chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err := kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		if err != nil {
 			return false, nil
@@ -180,7 +180,7 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 
 	By("waiting for assertion some pod fall into failure")
 	// check whether the pod failure chaos succeeded or not
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err := kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		if err != nil {
 			return false, nil
@@ -201,7 +201,7 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("waiting for assertion about chaos experiment paused")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get pod chaos error")
@@ -215,7 +215,7 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	By("wait for 30 seconds and no pod failure")
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get timer pod error")
-	err = wait.Poll(5*time.Second, 30*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get timer pod error")
 		pod := pods.Items[0]
@@ -234,7 +234,7 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("waiting for assertion about pod failure happens again")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get pod chaos error")
@@ -246,7 +246,7 @@ func TestcasePodFailurePauseThenUnPause(ns string, kubeCli kubernetes.Interface,
 	framework.ExpectNoError(err, "check resumed chaos failed")
 
 	By("waiting for assert pod failure happens again")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get timer pod error")
 		pod := pods.Items[0]

--- a/e2e-test/e2e/chaos/podchaos/pod_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_kill.go
@@ -137,7 +137,9 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	// some pod is killed as expected
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get nginx pods error")
+		if err != nil {
+			return false, err
+		}
 		return !fixture.HaveSameUIDs(pods.Items, newPods.Items), nil
 	})
 	framework.ExpectNoError(err, "wait pod killed failed")
@@ -149,7 +151,9 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get pod chaos error")
+		if err != nil {
+			return false, nil
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -162,7 +166,9 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	framework.ExpectNoError(err, "get nginx pods error")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
-		framework.ExpectNoError(err, "get nginx pods error")
+		if err != nil {
+			return false, nil
+		}
 		return !fixture.HaveSameUIDs(pods.Items, newPods.Items), nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait pod not killed failed")

--- a/e2e-test/e2e/chaos/podchaos/pod_kill.go
+++ b/e2e-test/e2e/chaos/podchaos/pod_kill.go
@@ -72,7 +72,7 @@ func TestcasePodKillOnceThenDelete(ns string, kubeCli kubernetes.Interface, cli 
 	err = cli.Create(ctx, podKillChaos)
 	framework.ExpectNoError(err, "create pod chaos error")
 
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		_, err = kubeCli.CoreV1().Pods(ns).Get(context.TODO(), "nginx", metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			return true, nil
@@ -135,7 +135,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	}
 
 	// some pod is killed as expected
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
 		return !fixture.HaveSameUIDs(pods.Items, newPods.Items), nil
@@ -146,7 +146,7 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	err = util.PauseChaos(ctx, cli, podKillChaos)
 	framework.ExpectNoError(err, "pause chaos error")
 
-	err = wait.Poll(1*time.Second, 5*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.PodChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get pod chaos error")
@@ -160,12 +160,12 @@ func TestcasePodKillPauseThenUnPause(ns string, kubeCli kubernetes.Interface, cl
 	// wait for 1 minutes and no pod is killed
 	pods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 	framework.ExpectNoError(err, "get nginx pods error")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err = kubeCli.CoreV1().Pods(ns).List(context.TODO(), listOption)
 		framework.ExpectNoError(err, "get nginx pods error")
 		return !fixture.HaveSameUIDs(pods.Items, newPods.Items), nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait pod not killed failed")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 }

--- a/e2e-test/e2e/chaos/sidecar/injection_config.go
+++ b/e2e-test/e2e/chaos/sidecar/injection_config.go
@@ -58,7 +58,9 @@ selector:
 
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
-		framework.ExpectNoError(err, "get chaos mesh controller pods error")
+		if err != nil {
+			return false, nil
+		}
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
@@ -111,7 +113,9 @@ selector:
 
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
-		framework.ExpectNoError(err, "get chaos mesh controller pods error")
+		if err != nil {
+			return false, nil
+		}
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}

--- a/e2e-test/e2e/chaos/sidecar/injection_config.go
+++ b/e2e-test/e2e/chaos/sidecar/injection_config.go
@@ -56,7 +56,7 @@ selector:
 	pods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 	framework.ExpectNoError(err, "get chaos mesh controller pods error")
 
-	err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 		framework.ExpectNoError(err, "get chaos mesh controller pods error")
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
@@ -68,7 +68,7 @@ selector:
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 	err = enableWebhook(ns)
 	framework.ExpectNoError(err, "enable webhook on ns error")
@@ -109,7 +109,7 @@ selector:
 	pods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 	framework.ExpectNoError(err, "get chaos mesh controller pods error")
 
-	err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 		framework.ExpectNoError(err, "get chaos mesh controller pods error")
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
@@ -121,7 +121,7 @@ selector:
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 	err = enableWebhook(ns)
 	framework.ExpectNoError(err, "enable webhook on ns error")

--- a/e2e-test/e2e/chaos/sidecar/template_config.go
+++ b/e2e-test/e2e/chaos/sidecar/template_config.go
@@ -57,7 +57,9 @@ selector:
 
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
-		framework.ExpectNoError(err, "get chaos mesh controller pods error")
+		if err != nil {
+			return false, nil
+		}
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}
@@ -100,7 +102,9 @@ selector:
 
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
-		framework.ExpectNoError(err, "get chaos mesh controller pods error")
+		if err != nil {
+			return false, nil
+		}
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
 			return true, nil
 		}

--- a/e2e-test/e2e/chaos/sidecar/template_config.go
+++ b/e2e-test/e2e/chaos/sidecar/template_config.go
@@ -55,7 +55,7 @@ selector:
 	pods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 	framework.ExpectNoError(err, "get chaos mesh controller pods error")
 
-	err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 		framework.ExpectNoError(err, "get chaos mesh controller pods error")
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
@@ -67,7 +67,7 @@ selector:
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 	cancel()
 }
@@ -98,7 +98,7 @@ selector:
 	pods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 	framework.ExpectNoError(err, "get chaos mesh controller pods error")
 
-	err = wait.Poll(time.Second, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		newPods, err := kubeCli.CoreV1().Pods(cmNamespace).List(context.TODO(), listOptions)
 		framework.ExpectNoError(err, "get chaos mesh controller pods error")
 		if !fixture.HaveSameUIDs(pods.Items, newPods.Items) {
@@ -110,5 +110,5 @@ selector:
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait chaos mesh not dies")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 }

--- a/e2e-test/e2e/chaos/stresschaos/cpu.go
+++ b/e2e-test/e2e/chaos/stresschaos/cpu.go
@@ -43,7 +43,7 @@ func TestcaseCPUStressInjectionOnceThenRecover(
 	lastCPUTime := make([]uint64, 2)
 	diff := make([]uint64, 2)
 	By("waiting for assertion some pods are experiencing cpu stress")
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		conditions, err := probeStressCondition(c, ports)
 		if err != nil {
 			return false, err
@@ -73,7 +73,7 @@ func TestcaseCPUStressInjectionOnceThenRecover(
 	By("waiting for assertion recovering")
 	lastCPUTime = make([]uint64, 2)
 	diff = make([]uint64, 2)
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		conditions, err := probeStressCondition(c, ports)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/stresschaos/memory.go
+++ b/e2e-test/e2e/chaos/stresschaos/memory.go
@@ -47,7 +47,7 @@ func TestcaseMemoryStressInjectionOnceThenRecover(
 	framework.ExpectNoError(err, "create stresschaos error")
 
 	By("waiting for assertion some pods are experiencing memory stress")
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		conditions, err := probeStressCondition(c, ports)
 		if err != nil {
 			return false, err
@@ -68,7 +68,7 @@ func TestcaseMemoryStressInjectionOnceThenRecover(
 	err = cli.Delete(ctx, memoryStressChaos.DeepCopy())
 	framework.ExpectNoError(err, "delete stresschaos error")
 	By("waiting for assertion recovering")
-	err = wait.Poll(time.Second, 15*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		conditions, err := probeStressCondition(c, ports)
 		if err != nil {
 			return false, err

--- a/e2e-test/e2e/chaos/timechaos/time_skew.go
+++ b/e2e-test/e2e/chaos/timechaos/time_skew.go
@@ -78,7 +78,9 @@ func TestcaseTimeSkewOnceThenRecover(
 	By("waiting for assertion")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, err
+		}
 		if podTime.Before(*initTime) {
 			return true, nil
 		}
@@ -93,7 +95,9 @@ func TestcaseTimeSkewOnceThenRecover(
 	By("waiting for assertion recovering")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, nil
+		}
 		// since there is no timechaos now, current pod time should not be earlier
 		// than the init time
 		if podTime.Before(*initTime) {
@@ -150,7 +154,9 @@ func TestcaseTimeSkewPauseThenUnpause(
 	By("waiting for assertion")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, err
+		}
 		if podTime.Before(*initTime) {
 			return true, nil
 		}
@@ -172,7 +178,9 @@ func TestcaseTimeSkewPauseThenUnpause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.TimeChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get time chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.StoppedPhase {
 			return true, nil
 		}
@@ -184,7 +192,9 @@ func TestcaseTimeSkewPauseThenUnpause(
 	framework.ExpectNoError(err, "get timer pod error")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, nil
+		}
 		if podTime.Before(*initTime) {
 			return true, nil
 		}
@@ -201,7 +211,9 @@ func TestcaseTimeSkewPauseThenUnpause(
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.TimeChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
-		framework.ExpectNoError(err, "get time chaos error")
+		if err != nil {
+			return false, err
+		}
 		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
 			return true, nil
 		}
@@ -213,7 +225,9 @@ func TestcaseTimeSkewPauseThenUnpause(
 	// whether time is earlier than init time,
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, err
+		}
 		if podTime.Before(*initTime) {
 			return true, nil
 		}
@@ -270,7 +284,9 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 	By("waiting for assertion")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodChildProcessTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, err
+		}
 		if podTime.Before(*initTime) {
 			return true, nil
 		}
@@ -285,7 +301,9 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 	By("waiting for assertion recovering")
 	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodChildProcessTimeNS(c, port)
-		framework.ExpectNoError(err, "failed to get pod time")
+		if err != nil {
+			return false, nil
+		}
 		// since there is no timechaos now, current pod time should not be earlier
 		// than the init time
 		if podTime.Before(*initTime) {

--- a/e2e-test/e2e/chaos/timechaos/time_skew.go
+++ b/e2e-test/e2e/chaos/timechaos/time_skew.go
@@ -91,7 +91,7 @@ func TestcaseTimeSkewOnceThenRecover(
 	framework.ExpectNoError(err, "failed to delete time chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		// since there is no timechaos now, current pod time should not be earlier
@@ -102,7 +102,7 @@ func TestcaseTimeSkewOnceThenRecover(
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait no timechaos error")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 	By("success to perform time chaos")
 }
 
@@ -169,7 +169,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 	framework.ExpectNoError(err, "pause chaos error")
 
 	By("assert pause is effective")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.TimeChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get time chaos error")
@@ -182,7 +182,7 @@ func TestcaseTimeSkewPauseThenUnpause(
 
 	// wait for 1 minutes and check timer
 	framework.ExpectNoError(err, "get timer pod error")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		if podTime.Before(*initTime) {
@@ -191,14 +191,14 @@ func TestcaseTimeSkewPauseThenUnpause(
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait time chaos paused error")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 
 	By("resume time skew chaos experiment")
 	err = util.UnPauseChaos(ctx, cli, timeChaos)
 	framework.ExpectNoError(err, "resume chaos error")
 
 	By("assert chaos experiment resumed")
-	err = wait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		chaos := &v1alpha1.TimeChaos{}
 		err = cli.Get(ctx, chaosKey, chaos)
 		framework.ExpectNoError(err, "get time chaos error")
@@ -283,7 +283,7 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 	framework.ExpectNoError(err, "failed to delete time chaos")
 
 	By("waiting for assertion recovering")
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podTime, err := getPodChildProcessTimeNS(c, port)
 		framework.ExpectNoError(err, "failed to get pod time")
 		// since there is no timechaos now, current pod time should not be earlier
@@ -294,6 +294,6 @@ func TestcaseTimeSkewShouldAlsoAffectChildProces(
 		return false, nil
 	})
 	gomega.Expect(err).Should(gomega.HaveOccurred(), "wait no timechaos error")
-	gomega.Expect(err).To(gomega.MatchError(wait.ErrWaitTimeout))
+	gomega.Expect(err).To(gomega.MatchError(context.DeadlineExceeded))
 	By("success to perform time chaos")
 }

--- a/e2e-test/e2e/util/util.go
+++ b/e2e-test/e2e/util/util.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,26 @@ import (
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
+
+// ChaosConditionsTrue reports whether each expected condition is present and true.
+func ChaosConditionsTrue(status *v1alpha1.ChaosStatus, expected ...v1alpha1.ChaosConditionType) bool {
+	if status == nil {
+		return false
+	}
+
+	conditions := make(map[v1alpha1.ChaosConditionType]corev1.ConditionStatus, len(status.Conditions))
+	for _, condition := range status.Conditions {
+		conditions[condition.Type] = condition.Status
+	}
+
+	for _, conditionType := range expected {
+		if conditions[conditionType] != corev1.ConditionTrue {
+			return false
+		}
+	}
+
+	return true
+}
 
 // WaitForAPIServicesAvailable waits for apiservices to be available
 func WaitForAPIServicesAvailable(ctx context.Context, client aggregatorclientset.Interface, selector labels.Selector) error {
@@ -110,7 +131,7 @@ func WaitForCRDsEstablished(ctx context.Context, client apiextensionsclientset.I
 
 // WaitDeploymentReady waits for all pods which controlled by deployment to be ready.
 func WaitDeploymentReady(name, namespace string, cli kubernetes.Interface) error {
-	return wait.Poll(2*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		d, err := cli.AppsV1().Deployments(namespace).Get(
 			context.TODO(),
 			name,
@@ -150,7 +171,7 @@ func UnPauseChaos(ctx context.Context, cli client.Client, chaos client.Object) e
 }
 
 func WaitE2EHelperReady(c http.Client, port uint16) error {
-	return wait.Poll(2*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		if _, err = c.Get(fmt.Sprintf("http://localhost:%d/ping", port)); err != nil {
 			return false, nil
 		}
@@ -159,7 +180,7 @@ func WaitE2EHelperReady(c http.Client, port uint16) error {
 }
 
 func WaitHTTPE2EHelperReady(c http.Client, ip string, port uint16) error {
-	return wait.Poll(2*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		if _, err = c.Get(fmt.Sprintf("http://%s:%d/ping", ip, port)); err != nil {
 			framework.Logf("Err : %v , IP : %s", err, ip)
 			return false, nil
@@ -169,7 +190,7 @@ func WaitHTTPE2EHelperReady(c http.Client, ip string, port uint16) error {
 }
 
 func SetupHTTPE2EHelperTLSConfig(c http.Client, ip string, port uint16, tls_port uint16, body []byte) error {
-	return wait.Poll(2*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		if _, err = c.Post(fmt.Sprintf("http://%s:%d/setup_https", ip, port), "application/json", bytes.NewBuffer(body)); err != nil {
 			framework.Logf("Err : %v , IP : %s", err, ip)
 			return false, nil
@@ -183,7 +204,7 @@ func SetupHTTPE2EHelperTLSConfig(c http.Client, ip string, port uint16, tls_port
 }
 
 func WaitHTTPE2EHelperTLSReady(c http.Client, ip string, port uint16) error {
-	return wait.Poll(2*time.Second, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		if _, err = c.Get(fmt.Sprintf("https://%s:%d/ping", ip, port)); err != nil {
 			framework.Logf("Err : %v , IP : %s", err, ip)
 			return false, nil

--- a/e2e-test/e2e/util/util.go
+++ b/e2e-test/e2e/util/util.go
@@ -133,7 +133,7 @@ func WaitForCRDsEstablished(ctx context.Context, client apiextensionsclientset.I
 func WaitDeploymentReady(name, namespace string, cli kubernetes.Interface) error {
 	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		d, err := cli.AppsV1().Deployments(namespace).Get(
-			context.TODO(),
+			ctx,
 			name,
 			metav1.GetOptions{},
 		)

--- a/e2e-test/e2e/util/util_test.go
+++ b/e2e-test/e2e/util/util_test.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+)
+
+func TestChaosConditionsTrue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		status   *v1alpha1.ChaosStatus
+		expected []v1alpha1.ChaosConditionType
+		want     bool
+	}{
+		{
+			name: "all expected conditions are true",
+			status: &v1alpha1.ChaosStatus{Conditions: []v1alpha1.ChaosCondition{
+				{Type: v1alpha1.ConditionSelected, Status: corev1.ConditionTrue},
+				{Type: v1alpha1.ConditionAllInjected, Status: corev1.ConditionTrue},
+			}},
+			expected: []v1alpha1.ChaosConditionType{v1alpha1.ConditionSelected, v1alpha1.ConditionAllInjected},
+			want:     true,
+		},
+		{
+			name: "expected condition is absent",
+			status: &v1alpha1.ChaosStatus{Conditions: []v1alpha1.ChaosCondition{
+				{Type: v1alpha1.ConditionSelected, Status: corev1.ConditionTrue},
+			}},
+			expected: []v1alpha1.ChaosConditionType{v1alpha1.ConditionSelected, v1alpha1.ConditionAllInjected},
+			want:     false,
+		},
+		{
+			name: "expected condition is not true",
+			status: &v1alpha1.ChaosStatus{Conditions: []v1alpha1.ChaosCondition{
+				{Type: v1alpha1.ConditionSelected, Status: corev1.ConditionFalse},
+			}},
+			expected: []v1alpha1.ChaosConditionType{v1alpha1.ConditionSelected},
+			want:     false,
+		},
+		{
+			name:     "nil status",
+			status:   nil,
+			expected: []v1alpha1.ChaosConditionType{v1alpha1.ConditionSelected},
+			want:     false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := ChaosConditionsTrue(testCase.status, testCase.expected...)
+			if got != testCase.want {
+				t.Errorf("ChaosConditionsTrue() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}

--- a/e2e-test/types.go
+++ b/e2e-test/types.go
@@ -138,8 +138,3 @@ func (oa *operatorAction) runKubectlOrDie(args ...string) string {
 	klog.Infof("Combined output: %q", string(out))
 	return string(out)
 }
-
-func (oa *operatorAction) apiVersions() []string {
-	stdout := oa.runKubectlOrDie("api-versions")
-	return strings.Split(stdout, "\n")
-}

--- a/examples/client-go/main.go
+++ b/examples/client-go/main.go
@@ -259,7 +259,7 @@ func main() {
 	}
 
 	// Wait for lister cache to catch up if needed
-	wait.Poll(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, false, func(ctx context.Context) (bool, error) {
 		listerList, _ := podChaosLister.Podchaos(namespace).List(labels.Everything())
 		return len(listerList) == len(directList.Items), nil
 	})


### PR DESCRIPTION
## What problem does this PR solve?

Close #4931
Close #4975

Replace deprecated `wait.Poll` with `wait.PollUntilContextTimeout`.

## What's changed and how does it work?

In addition to replacing deprecated functions, this PR also fixes some issues found by gls (go language server).

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [x] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
