### PR TITLE
test(statuscheck): isolate asynchronous controller specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
+- Stabilize StatusCheck controller tests on slower runners [#5072](https://github.com/chaos-mesh/chaos-mesh/pull/5072)
 
 ### Security
 

--- a/controllers/statuscheck/controller_test.go
+++ b/controllers/statuscheck/controller_test.go
@@ -17,6 +17,7 @@ package statuscheck
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,6 +33,10 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+func statusCheckName(prefix string) string {
+	return fmt.Sprintf("%s-%x", prefix, uint64(GinkgoRandomSeed()))
+}
+
 var _ = Describe("StatusCheck", func() {
 
 	BeforeEach(func() {
@@ -44,13 +49,14 @@ var _ = Describe("StatusCheck", func() {
 
 	Context("Reconcile Synchronous StatusCheck", func() {
 		It("success threshold exceed", func() {
+			name := statusCheckName("synchronous-success")
 			key := types.NamespacedName{
-				Name:      "foo1",
+				Name:      name,
 				Namespace: "default",
 			}
 			statusCheck := &v1alpha1.StatusCheck{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StatusCheckSpec{
@@ -113,13 +119,14 @@ var _ = Describe("StatusCheck", func() {
 			}
 		})
 		It("failure threshold exceed", func() {
+			name := statusCheckName("synchronous-failure")
 			key := types.NamespacedName{
-				Name:      "foo1",
+				Name:      name,
 				Namespace: "default",
 			}
 			statusCheck := &v1alpha1.StatusCheck{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StatusCheckSpec{
@@ -182,14 +189,15 @@ var _ = Describe("StatusCheck", func() {
 			}
 		})
 		It("duration exceed", func() {
+			name := statusCheckName("synchronous-duration")
 			key := types.NamespacedName{
-				Name:      "foo1",
+				Name:      name,
 				Namespace: "default",
 			}
 			duration := "100ms"
 			statusCheck := &v1alpha1.StatusCheck{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StatusCheckSpec{
@@ -253,13 +261,14 @@ var _ = Describe("StatusCheck", func() {
 			}
 		})
 		It("failure threshold exceed, execution timeout", func() {
+			name := statusCheckName("synchronous-timeout")
 			key := types.NamespacedName{
-				Name:      "foo1",
+				Name:      name,
 				Namespace: "default",
 			}
 			statusCheck := &v1alpha1.StatusCheck{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				},
 				Spec: v1alpha1.StatusCheckSpec{
@@ -324,14 +333,15 @@ var _ = Describe("StatusCheck", func() {
 
 		Context("Reconcile Continuous StatusCheck", func() {
 			It("success threshold exceed", func() {
+				name := statusCheckName("continuous-success")
 				key := types.NamespacedName{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				}
 				duration := "10s"
 				statusCheck := &v1alpha1.StatusCheck{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo1",
+						Name:      name,
 						Namespace: "default",
 					},
 					Spec: v1alpha1.StatusCheckSpec{
@@ -397,7 +407,7 @@ var _ = Describe("StatusCheck", func() {
 							return nil, err
 						}
 						return statusCheck.Status.Conditions, nil
-					}, 10*time.Second, time.Second).Should(
+					}, 15*time.Second, time.Second).Should(
 						ConsistOf(
 							MatchFields(IgnoreExtras, Fields{
 								"Type":   Equal(v1alpha1.StatusCheckConditionCompleted),
@@ -425,14 +435,15 @@ var _ = Describe("StatusCheck", func() {
 			})
 
 			It("failure threshold exceed", func() {
+				name := statusCheckName("continuous-failure")
 				key := types.NamespacedName{
-					Name:      "foo1",
+					Name:      name,
 					Namespace: "default",
 				}
 				duration := "10s"
 				statusCheck := &v1alpha1.StatusCheck{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo1",
+						Name:      name,
 						Namespace: "default",
 					},
 					Spec: v1alpha1.StatusCheckSpec{
@@ -469,7 +480,7 @@ var _ = Describe("StatusCheck", func() {
 							return nil, err
 						}
 						return statusCheck.Status.Conditions, nil
-					}, 5*time.Second, time.Second).Should(
+					}, 10*time.Second, time.Second).Should(
 						ConsistOf(
 							MatchFields(IgnoreExtras, Fields{
 								"Type":   Equal(v1alpha1.StatusCheckConditionCompleted),


### PR DESCRIPTION
## Summary
- give every StatusCheck spec a unique resource name derived from the Ginkgo seed
- prevent delayed deletion from reusing the shared manager worker and result cache across specs
- add polling headroom beyond continuous failure-threshold and duration transitions

This addresses the arm64 flakes observed in the `go (arm64, test)` job on #5044, where the controller completed after the assertion boundary or a new `default/foo1` reused state awaiting asynchronous deletion.

#### Test plan
- [x] five uncached StatusCheck suite runs against a disposable Kubernetes cluster
- [x] `go vet ./controllers/statuscheck`
- [x] `gofmt`
- [x] `git diff --check`

Generated with [Devin](https://devin.ai)