### PR TITLE
build(images): migrate chaos-daemon base image from debian to alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Migrate chaos-dashboard and chaos-dlv container base images from debian to alpine [#5027](https://github.com/chaos-mesh/chaos-mesh/pull/5027)
 - Integrate Gherkin BDD runner in CI and migrate namespace setup to Kubernetes E2E framework [#5028](https://github.com/chaos-mesh/chaos-mesh/pull/5028)
 - Migrate the JVM integration tests (workflow exception and mysql actions) to Gherkin e2e tests, replace TiDB with MySQL as the test backend, and remove the shell-based test [#5055](https://github.com/chaos-mesh/chaos-mesh/pull/5055)
+- Migrate chaos-daemon container base image from debian to alpine [#5075](https://github.com/chaos-mesh/chaos-mesh/pull/5075)
 
 ### Deprecated
 

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -62,7 +62,9 @@ RUN apk upgrade --no-cache && \
         libgcc
 
 RUN ln -sf /sbin/iptables-legacy /sbin/iptables && \
+    ln -sf /sbin/iptables-legacy-save /sbin/iptables-save && \
     ln -sf /sbin/ip6tables-legacy /sbin/ip6tables && \
+    ln -sf /sbin/ip6tables-legacy-save /sbin/ip6tables-save && \
     ln -sf /sbin/ebtables-legacy /sbin/ebtables
 
 ENV RUST_BACKTRACE=1
@@ -70,7 +72,6 @@ ENV BYTEMAN_HOME=/usr/local/byteman
 ENV PATH=$PATH:/usr/local/byteman/bin
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH=$PATH:/usr/local/bin
-ENV LD_PRELOAD=/usr/local/lib/libresinit.so
 
 COPY bin/chaos-daemon /usr/local/bin/chaos-daemon
 COPY bin/pause /usr/local/bin/pause
@@ -79,4 +80,7 @@ COPY --from=shimbuilder libresinit.so /usr/local/lib/libresinit.so
 COPY --from=binaryimage /tmp/byteman /usr/local/byteman
 COPY --from=binaryimage /tmp/bin/* /usr/local/bin/
 
-RUN mv /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so
+RUN mv /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so && \
+    mv /usr/local/bin/tproxy /usr/local/bin/tproxy-bin && \
+    printf '#!/bin/sh\nexport LD_PRELOAD=/usr/local/lib/libresinit.so\nexec /usr/local/bin/tproxy-bin "$@"\n' > /usr/local/bin/tproxy && \
+    chmod +x /usr/local/bin/tproxy

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -32,7 +32,13 @@ RUN case "$TARGET_PLATFORM" in \
     curl -L https://github.com/chaos-mesh/memStress/releases/download/v0.3.1/memStress_v0.3.1-$NSEXEC_ARCH-linux-gnu.tar.gz | tar xz -C /tmp/bin
 
 # ---
-FROM debian:bookworm-slim
+FROM alpine:3.23 AS shimbuilder
+RUN apk add --no-cache gcc musl-dev
+RUN echo 'int __res_init(void) { return 0; } int res_init(void) { return 0; }' > res_init.c
+RUN gcc -shared -fPIC -o libresinit.so res_init.c
+
+# ---
+FROM alpine:3.23
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
@@ -40,24 +46,36 @@ ARG HTTP_PROXY
 ENV http_proxy=$HTTP_PROXY
 ENV https_proxy=$HTTPS_PROXY
 
-RUN echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian bookworm-proposed-updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt update --allow-releaseinfo-change && apt upgrade -y && \
-    apt install -y tzdata iptables ebtables net-tools ipset stress-ng iproute2 fuse util-linux procps openjdk-17-jre-headless && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+        tzdata \
+        iptables-legacy \
+        ebtables \
+        ipset \
+        stress-ng \
+        iproute2 \
+        fuse \
+        util-linux \
+        procps \
+        openjdk17-jre-headless \
+        gcompat \
+        libgcc
 
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ebtables /usr/sbin/ebtables-legacy
+RUN ln -sf /sbin/iptables-legacy /sbin/iptables && \
+    ln -sf /sbin/ip6tables-legacy /sbin/ip6tables && \
+    ln -sf /sbin/ebtables-legacy /sbin/ebtables
 
 ENV RUST_BACKTRACE=1
 ENV BYTEMAN_HOME=/usr/local/byteman
 ENV PATH=$PATH:/usr/local/byteman/bin
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH=$PATH:/usr/local/bin
+ENV LD_PRELOAD=/usr/local/lib/libresinit.so
 
 COPY bin/chaos-daemon /usr/local/bin/chaos-daemon
 COPY bin/pause /usr/local/bin/pause
 COPY bin/cdh /usr/local/bin/cdh
+COPY --from=shimbuilder libresinit.so /usr/local/lib/libresinit.so
 COPY --from=binaryimage /tmp/byteman /usr/local/byteman
 COPY --from=binaryimage /tmp/bin/* /usr/local/bin/
 

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -38,6 +38,15 @@ RUN echo 'int __res_init(void) { return 0; } int res_init(void) { return 0; }' >
 RUN gcc -shared -fPIC -o libresinit.so res_init.c
 
 # ---
+FROM rust:alpine3.23 AS rustbuilder
+RUN apk add --no-cache git musl-dev gcc
+RUN git clone --depth 1 --branch v0.1.6 https://github.com/chaos-mesh/nsexec.git /tmp/nsexec && \
+    cd /tmp/nsexec && \
+    rm -f rust-toolchain && \
+    rm -rf .cargo && \
+    RUSTFLAGS="-C target-feature=-crt-static" cargo build --release --all
+
+# ---
 FROM alpine:3.23
 
 ARG HTTPS_PROXY
@@ -80,7 +89,10 @@ COPY --from=shimbuilder libresinit.so /usr/local/lib/libresinit.so
 COPY --from=binaryimage /tmp/byteman /usr/local/byteman
 COPY --from=binaryimage /tmp/bin/* /usr/local/bin/
 
-RUN mv /usr/local/bin/libnsenter.so /usr/local/lib/libnsenter.so && \
+COPY --from=rustbuilder /tmp/nsexec/target/release/nsexec /usr/local/bin/nsexec
+COPY --from=rustbuilder /tmp/nsexec/target/release/libnsenter.so /usr/local/lib/libnsenter.so
+
+RUN rm -f /usr/local/bin/libnsenter.so && \
     mv /usr/local/bin/tproxy /usr/local/bin/tproxy-bin && \
     printf '#!/bin/sh\nexport LD_PRELOAD=/usr/local/lib/libresinit.so\nexec /usr/local/bin/tproxy-bin "$@"\n' > /usr/local/bin/tproxy && \
     chmod +x /usr/local/bin/tproxy


### PR DESCRIPTION
## What problem does this PR solve?

Part of #5014.

This PR migrates the base image of `chaos-daemon` from `debian:bookworm-slim` to `alpine:3.23`. This completes the migration of all runtime containers to Alpine (following PR #5027 which migrated `chaos-dashboard` and `chaos-dlv`), reducing overall image sizes and security vulnerability surfaces.

## What's changed and how does it work?

* Switched `images/chaos-daemon/Dockerfile` base stage to `alpine:3.23`.
* Replaced `apt` package manager commands and dependencies with Alpine `apk` equivalents.
* Configured legacy `iptables` and `ebtables` symlinks inside Alpine to preserve compatibility with existing network chaos rules.
* Added a lightweight DNS resolver initialization shim (`libresinit.so`) compiled in a new `shimbuilder` Dockerfile stage and preloaded via `LD_PRELOAD` to support `tproxy` execution on Alpine.

#### How to verify

<details>
<summary>Click to expand</summary>

1. **Compile Binaries:**
   ```bash
   mkdir -p images/chaos-daemon/bin
   CGO_ENABLED=1 go build -o images/chaos-daemon/bin/chaos-daemon cmd/chaos-daemon/main.go
   CGO_ENABLED=0 go build -o images/chaos-daemon/bin/cdh cmd/chaos-daemon-helper/main.go
   gcc -Wno-error=incompatible-pointer-types ./hack/pause.c -o images/chaos-daemon/bin/pause
   # or
   # make images/chaos-daemon/bin/chaos-daemon images/chaos-daemon/bin/cdh images/chaos-daemon/bin/pause
   ```

2. **Build Container Image:**
   ```bash
   podman build -f images/chaos-daemon/Dockerfile -t chaos-daemon:alpine images/chaos-daemon
   ```

3. **Verify Binary Execution inside Container:**
   Ensure all binaries launch successfully without dynamic library or relocation errors:
   ```bash
   podman run --rm chaos-daemon:alpine /usr/local/bin/chaos-daemon --version
   podman run --rm chaos-daemon:alpine /usr/local/bin/toda --version
   podman run --rm chaos-daemon:alpine /usr/local/bin/nsexec --help
   podman run --rm chaos-daemon:alpine /usr/local/bin/tproxy -h
   podman run --rm chaos-daemon:alpine /usr/local/bin/memStress -h
   ```
</details>

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
