### PR TITLE
ci(license-checker): filter ignored files from changed-files

### DIFF
--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -1,3 +1,8 @@
+# Note: If you change `paths-ignore` in this workflow,
+# please also update the `files_ignore` in the `Get changed files` step accordingly.
+#
+# Because the `paths-ignore` is used to determine whether to trigger the workflow or not,
+# while the `files_ignore` is used to determine which files to check for license headers.
 name: License checker
 
 on:

--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -65,13 +65,62 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v47
+        with:
+          files_ignore: |
+            .github/**
+            .well-known/**
+            **.md
+            **.json
+            *.mk
+            static/**
+            .dockerignore
+            .editorconfig
+            **/.gitignore
+            **/.gitkeep
+            .golangci.yml
+            .lift.toml
+            .muse.toml
+            .prettierrc
+            codecov.yml
+            env-images.yaml
+            Makefile
+            OWNERS
+            OWNERS_ALIASES
+            revive.toml
+            **/go.mod
+            **/go.sum
+            **/Dockerfile
+            helm/chaos-mesh/.helmignore
+            helm/chaos-mesh/templates/*.tpl
+            **.proto
+            config/**
+            helm/chaos-mesh/crds/*
+            manifests/**
+            **/*_generated*
+            pkg/dashboard/swaggerdocs/docs.go
+            pkg/dashboard/swaggerdocs/swagger.yaml
+            **.pb.go
+            pkg/time/fakeclock/.embed.o
+            ui/.husky/**
+            ui/.prettierignore
+            ui/.prettierrc
+            ui/pnpm-lock.yaml
+            ui/pnpm-workspace.yaml
+            ui/app/eslint.config.js
+            ui/app/index.html
+            ui/app/public/**
+            ui/app/src/api/zz_generated.frontend.chaos-mesh.ts
+            ui/app/src/formik/**
+            ui/app/src/openapi/**
+            ui/**/*.svg
+            **/__mocks__/**
 
       - name: Check license header for changed files
         env:
           ADDED_FILES: ${{ steps.changed-files.outputs.added_files }}
         run: |
           for file in ${ADDED_FILES}; do
-            if ! grep -q "Licensed under the Apache License, Version 2.0" $file; then
+            if ! grep -q "Licensed under the Apache License, Version 2.0" "$file"; then
               echo "License header is missing in $file."
               echo "Please check all added files have the license header before committing."
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
+- Fix mixed-file license checks incorrectly validating generated and documentation files [#5070](https://github.com/chaos-mesh/chaos-mesh/pull/5070)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
-- Fix mixed-file license checks incorrectly validating generated and documentation files [#5070](https://github.com/chaos-mesh/chaos-mesh/pull/5070)
 
 ### Security
 


### PR DESCRIPTION
## Summary
- filter generated and non-source additions from `tj-actions/changed-files` outputs
- keep the action ignore patterns identical to the existing pull request trigger ignores
- quote file paths passed to `grep`

This fixes mixed pull requests where a source change starts the workflow and generated CRDs, Swagger output, or documentation are then incorrectly checked for source-code license headers.

#### Test plan
- [x] `actionlint .github/workflows/license_checker.yml`
- [x] Parse the workflow as YAML
- [x] Verify all 47 trigger ignore patterns match the action ignore patterns
- [x] `git diff --check`

Generated with [Devin](https://devin.ai)