### PR TITLE
fix(chaosdaemon): convert netem delay/jitter as durations instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
+- Fix convert netem delay/jitter as durations instead of strings [#5074](https://github.com/chaos-mesh/chaos-mesh/pull/5074)
 
 ### Security
 

--- a/pkg/chaosdaemon/tc_server.go
+++ b/pkg/chaosdaemon/tc_server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -392,7 +393,12 @@ func (c *tcClient) addPrio(device string, parent int, band int) error {
 func (c *tcClient) addNetem(device string, parent string, handle string, netem *pb.Netem) error {
 	c.log.Info("adding netem", "device", device, "parent", parent, "handle", handle)
 
-	args := fmt.Sprintf("qdisc add dev %s %s %s netem %s", device, parent, handle, convertNetemToArgs(netem))
+	netemArgs, err := convertNetemToArgs(netem)
+	if err != nil {
+		return err
+	}
+
+	args := fmt.Sprintf("qdisc add dev %s %s %s netem %s", device, parent, handle, netemArgs)
 	processBuilder := bpm.DefaultProcessBuilder("tc", strings.Split(args, " ")...).SetContext(c.ctx)
 	if c.enterNS {
 		processBuilder = processBuilder.SetNS(c.pid, bpm.NetNS)
@@ -421,12 +427,72 @@ func (c *tcClient) addTbf(device string, parent string, handle string, tbf *pb.T
 	return nil
 }
 
-func convertNetemToArgs(netem *pb.Netem) string {
+// optionalDuration parses an optional duration field of Netem. An empty value
+// means the field is not set, and is reported as a zero duration. A negative
+// value is rejected, so that it cannot be mistaken for an unset field and
+// silently ignored.
+func optionalDuration(value string) (time.Duration, error) {
+	if len(value) == 0 {
+		return 0, nil
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, err
+	}
+
+	if duration < 0 {
+		return 0, errors.Errorf("negative duration %s", value)
+	}
+
+	return duration, nil
+}
+
+// formatTcDuration renders a non-negative duration with a unit understood by
+// tc.
+//
+// The duration fields of Netem carry any format accepted by
+// time.ParseDuration, which knows the "ns", "us", "ms", "s", "m" and "h" units
+// and compound values like "0m30s". tc only knows three time scales, seconds,
+// milliseconds and microseconds, and rejects everything else with
+// `Illegal "latency"`, so the value cannot be forwarded as is. Its output is
+// therefore restricted to "s"/"ms"/"us", the scales both sides understand.
+func formatTcDuration(duration time.Duration) string {
+	switch {
+	case duration%time.Second == 0:
+		return fmt.Sprintf("%ds", int64(duration/time.Second))
+	case duration%time.Millisecond == 0:
+		return fmt.Sprintf("%dms", int64(duration/time.Millisecond))
+	default:
+		// A microsecond is the finest scale tc can be given with a unit. Round
+		// up, so that a shorter non-zero duration does not turn into a no-op.
+		microseconds := int64(duration / time.Microsecond)
+		if duration%time.Microsecond != 0 {
+			microseconds++
+		}
+		return fmt.Sprintf("%dus", microseconds)
+	}
+}
+
+func convertNetemToArgs(netem *pb.Netem) (string, error) {
+	// Durations must be parsed instead of being compared and forwarded as
+	// strings: comparing the raw strings drops valid values like "0.5s", which
+	// is lexicographically smaller than "0ms" while being greater than zero.
+	delay, err := optionalDuration(netem.Time)
+	if err != nil {
+		return "", errors.Wrapf(err, "parse netem delay %s", netem.Time)
+	}
+
+	jitter, err := optionalDuration(netem.Jitter)
+	if err != nil {
+		return "", errors.Wrapf(err, "parse netem jitter %s", netem.Jitter)
+	}
+
 	args := ""
-	if netem.Time > "0ms" {
-		args = fmt.Sprintf("delay %s", netem.Time)
-		if netem.Jitter > "0ms" {
-			args = fmt.Sprintf("%s %s", args, netem.Jitter)
+	if delay > 0 {
+		args = fmt.Sprintf("delay %s", formatTcDuration(delay))
+		if jitter > 0 {
+			args = fmt.Sprintf("%s %s", args, formatTcDuration(jitter))
 
 			if netem.DelayCorr > 0 {
 				args = fmt.Sprintf("%s %f", args, netem.DelayCorr)
@@ -477,13 +543,13 @@ func convertNetemToArgs(netem *pb.Netem) string {
 
 	trimedArgs := []string{}
 
-	for _, part := range strings.Split(args, " ") {
+	for part := range strings.SplitSeq(args, " ") {
 		if len(part) > 0 {
 			trimedArgs = append(trimedArgs, part)
 		}
 	}
 
-	return strings.Join(trimedArgs, " ")
+	return strings.Join(trimedArgs, " "), nil
 }
 
 func convertTbfToArgs(tbf *pb.Tbf) string {

--- a/pkg/chaosdaemon/tc_server_test.go
+++ b/pkg/chaosdaemon/tc_server_test.go
@@ -16,7 +16,9 @@
 package chaosdaemon
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -57,40 +59,134 @@ func Test_generateQdiscArgs(t *testing.T) {
 func Test_convertNetemToArgs(t *testing.T) {
 	g := NewWithT(t)
 
+	// mustConvertNetemToArgs asserts the conversion succeeds and returns the args.
+	mustConvertNetemToArgs := func(netem *pb.Netem) string {
+		args, err := convertNetemToArgs(netem)
+		g.Expect(err).To(BeNil())
+		return args
+	}
+
 	t.Run("convert network delay", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Time: "1000ms",
 		})
-		g.Expect(args).To(Equal("delay 1000ms"))
+		g.Expect(args).To(Equal("delay 1s"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Time:      "1000ms",
 			DelayCorr: 25,
 		})
-		g.Expect(args).To(Equal("delay 1000ms"))
+		g.Expect(args).To(Equal("delay 1s"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Time:      "1000us",
 			Jitter:    "10000ns",
 			DelayCorr: 25,
 		})
-		g.Expect(args).To(Equal("delay 1000us 10000ns 25.000000"))
+		g.Expect(args).To(Equal("delay 1ms 10us 25.000000"))
+	})
+
+	t.Run("convert network delay with units unknown to tc", func(t *testing.T) {
+		// tc only understands "s", "ms" and "us", while these are all valid
+		// values for the API, so they must be normalized instead of being
+		// forwarded as is.
+		args := mustConvertNetemToArgs(&pb.Netem{
+			Time: "1m",
+		})
+		g.Expect(args).To(Equal("delay 60s"))
+
+		args = mustConvertNetemToArgs(&pb.Netem{
+			Time: "0m30s",
+		})
+		g.Expect(args).To(Equal("delay 30s"))
+
+		args = mustConvertNetemToArgs(&pb.Netem{
+			Time: "1m30s",
+		})
+		g.Expect(args).To(Equal("delay 90s"))
+
+		args = mustConvertNetemToArgs(&pb.Netem{
+			Time: "1500ns",
+		})
+		g.Expect(args).To(Equal("delay 2us"))
+	})
+
+	t.Run("convert network delay below one millisecond", func(t *testing.T) {
+		// "0.5s" is lexicographically smaller than "0ms", it used to be
+		// silently dropped, leaving the experiment without any delay.
+		args := mustConvertNetemToArgs(&pb.Netem{
+			Time: "0.5s",
+		})
+		g.Expect(args).To(Equal("delay 500ms"))
+
+		args = mustConvertNetemToArgs(&pb.Netem{
+			Time:      "0.25s",
+			Jitter:    "0.1s",
+			DelayCorr: 25,
+		})
+		g.Expect(args).To(Equal("delay 250ms 100ms 25.000000"))
+	})
+
+	t.Run("convert zero network delay", func(t *testing.T) {
+		// "0s" and "0us" are lexicographically greater than "0ms" while being
+		// zero, they used to generate a pointless `delay 0s`.
+		for _, zero := range []string{"", "0ms", "0s", "0us", "0ns"} {
+			args := mustConvertNetemToArgs(&pb.Netem{
+				Time: zero,
+			})
+			g.Expect(args).To(Equal(""), "delay %q should be dropped", zero)
+
+			args = mustConvertNetemToArgs(&pb.Netem{
+				Time:      "1s",
+				Jitter:    zero,
+				DelayCorr: 25,
+			})
+			g.Expect(args).To(Equal("delay 1s"), "jitter %q should be dropped", zero)
+		}
+	})
+
+	t.Run("reject invalid durations", func(t *testing.T) {
+		_, err := convertNetemToArgs(&pb.Netem{
+			Time: "1000",
+		})
+		g.Expect(err).To(HaveOccurred())
+
+		_, err = convertNetemToArgs(&pb.Netem{
+			Time:   "1s",
+			Jitter: "not a duration",
+		})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("reject negative durations", func(t *testing.T) {
+		// A negative duration would compare as "not greater than zero" and be
+		// indistinguishable from an unset field, so it must not be accepted.
+		_, err := convertNetemToArgs(&pb.Netem{
+			Time: "-1s",
+		})
+		g.Expect(err).To(HaveOccurred())
+
+		_, err = convertNetemToArgs(&pb.Netem{
+			Time:   "1s",
+			Jitter: "-1ms",
+		})
+		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("convert packet limit", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Limit: 1000,
 		})
 		g.Expect(args).To(Equal("limit 1000"))
 	})
 
 	t.Run("convert packet loss", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Loss: 100,
 		})
 		g.Expect(args).To(Equal("loss 100.000000"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Loss:     50,
 			LossCorr: 12,
 		})
@@ -98,13 +194,13 @@ func Test_convertNetemToArgs(t *testing.T) {
 	})
 
 	t.Run("convert packet reorder", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Reorder:     5,
 			ReorderCorr: 10,
 		})
 		g.Expect(args).To(Equal(""))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Time:        "1000ms",
 			Jitter:      "10000ms",
 			DelayCorr:   25,
@@ -112,9 +208,9 @@ func Test_convertNetemToArgs(t *testing.T) {
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("delay 1000ms 10000ms 25.000000 reorder 5.000000 10.000000 gap 10"))
+		g.Expect(args).To(Equal("delay 1s 10s 25.000000 reorder 5.000000 10.000000 gap 10"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Time:        "1000ms",
 			Jitter:      "10000ms",
 			DelayCorr:   25,
@@ -122,25 +218,25 @@ func Test_convertNetemToArgs(t *testing.T) {
 			ReorderCorr: 10,
 			Gap:         10,
 		})
-		g.Expect(args).To(Equal("delay 1000ms 10000ms 25.000000 reorder 5.000000 10.000000 gap 10"))
+		g.Expect(args).To(Equal("delay 1s 10s 25.000000 reorder 5.000000 10.000000 gap 10"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Time:      "1000ms",
 			Jitter:    "10000ms",
 			DelayCorr: 25,
 			Reorder:   5,
 			Gap:       10,
 		})
-		g.Expect(args).To(Equal("delay 1000ms 10000ms 25.000000 reorder 5.000000 gap 10"))
+		g.Expect(args).To(Equal("delay 1s 10s 25.000000 reorder 5.000000 gap 10"))
 	})
 
 	t.Run("convert packet duplication", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Duplicate: 10,
 		})
 		g.Expect(args).To(Equal("duplicate 10.000000"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Duplicate:     10,
 			DuplicateCorr: 50,
 		})
@@ -148,12 +244,12 @@ func Test_convertNetemToArgs(t *testing.T) {
 	})
 
 	t.Run("convert packet corrupt", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Corrupt: 10,
 		})
 		g.Expect(args).To(Equal("corrupt 10.000000"))
 
-		args = convertNetemToArgs(&pb.Netem{
+		args = mustConvertNetemToArgs(&pb.Netem{
 			Corrupt:     10,
 			CorruptCorr: 50,
 		})
@@ -161,7 +257,7 @@ func Test_convertNetemToArgs(t *testing.T) {
 	})
 
 	t.Run("complicate cases", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Time:        "1000ms",
 			Jitter:      "10000ms",
 			Reorder:     5,
@@ -169,15 +265,44 @@ func Test_convertNetemToArgs(t *testing.T) {
 			Corrupt:     10,
 			CorruptCorr: 50,
 		})
-		g.Expect(args).To(Equal("delay 1000ms 10000ms reorder 5.000000 gap 10 corrupt 10.000000 50.000000"))
+		g.Expect(args).To(Equal("delay 1s 10s reorder 5.000000 gap 10 corrupt 10.000000 50.000000"))
 	})
 
 	t.Run("delay with rate", func(t *testing.T) {
-		args := convertNetemToArgs(&pb.Netem{
+		args := mustConvertNetemToArgs(&pb.Netem{
 			Time:   "1000ms",
 			Jitter: "10000ms",
 			Rate:   "8000bit",
 		})
-		g.Expect(args).To(Equal("delay 1000ms 10000ms rate 8000bit"))
+		g.Expect(args).To(Equal("delay 1s 10s rate 8000bit"))
 	})
+}
+
+func Test_formatTcDuration(t *testing.T) {
+	g := NewWithT(t)
+
+	// tc only understands the "s", "ms" and "us" suffixes.
+	for _, tc := range []struct {
+		duration time.Duration
+		expected string
+	}{
+		{0, "0s"},
+		{time.Second, "1s"},
+		{90 * time.Second, "90s"},
+		{time.Minute, "60s"},
+		{time.Hour, "3600s"},
+		{100 * time.Millisecond, "100ms"},
+		{1500 * time.Millisecond, "1500ms"},
+		{time.Microsecond, "1us"},
+		{1500 * time.Microsecond, "1500us"},
+		// Sub-microsecond values are rounded up, tc cannot express them and
+		// rounding down would turn the delay into a no-op.
+		{time.Nanosecond, "1us"},
+		{1500 * time.Nanosecond, "2us"},
+		{time.Millisecond + time.Nanosecond, "1001us"},
+		// The largest duration time.ParseDuration can return must not overflow.
+		{time.Duration(math.MaxInt64), "9223372036854776us"},
+	} {
+		g.Expect(formatTcDuration(tc.duration)).To(Equal(tc.expected), "%v", tc.duration)
+	}
 }


### PR DESCRIPTION

## What problem does this PR solve?
Fix https://github.com/chaos-mesh/chaos-mesh/issues/5073

## What's changed and how does it work?

https://github.com/chaos-mesh/chaos-mesh/issues/5073

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [x] release-2.8
- [x] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
