### PR TITLE
test(e2e-test): migrate remaining podchaos scenarios to gherkin BDD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - ci: extract Build Chaos Mesh Build Env step into composite action [#5000](https://github.com/chaos-mesh/chaos-mesh/pull/5000)
 - Integrate Gherkin BDD runner in CI and migrate namespace setup to Kubernetes E2E framework [#5028](https://github.com/chaos-mesh/chaos-mesh/pull/5028)
 - Migrate the JVM integration tests (workflow exception and mysql actions) to Gherkin e2e tests, replace TiDB with MySQL as the test backend, and remove the shell-based test [#5055](https://github.com/chaos-mesh/chaos-mesh/pull/5055)
+- Migrate the remaining PodChaos E2E scenarios (PodFailure and ContainerKill) to Gherkin BDD format [#5059](https://github.com/chaos-mesh/chaos-mesh/pull/5059)
 
 ### Deprecated
 

--- a/e2e-test/e2e-gherkin/features/podchaos.feature
+++ b/e2e-test/e2e-gherkin/features/podchaos.feature
@@ -30,3 +30,41 @@ Feature: PodChaos Simulation
     Then at least one pod should be replaced with a different UID
     When the chaos experiment "nginx-kill" is paused
     Then no further pods should be killed within 1 minute
+
+  Scenario: PodFailure once then delete
+    Given a namespace is prepared
+    And a deployment named "nginx" with 1 replicas is running
+    When a "PodFailure" chaos named "nginx-failure" with mode "one" is applied to pods with label "app=nginx"
+    Then the pods with label "app=nginx" should eventually have their container image changed to the pause image
+    When the chaos experiment "nginx-failure" is deleted
+    Then the pods with label "app=nginx" should eventually recover their original container image
+
+  Scenario: PodFailure pause then unpause
+    Given a namespace is prepared
+    And a deployment named "nginx" with 1 replicas is running
+    When a "PodFailure" chaos named "nginx-failure" with mode "one" is applied to pods with label "app=nginx"
+    Then the pods with label "app=nginx" should eventually have their container image changed to the pause image
+    When the chaos experiment "nginx-failure" is paused
+    Then the pods with label "app=nginx" should eventually recover their original container image
+    When the chaos experiment "nginx-failure" is unpaused
+    Then the pods with label "app=nginx" should eventually have their container image changed to the pause image
+
+  Scenario: ContainerKill once then delete
+    Given a namespace is prepared
+    And a deployment named "nginx" with 1 replicas is running
+    When a "ContainerKill" chaos named "nginx-container-kill" with mode "one" targeting container "nginx" is applied to pods with label "app=nginx"
+    Then the container "nginx" in pods with label "app=nginx" should eventually be terminated
+    When the chaos experiment "nginx-container-kill" is deleted
+    Then the container "nginx" in pods with label "app=nginx" should eventually be running and ready
+
+  Scenario: ContainerKill pause then unpause
+    Given a namespace is prepared
+    And a deployment named "nginx" with 1 replicas is running
+    When the container ID of container "nginx" in pods with label "app=nginx" is recorded
+    And a "ContainerKill" chaos named "nginx-container-kill" with mode "one" targeting container "nginx" is applied to pods with label "app=nginx"
+    Then the container ID should change
+    When the chaos experiment "nginx-container-kill" is paused
+    And the container ID of container "nginx" in pods with label "app=nginx" is recorded again
+    Then the container ID should not change within 1 minute
+    When the chaos experiment "nginx-container-kill" is unpaused
+    Then the container ID should not change within 10 seconds

--- a/e2e-test/e2e-gherkin/steps/common_steps.go
+++ b/e2e-test/e2e-gherkin/steps/common_steps.go
@@ -39,7 +39,8 @@ type TestContext struct {
 	Namespace string
 
 	// State recorded within a scenario
-	InitialPods []corev1.Pod
+	InitialPods     []corev1.Pod
+	LastContainerID string
 }
 
 func (tc *TestContext) RegisterSteps(ctx *godog.ScenarioContext) {

--- a/e2e-test/e2e-gherkin/steps/common_steps.go
+++ b/e2e-test/e2e-gherkin/steps/common_steps.go
@@ -41,6 +41,7 @@ type TestContext struct {
 	// State recorded within a scenario
 	InitialPods     []corev1.Pod
 	LastContainerID string
+	OriginalImage   string
 }
 
 func (tc *TestContext) RegisterSteps(ctx *godog.ScenarioContext) {

--- a/e2e-test/e2e-gherkin/steps/podchaos_steps.go
+++ b/e2e-test/e2e-gherkin/steps/podchaos_steps.go
@@ -26,10 +26,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/config"
 	"github.com/chaos-mesh/chaos-mesh/e2e-test/e2e/util"
 	"github.com/chaos-mesh/chaos-mesh/e2e-test/pkg/fixture"
 )
@@ -43,6 +45,18 @@ func (tc *TestContext) RegisterPodChaosSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^at least one pod should be replaced with a different UID$`, tc.atLeastOnePodShouldBeReplacedWithDifferentUID)
 	ctx.Step(`^the chaos experiment "([^"]*)" is paused$`, tc.theChaosExperimentIsPaused)
 	ctx.Step(`^no further pods should be killed within (\d+) minute$`, tc.noFurtherPodsShouldBeKilledWithinMinutes)
+	ctx.Step(`^the pods with label "([^"]*)" should eventually have their container image changed to the pause image$`, tc.podsHavePauseImage)
+	ctx.Step(`^the chaos experiment "([^"]*)" is deleted$`, tc.deleteChaos)
+	ctx.Step(`^the pods with label "([^"]*)" should eventually recover their original container image$`, tc.podsHaveOriginalImage)
+	ctx.Step(`^the chaos experiment "([^"]*)" is unpaused$`, tc.unpauseChaos)
+	ctx.Step(`^a "ContainerKill" chaos named "([^"]*)" with mode "([^"]*)" targeting container "([^"]*)" is applied to pods with label "([^"]*)"$`, tc.applyContainerKill)
+	ctx.Step(`^the container "([^"]*)" in pods with label "([^"]*)" should eventually be terminated$`, tc.containerTerminated)
+	ctx.Step(`^the container "([^"]*)" in pods with label "([^"]*)" should eventually be running and ready$`, tc.containerRunningAndReady)
+	ctx.Step(`^the container ID of container "([^"]*)" in pods with label "([^"]*)" is recorded$`, tc.recordContainerID)
+	ctx.Step(`^the container ID should change$`, tc.containerIDChanged)
+	ctx.Step(`^the container ID of container "([^"]*)" in pods with label "([^"]*)" is recorded again$`, tc.recordContainerID)
+	ctx.Step(`^the container ID should not change within (\d+) minute$`, tc.containerIDNotChangedMinutes)
+	ctx.Step(`^the container ID should not change within (\d+) seconds$`, tc.containerIDNotChangedSeconds)
 }
 
 func (tc *TestContext) aSinglePodNamedIsRunning(name string) error {
@@ -249,4 +263,305 @@ func (tc *TestContext) waitPodRunning(name string) error {
 		}
 		return true, nil
 	})
+}
+
+func (tc *TestContext) podsHavePauseImage(labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			parts[0]: parts[1],
+		}).String(),
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		pod := pods.Items[0]
+		for _, c := range pod.Spec.Containers {
+			if c.Image == config.TestConfig.PauseImage {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) deleteChaos(ctx context.Context, name string) error {
+	chaos := &v1alpha1.PodChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: tc.Namespace,
+			Name:      name,
+		},
+	}
+	return tc.Client.Delete(ctx, chaos)
+}
+
+func (tc *TestContext) podsHaveOriginalImage(labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			parts[0]: parts[1],
+		}).String(),
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		pod := pods.Items[0]
+		for _, c := range pod.Spec.Containers {
+			if c.Image == "nginx:latest" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) unpauseChaos(ctx context.Context, name string) error {
+	chaos := &v1alpha1.PodChaos{}
+	err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, chaos)
+	if err != nil {
+		return err
+	}
+	err = util.UnPauseChaos(ctx, tc.Client, chaos)
+	if err != nil {
+		return err
+	}
+
+	chaosKey := types.NamespacedName{
+		Namespace: tc.Namespace,
+		Name:      name,
+	}
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(innerCtx context.Context) (done bool, err error) {
+		err = tc.Client.Get(innerCtx, chaosKey, chaos)
+		if err != nil {
+			return false, err
+		}
+		if chaos.Status.Experiment.DesiredPhase == v1alpha1.RunningPhase {
+			return true, nil
+		}
+		return false, err
+	})
+}
+
+func (tc *TestContext) applyContainerKill(name, modeStr, containerName, labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	labelKey := parts[0]
+	labelVal := parts[1]
+
+	mode, err := tc.parseChaosMode(modeStr)
+	if err != nil {
+		return err
+	}
+
+	podChaos := &v1alpha1.PodChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tc.Namespace,
+		},
+		Spec: v1alpha1.PodChaosSpec{
+			Action: v1alpha1.ContainerKillAction,
+			ContainerSelector: v1alpha1.ContainerSelector{
+				PodSelector: v1alpha1.PodSelector{
+					Selector: v1alpha1.PodSelectorSpec{
+						GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+							Namespaces: []string{tc.Namespace},
+							LabelSelectors: map[string]string{
+								labelKey: labelVal,
+							},
+						},
+					},
+					Mode: mode,
+				},
+				ContainerNames: []string{containerName},
+			},
+		},
+	}
+	return tc.Client.Create(context.TODO(), podChaos)
+}
+
+func (tc *TestContext) containerTerminated(containerName, labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			parts[0]: parts[1],
+		}).String(),
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		pod := pods.Items[0]
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == containerName && cs.LastTerminationState.Terminated != nil {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) containerRunningAndReady(containerName, labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			parts[0]: parts[1],
+		}).String(),
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		pod := pods.Items[0]
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == containerName && cs.Ready && cs.State.Running != nil {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) recordContainerID(containerName, labelKeyVal string) error {
+	parts := strings.Split(labelKeyVal, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid label selector format: %s", labelKeyVal)
+	}
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			parts[0]: parts[1],
+		}).String(),
+	}
+	pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(context.TODO(), listOption)
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) != 1 {
+		return fmt.Errorf("expected 1 pod, found %d", len(pods.Items))
+	}
+	for _, cs := range pods.Items[0].Status.ContainerStatuses {
+		if cs.Name == containerName {
+			tc.LastContainerID = cs.ContainerID
+			return nil
+		}
+	}
+	return fmt.Errorf("container %s not found in pod %s", containerName, pods.Items[0].Name)
+}
+
+func (tc *TestContext) containerIDChanged() error {
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app": "nginx",
+		}).String(),
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		for _, cs := range pods.Items[0].Status.ContainerStatuses {
+			if cs.Name == "nginx" {
+				return tc.LastContainerID != cs.ContainerID, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (tc *TestContext) containerIDNotChangedMinutes(duration int) error {
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app": "nginx",
+		}).String(),
+	}
+	err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, time.Duration(duration)*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		for _, cs := range pods.Items[0].Status.ContainerStatuses {
+			if cs.Name == "nginx" {
+				if tc.LastContainerID != cs.ContainerID {
+					return true, fmt.Errorf("container ID changed from %s to %s", tc.LastContainerID, cs.ContainerID)
+				}
+			}
+		}
+		return false, nil
+	})
+	if wait.Interrupted(err) {
+		return nil
+	}
+	if err == nil {
+		return fmt.Errorf("expected container ID not to change, but no error occurred")
+	}
+	return err
+}
+
+func (tc *TestContext) containerIDNotChangedSeconds(duration int) error {
+	listOption := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app": "nginx",
+		}).String(),
+	}
+	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, time.Duration(duration)*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).List(ctx, listOption)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		for _, cs := range pods.Items[0].Status.ContainerStatuses {
+			if cs.Name == "nginx" {
+				if tc.LastContainerID != cs.ContainerID {
+					return true, fmt.Errorf("container ID changed from %s to %s", tc.LastContainerID, cs.ContainerID)
+				}
+			}
+		}
+		return false, nil
+	})
+	if wait.Interrupted(err) {
+		return nil
+	}
+	if err == nil {
+		return fmt.Errorf("expected container ID not to change, but no error occurred")
+	}
+	return err
 }

--- a/e2e-test/e2e-gherkin/steps/podchaos_steps.go
+++ b/e2e-test/e2e-gherkin/steps/podchaos_steps.go
@@ -61,6 +61,9 @@ func (tc *TestContext) RegisterPodChaosSteps(ctx *godog.ScenarioContext) {
 
 func (tc *TestContext) aSinglePodNamedIsRunning(name string) error {
 	pod := fixture.NewCommonNginxPod(name, tc.Namespace)
+	if len(pod.Spec.Containers) > 0 {
+		tc.OriginalImage = pod.Spec.Containers[0].Image
+	}
 	_, err := tc.KubeCli.CoreV1().Pods(tc.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -136,6 +139,9 @@ func (tc *TestContext) thePodNamedShouldEventuallyNotBeFound(name string) error 
 
 func (tc *TestContext) aDeploymentNamedWithReplicasIsRunning(name string, replicas int) error {
 	nd := fixture.NewCommonNginxDeployment(name, tc.Namespace, int32(replicas))
+	if len(nd.Spec.Template.Spec.Containers) > 0 {
+		tc.OriginalImage = nd.Spec.Template.Spec.Containers[0].Image
+	}
 	_, err := tc.KubeCli.AppsV1().Deployments(tc.Namespace).Create(context.TODO(), nd, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -300,7 +306,10 @@ func (tc *TestContext) deleteChaos(ctx context.Context, name string) error {
 			Name:      name,
 		},
 	}
-	return tc.Client.Delete(ctx, chaos)
+	if err := tc.Client.Delete(ctx, chaos); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (tc *TestContext) podsHaveOriginalImage(labelKeyVal string) error {
@@ -323,7 +332,11 @@ func (tc *TestContext) podsHaveOriginalImage(labelKeyVal string) error {
 		}
 		pod := pods.Items[0]
 		for _, c := range pod.Spec.Containers {
-			if c.Image == "nginx:latest" {
+			expectedImage := "nginx:latest"
+			if tc.OriginalImage != "" {
+				expectedImage = tc.OriginalImage
+			}
+			if c.Image == expectedImage {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
## What problem does this PR solve?

Part of #4902, follow up of #5028.

This PR migrates the remaining `PodChaos` scenarios to Gherkin BDD format.

## What's changed and how does it work?

* Appends the 4 remaining `PodChaos` scenarios to `e2e-test/e2e-gherkin/features/podchaos.feature`:
  - `PodFailure once then delete`
  - `PodFailure pause then unpause`
  - `ContainerKill once then delete`
  - `ContainerKill pause then unpause`
* Implements the corresponding step definitions and verification helpers in `e2e-test/e2e-gherkin/steps/podchaos_steps.go`.
* Registers the new step definitions inside `RegisterPodChaosSteps`.
* Adds the `LastContainerID` field to the shared scenario context in `common_steps.go` to track container restarts.

All scenarios have been verified locally to execute and pass.

### Test Result

```bash
6 scenarios (6 passed)
41 steps (41 passed)
5m58.367153822s
--- PASS: TestFeatures (358.38s)
    --- PASS: TestFeatures/PodKill_once_then_delete (38.23s)
    --- PASS: TestFeatures/PodKill_pause_does_not_trigger_further_kills (104.88s)
    --- PASS: TestFeatures/PodFailure_once_then_delete (27.14s)
    --- PASS: TestFeatures/PodFailure_pause_then_unpause (41.14s)
    --- PASS: TestFeatures/ContainerKill_once_then_delete (25.71s)
    --- PASS: TestFeatures/ContainerKill_pause_then_unpause (121.26s)
PASS
ok  	github.com/chaos-mesh/chaos-mesh/e2e-test/e2e-gherkin	358.40s
```

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [x] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
