### PR TITLE
test(e2e): add Gherkin BDD e2e test for JVMChaos latency on JDK 21

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -159,6 +159,7 @@ jobs:
           - "[Basic] [NetworkChaos]"
           - "[Basic] [DNSChaos]"
           - "[Basic] [StressChaos]"
+          - "[Basic] [JVMChaos]"
     steps:
       - name: checkout codes
         uses: actions/checkout@v7
@@ -206,6 +207,8 @@ jobs:
           helm install --wait --create-namespace chaos-mesh helm/chaos-mesh --namespace=chaos-mesh \
             --set images.tag=latest
       - name: e2e tests
+        # JVMChaos only has gherkin scenarios, no ginkgo specs
+        if: matrix.focus != '[Basic] [JVMChaos]'
         env:
           FOCUS: ${{ matrix.focus }}
         # because ginkgo -focus accepts the regex expression, we should use escape to represent the squared brackets and dash
@@ -213,10 +216,15 @@ jobs:
           export ESCAPED_FOCUS=$(echo $FOCUS | sed -e 's/\[/\\\[/g' | sed -e 's/\]/\\\]/g' | sed -e 's/\-/\\\-/g')
           KUBECONFIG=~/.kube/config ./e2e-test/image/e2e/bin/ginkgo -focus="${ESCAPED_FOCUS}" ./e2e-test/image/e2e/bin/e2e.test -- --e2e-image ghcr.io/chaos-mesh/e2e-helper:latest
 
-      - name: e2e gherkin tests
+      - name: e2e gherkin tests (podchaos)
         if: matrix.focus == '[Basic] [PodChaos]'
         run: |
-          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config ../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
+          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config GHERKIN_TAGS=@podchaos ../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
+
+      - name: e2e gherkin tests (jvmchaos)
+        if: matrix.focus == '[Basic] [JVMChaos]'
+        run: |
+          cd e2e-test/e2e-gherkin && KUBECONFIG=~/.kube/config GHERKIN_TAGS=@jvmchaos ../image/e2e/bin/e2e-gherkin.test -test.v --e2e-image=ghcr.io/chaos-mesh/e2e-helper:latest
       - name: post run - extract profile info from kubernetes
         if: always()
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add unit tests for `pkg/netem/convert.go` achieving 100% statement coverage [#4915](https://github.com/chaos-mesh/chaos-mesh/pull/4915)
 - Add unit tests for `pkg/chaosdaemon/cgroups/pidpath.go` covering parseCgroupFromReader [#4926](https://github.com/chaos-mesh/chaos-mesh/pull/4926)
 - Add Gherkin BDD e2e test runner with PodKill scenarios [#5013](https://github.com/chaos-mesh/chaos-mesh/pull/5013)
+- Add Gherkin BDD e2e test for JVMChaos latency action on JDK 21 [#5054](https://github.com/chaos-mesh/chaos-mesh/pull/5054)
 - fix(api): add missing omitempty tags to optional fields [#5006](https://github.com/chaos-mesh/chaos-mesh/pull/5006)
 
 ### Changed

--- a/e2e-test/e2e-gherkin/features/jvmchaos.feature
+++ b/e2e-test/e2e-gherkin/features/jvmchaos.feature
@@ -1,0 +1,39 @@
+# Copyright 2026 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+@jvmchaos
+Feature: JVMChaos Simulation
+
+  Scenario: JVM latency slows down method calls
+    Given a namespace is prepared
+    And a java pod named "helloworld" printing one log line per second is running
+    When a JVM latency chaos named "helloworld-latency" with 3000 ms latency is applied to class "Main" method "sayhello" for pods with label "app=helloworld"
+    Then the pod named "helloworld" should eventually print log lines with intervals longer than 3000 milliseconds
+
+  Scenario: JVM exception chaos injects and recovers
+    Given a namespace is prepared
+    And a java pod named "helloworld" printing one log line per second is running
+    When a JVM exception chaos named "helloworld-exception" throwing exception "java.io.IOException" with message "BOOM" is applied to class "Main" method "sayhello" for pods with label "app=helloworld"
+    Then the pod named "helloworld" should eventually print a log line containing "Got an exception! java.io.IOException: BOOM"
+    When the JVM chaos "helloworld-exception" is deleted
+    Then the pod named "helloworld" should eventually stop printing log lines containing "Got an exception! java.io.IOException: BOOM"
+
+  Scenario: JVM ruleData chaos modifies return value and recovers
+    Given a namespace is prepared
+    And a java pod named "helloworld" printing one log line per second is running
+    When a JVM ruleData chaos named "helloworld-rule" modifying method "getnum" of class "Main" to return "9999" is applied to pods with label "app=helloworld"
+    Then the pod named "helloworld" should eventually print a log line containing "9999. Hello World"
+    When the JVM chaos "helloworld-rule" is deleted
+    Then the pod named "helloworld" should eventually stop printing log lines containing "9999. Hello World"

--- a/e2e-test/e2e-gherkin/features/podchaos.feature
+++ b/e2e-test/e2e-gherkin/features/podchaos.feature
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+@podchaos
 Feature: PodChaos Simulation
 
   Scenario: PodKill once then delete

--- a/e2e-test/e2e-gherkin/gherkin_test.go
+++ b/e2e-test/e2e-gherkin/gherkin_test.go
@@ -93,10 +93,14 @@ func TestFeatures(t *testing.T) {
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			tc.RegisterSteps(ctx)
 			tc.RegisterPodChaosSteps(ctx)
+			tc.RegisterJVMChaosSteps(ctx)
 		},
 		Options: &godog.Options{
-			Format:   "pretty",
-			Paths:    []string{"features"},
+			Format: "pretty",
+			Paths:  []string{"features"},
+			// GHERKIN_TAGS selects which features to run, for example
+			// "@jvmchaos". Empty means run all features.
+			Tags:     os.Getenv("GHERKIN_TAGS"),
 			TestingT: t,
 		},
 	}

--- a/e2e-test/e2e-gherkin/steps/jvmchaos_steps.go
+++ b/e2e-test/e2e-gherkin/steps/jvmchaos_steps.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package steps
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
+)
+
+func (tc *TestContext) RegisterJVMChaosSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^a java pod named "([^"]*)" printing one log line per second is running$`, tc.aJavaPodPrintingLogsIsRunning)
+	ctx.Step(`^a JVM latency chaos named "([^"]*)" with (\d+) ms latency is applied to class "([^"]*)" method "([^"]*)" for pods with label "([^"]*)"$`, tc.aJVMLatencyChaosIsApplied)
+	ctx.Step(`^a JVM exception chaos named "([^"]*)" throwing exception "([^"]*)" with message "([^"]*)" is applied to class "([^"]*)" method "([^"]*)" for pods with label "([^"]*)"$`, tc.aJVMExceptionChaosIsApplied)
+	ctx.Step(`^a JVM ruleData chaos named "([^"]*)" modifying method "([^"]*)" of class "([^"]*)" to return "([^"]*)" is applied to pods with label "([^"]*)"$`, tc.aJVMRuleDataChaosIsApplied)
+	ctx.Step(`^the JVM chaos "([^"]*)" is deleted$`, tc.theJVMChaosIsDeleted)
+	ctx.Step(`^the pod named "([^"]*)" should eventually print log lines with intervals longer than (\d+) milliseconds$`, tc.thePodShouldPrintLogLinesWithLongIntervals)
+	ctx.Step(`^the pod named "([^"]*)" should eventually print a log line containing "([^"]*)"$`, tc.thePodShouldPrintLogLineContaining)
+	ctx.Step(`^the pod named "([^"]*)" should eventually stop printing log lines containing "([^"]*)"$`, tc.thePodShouldStopPrintingLogLinesContaining)
+}
+
+func (tc *TestContext) aJavaPodPrintingLogsIsRunning(name string) error {
+	pod := fixture.NewJavaHelloWorldPod(name, tc.Namespace)
+	_, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	if err := tc.waitPodRunning(name); err != nil {
+		return err
+	}
+	// Wait until the java process starts printing logs, so the java process
+	// is ready before chaos is applied.
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		timestamps, err := tc.podLogTimestamps(ctx, name, 5)
+		if err != nil {
+			return false, nil
+		}
+		return len(timestamps) > 0, nil
+	})
+}
+
+// newJVMChaos builds a JVMChaos object selecting all pods with the given
+// label in the scenario namespace. The caller fills in action fields.
+func (tc *TestContext) newJVMChaos(name, labelKeyVal string, param v1alpha1.JVMParameter, action v1alpha1.JVMChaosAction) (*v1alpha1.JVMChaos, error) {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+
+	return &v1alpha1.JVMChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tc.Namespace,
+		},
+		Spec: v1alpha1.JVMChaosSpec{
+			Action:       action,
+			JVMParameter: param,
+			ContainerSelector: v1alpha1.ContainerSelector{
+				PodSelector: v1alpha1.PodSelector{
+					Selector: v1alpha1.PodSelectorSpec{
+						GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+							Namespaces: []string{tc.Namespace},
+							LabelSelectors: map[string]string{
+								parts[0]: parts[1],
+							},
+						},
+					},
+					Mode: v1alpha1.AllMode,
+				},
+			},
+		},
+	}, nil
+}
+
+func (tc *TestContext) aJVMLatencyChaosIsApplied(name string, latencyMs int, class, method, labelKeyVal string) error {
+	param := v1alpha1.JVMParameter{
+		JVMClassMethodSpec: v1alpha1.JVMClassMethodSpec{
+			Class:  class,
+			Method: method,
+		},
+		LatencyDuration: latencyMs,
+	}
+	jvmChaos, err := tc.newJVMChaos(name, labelKeyVal, param, v1alpha1.JVMLatencyAction)
+	if err != nil {
+		return err
+	}
+	return tc.Client.Create(context.TODO(), jvmChaos)
+}
+
+func (tc *TestContext) aJVMExceptionChaosIsApplied(name, exceptionClass, message, class, method, labelKeyVal string) error {
+	param := v1alpha1.JVMParameter{
+		JVMClassMethodSpec: v1alpha1.JVMClassMethodSpec{
+			Class:  class,
+			Method: method,
+		},
+		ThrowException: fmt.Sprintf("%s(%q)", exceptionClass, message),
+	}
+	jvmChaos, err := tc.newJVMChaos(name, labelKeyVal, param, v1alpha1.JVMExceptionAction)
+	if err != nil {
+		return err
+	}
+	return tc.Client.Create(context.TODO(), jvmChaos)
+}
+
+func (tc *TestContext) aJVMRuleDataChaosIsApplied(name, method, class, returnValue, labelKeyVal string) error {
+	ruleData := fmt.Sprintf(
+		"RULE modify return value\nCLASS %s\nMETHOD %s\nAT ENTRY\nIF true\nDO\n    return %s\nENDRULE",
+		class, method, returnValue,
+	)
+	param := v1alpha1.JVMParameter{
+		RuleData: ruleData,
+	}
+	jvmChaos, err := tc.newJVMChaos(name, labelKeyVal, param, v1alpha1.JVMRuleDataAction)
+	if err != nil {
+		return err
+	}
+	return tc.Client.Create(context.TODO(), jvmChaos)
+}
+
+func (tc *TestContext) theJVMChaosIsDeleted(name string) error {
+	jvmChaos := &v1alpha1.JVMChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tc.Namespace,
+		},
+	}
+	return tc.Client.Delete(context.TODO(), jvmChaos)
+}
+
+func (tc *TestContext) thePodShouldPrintLogLinesWithLongIntervals(name string, intervalMs int) error {
+	expected := time.Duration(intervalMs) * time.Millisecond
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		// Read more lines than needed: when the byteman agent runs in
+		// verbose mode, its own output is mixed into stdout, and
+		// podLogTimestamps only keeps the application log lines.
+		timestamps, err := tc.podLogTimestamps(ctx, name, 30)
+		if err != nil {
+			return false, nil
+		}
+		if len(timestamps) < 3 {
+			return false, nil
+		}
+		timestamps = timestamps[len(timestamps)-3:]
+		// The chaos takes effect when consecutive log lines are separated by
+		// more than the injected latency.
+		for i := 1; i < len(timestamps); i++ {
+			if timestamps[i].Sub(timestamps[i-1]) <= expected {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+func (tc *TestContext) thePodShouldPrintLogLineContaining(name, message string) error {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		lines, err := tc.podLogTail(ctx, name, 10)
+		if err != nil {
+			return false, nil
+		}
+		for _, line := range lines {
+			if strings.Contains(line, message) {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) thePodShouldStopPrintingLogLinesContaining(name, message string) error {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		// Look at the last few lines only: old lines from before the
+		// recovery still contain the message.
+		lines, err := tc.podLogTail(ctx, name, 3)
+		if err != nil {
+			return false, nil
+		}
+		if len(lines) == 0 {
+			return false, nil
+		}
+		for _, line := range lines {
+			if strings.Contains(line, message) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+// podLogTail reads the last lines of the pod log.
+func (tc *TestContext) podLogTail(ctx context.Context, name string, tailLines int64) ([]string, error) {
+	req := tc.KubeCli.CoreV1().Pods(tc.Namespace).GetLogs(name, &corev1.PodLogOptions{
+		TailLines: pointer.Int64(tailLines),
+	})
+	data, err := req.DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// podLogTimestamps reads the last lines of the pod log and returns the
+// timestamps of the "Hello World" lines printed by the java test app.
+func (tc *TestContext) podLogTimestamps(ctx context.Context, name string, tailLines int64) ([]time.Time, error) {
+	req := tc.KubeCli.CoreV1().Pods(tc.Namespace).GetLogs(name, &corev1.PodLogOptions{
+		Timestamps: true,
+		TailLines:  pointer.Int64(tailLines),
+	})
+	data, err := req.DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var timestamps []time.Time
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "Hello World") {
+			continue
+		}
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, fields[0])
+		if err != nil {
+			continue
+		}
+		timestamps = append(timestamps, ts)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return timestamps, nil
+}

--- a/e2e-test/pkg/fixture/fixture.go
+++ b/e2e-test/pkg/fixture/fixture.go
@@ -16,6 +16,7 @@
 package fixture
 
 import (
+	"fmt"
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -338,6 +339,66 @@ func NewE2EService(name, namespace string) *corev1.Service {
 					Name:       "chaosfs",
 					Port:       65534,
 					TargetPort: intstr.IntOrString{IntVal: 65534},
+				},
+			},
+		},
+	}
+}
+
+// NewJavaHelloWorldPod creates a pod running a small java program.
+// The program calls Main.sayhello once per second, and sayhello prints one
+// log line. It is used by JVMChaos e2e tests, which inject faults into the
+// sayhello method. The image uses JDK 21 on purpose: the byteman rule for
+// the latency action must work with the Thread.sleep(Duration) overload
+// added in JDK 19, see https://github.com/chaos-mesh/chaos-mesh/pull/4821.
+func NewJavaHelloWorldPod(name, namespace string) *corev1.Pod {
+	javaSource := `
+public class Main {
+    public static void main(String[] args) throws Exception {
+        for (long i = 0; ; i++) {
+            try {
+                sayhello(i);
+            } catch (Exception e) {
+                System.out.println("Got an exception! " + e);
+            }
+            Thread.sleep(1000);
+        }
+    }
+
+    public static void sayhello(long num) throws Exception {
+        System.out.println(getnum(num) + ". Hello World");
+    }
+
+    public static long getnum(long num) {
+        return num;
+    }
+}
+`
+	script := fmt.Sprintf(`set -e
+mkdir -p /app
+cat > /app/Main.java <<'EOF'
+%s
+EOF
+cd /app
+javac Main.java
+exec java Main
+`, javaSource)
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            name,
+					Image:           "eclipse-temurin:21-jdk",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sh", "-c", script},
 				},
 			},
 		},


### PR DESCRIPTION
## What problem does this PR solve?

JVMChaos has no e2e coverage. #4821 fixed the latency action on JDK 19+, and during its review we agreed an e2e test should follow up (see discussion in #4821). Without one, regressions like the `Thread.sleep` overload issue can only be caught by unit tests on the generated rule string, not by a real injection.

## What's changed and how does it work?

Add Gherkin BDD scenarios for JVMChaos, following the runner introduced in #5013. Three scenarios cover the actions that previously only had shell-based integration tests (`test/integration_test/jvm`):

- **latency**: apply a 3000 ms latency chaos to the `sayhello` method, then assert consecutive log line intervals grow beyond 3000 ms (asserted via pod log timestamps).
- **exception**: throw `java.io.IOException("BOOM")` in `sayhello`, assert the exception message appears in pod logs, then delete the chaos and assert it stops appearing (recovery).
- **ruleData**: modify `getnum` with a raw byteman rule to return 9999, assert `9999. Hello World` appears in logs, then delete the chaos and assert recovery.

The `NewJavaHelloWorldPod` fixture compiles and runs a small java program inside `eclipse-temurin:21-jdk`. JDK 21 is used on purpose: it covers the regression fixed in #4821, where byteman rule type checking failed on JDK 19+ after `Thread.sleep(Duration)` was added.

Verified locally on a kind cluster: all three scenarios pass in ~90s total, and the latency scenario fails without the #4821 fix.

> [!NOTE]
> This test only runs in CI after #5028 (integrate the Gherkin runner in CI) is merged. Until then it can be run locally with the compiled `e2e-gherkin` test binary against a cluster with Chaos Mesh installed.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e fixtures, Gherkin steps, and CI workflow; no runtime Chaos Mesh components are modified.
> 
> **Overview**
> Adds **end-to-end Gherkin coverage for JVMChaos** so latency, exception, and ruleData injections are validated against a real JDK 21 workload—not only unit tests on rule strings.
> 
> New `jvmchaos.feature` scenarios drive a `helloworld` Java pod (`NewJavaHelloWorldPod` on `eclipse-temurin:21-jdk`) and assert effects via pod logs (interval timing for latency, exception text, modified return values, and recovery after deleting the chaos). Step implementations live in `jvmchaos_steps.go` and are registered from `gherkin_test.go`.
> 
> **CI** gains a `[Basic] [JVMChaos]` matrix job that runs only tagged Gherkin tests (`GHERKIN_TAGS=@jvmchaos`) and skips Ginkgo for that focus; PodChaos Gherkin runs are scoped with `@podchaos`. Godog now honors `GHERKIN_TAGS` to filter features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ee39aa24b8276d5889e6bc9ec47902ad15c5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


