### PR TITLE
feat(helm): add Prometheus Operator ServiceMonitor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add Gherkin BDD e2e test runner with PodKill scenarios [#5013](https://github.com/chaos-mesh/chaos-mesh/pull/5013)
 - Add Gherkin BDD e2e test for JVMChaos latency action on JDK 21 [#5054](https://github.com/chaos-mesh/chaos-mesh/pull/5054)
 - fix(api): add missing omitempty tags to optional fields [#5006](https://github.com/chaos-mesh/chaos-mesh/pull/5006)
-- Add Prometheus Operator ServiceMonitor support to the Helm chart [#XXXX](https://github.com/chaos-mesh/chaos-mesh/pull/XXXX)
+- Add Prometheus Operator ServiceMonitor support to the Helm chart [#5076](https://github.com/chaos-mesh/chaos-mesh/pull/5076)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Add Gherkin BDD e2e test runner with PodKill scenarios [#5013](https://github.com/chaos-mesh/chaos-mesh/pull/5013)
 - Add Gherkin BDD e2e test for JVMChaos latency action on JDK 21 [#5054](https://github.com/chaos-mesh/chaos-mesh/pull/5054)
 - fix(api): add missing omitempty tags to optional fields [#5006](https://github.com/chaos-mesh/chaos-mesh/pull/5006)
+- Add Prometheus Operator ServiceMonitor support to the Helm chart [#XXXX](https://github.com/chaos-mesh/chaos-mesh/pull/XXXX)
 
 ### Changed
 

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -139,6 +139,9 @@ Key component settings:
 | `dashboard.ingress.enabled` | `false` | Creates a dashboard Ingress |
 | `dnsServer.create` | `true` | Installs the DNSChaos server |
 | `prometheus.create` | `false` | Installs the bundled Prometheus instance |
+| `serviceMonitor.enabled` | `false` | Creates Prometheus Operator ServiceMonitors |
+| `serviceMonitor.additionalLabels` | `{}` | Extra ServiceMonitor labels, e.g. the one Prometheus selects on |
+| `serviceMonitor.interval` | `""` | Scrape interval; empty uses the operator default |
 | `webhook.certManager.enabled` | `false` | Uses cert-manager for webhook and daemon certificates |
 | `bpfki.create` | `false` | Enables the `chaos-kernel` helper |
 | `chaosDlv.enable` | `false` | Adds the Delve debugging sidecar |
@@ -251,6 +254,45 @@ The chart then creates namespaced Issuers and Certificates for the admission web
 ### Pod Security Policy compatibility
 
 `chaosDaemon.podSecurityPolicy` is a legacy compatibility option and defaults to `false`. Enabling it renders a `policy/v1beta1` PodSecurityPolicy, which is unavailable in modern Kubernetes releases. Prefer the security controls supported by your cluster.
+
+### Prometheus Operator ServiceMonitors
+
+The chart annotates its Services with `prometheus.io/scrape`, which only a Prometheus configured for annotation-based service discovery acts on. Prometheus Operator ignores those annotations and discovers targets through `ServiceMonitor` resources, so set `serviceMonitor.enabled` when running the operator. It requires the `monitoring.coreos.com/v1` ServiceMonitor CRD and is disabled by default.
+
+```yaml
+serviceMonitor:
+  enabled: true
+  # The label the Prometheus instance selects ServiceMonitors on.
+  additionalLabels:
+    release: kube-prometheus-stack
+  interval: 30s
+```
+
+One ServiceMonitor is created per component — controller manager, chaos daemon, dashboard, and DNS server — each pointed at that component's metrics port. Components the chart does not install are skipped, and each can be turned off individually:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  dnsServer:
+    enabled: false
+```
+
+`interval`, `scrapeTimeout`, `scheme`, `tlsConfig`, `honorLabels`, `metricRelabelings`, and `relabelings` can be set globally and overridden per component, so one component can be scraped differently from the rest:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: go_.*
+      action: drop
+  chaosDaemon:
+    # The daemon runs on every node; scrape it less often than the rest.
+    interval: 1m
+```
+
+Settings left empty are omitted from the rendered resource so the operator applies its own defaults.
 
 ### Extra objects
 

--- a/helm/chaos-mesh/templates/service-monitors.yaml
+++ b/helm/chaos-mesh/templates/service-monitors.yaml
@@ -1,0 +1,86 @@
+# Copyright 2026 Chaos Mesh Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.serviceMonitor.enabled }}
+{{- $sm := .Values.serviceMonitor }}
+{{- $namespace := $sm.namespace | default .Release.Namespace }}
+
+{{/*
+Each component's metrics port, and the condition under which its Service
+exists. The port names match the Services defined by this chart.
+*/}}
+{{- $components := list
+      (dict "key" "controllerManager" "component" "controller-manager" "port" "http"    "create" true)
+      (dict "key" "chaosDaemon"       "component" "chaos-daemon"       "port" "http"    "create" true)
+      (dict "key" "dashboard"         "component" "chaos-dashboard"    "port" "metric"  "create" .Values.dashboard.create)
+      (dict "key" "dnsServer"         "component" "dns-server"         "port" "metrics" "create" .Values.dnsServer.create)
+}}
+
+{{- range $c := $components }}
+{{- $cfg := (index $sm $c.key) | default dict }}
+{{- if and $c.create $cfg.enabled }}
+{{/*
+Endpoint settings may be given globally on `serviceMonitor` and overridden per
+component. A per-component value wins; an unset one falls back to the global,
+and an empty one is omitted so the Prometheus Operator applies its own default.
+*/}}
+{{- $endpoint := dict "port" $c.port }}
+{{- range $field := list "interval" "scrapeTimeout" "scheme" "tlsConfig" "metricRelabelings" "relabelings" }}
+  {{- $value := index $cfg $field }}
+  {{- if kindIs "invalid" $value }}{{ $value = index $sm $field }}{{ end }}
+  {{- if $value }}{{ $_ := set $endpoint $field $value }}{{ end }}
+{{- end }}
+{{- $honorLabels := $cfg.honorLabels | default $sm.honorLabels }}
+{{- if $honorLabels }}{{ $_ := set $endpoint "honorLabels" true }}{{ end }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "chaos-mesh.name" $ }}-{{ $c.component }}
+  namespace: {{ $namespace | quote }}
+  labels:
+    {{- include "chaos-mesh.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $c.component }}
+    {{- with $sm.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $sm.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chaos-mesh.selectors" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $c.component }}
+  {{/*
+  The Services always live in the release namespace, even when the
+  ServiceMonitors are created somewhere else via `serviceMonitor.namespace`.
+  */}}
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace | quote }}
+  {{- with $sm.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with $sm.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  endpoints:
+{{ toYaml (list $endpoint) | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/chaos-mesh/templates/service-monitors.yaml
+++ b/helm/chaos-mesh/templates/service-monitors.yaml
@@ -42,7 +42,13 @@ and an empty one is omitted so the Prometheus Operator applies its own default.
   {{- if kindIs "invalid" $value }}{{ $value = index $sm $field }}{{ end }}
   {{- if $value }}{{ $_ := set $endpoint $field $value }}{{ end }}
 {{- end }}
-{{- $honorLabels := $cfg.honorLabels | default $sm.honorLabels }}
+{{/*
+Resolved separately from the fields above because `default` treats false as
+empty: with `default`, a component setting honorLabels: false could not turn off
+a global true.
+*/}}
+{{- $honorLabels := index $cfg "honorLabels" }}
+{{- if kindIs "invalid" $honorLabels }}{{ $honorLabels = $sm.honorLabels }}{{ end }}
 {{- if $honorLabels }}{{ $_ := set $endpoint "honorLabels" true }}{{ end }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/helm/chaos-mesh/templates/service-monitors.yaml
+++ b/helm/chaos-mesh/templates/service-monitors.yaml
@@ -54,7 +54,12 @@ a global true.
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "chaos-mesh.name" $ }}-{{ $c.component }}
+  {{/*
+  Release-qualified: `serviceMonitor.namespace` lets releases from several
+  namespaces put their ServiceMonitors in one central monitoring namespace,
+  where a chart-name-only name would collide between releases.
+  */}}
+  name: {{ template "chaos-mesh.fullname" $ }}-{{ $c.component }}
   namespace: {{ $namespace | quote }}
   labels:
     {{- include "chaos-mesh.labels" $ | nindent 4 }}

--- a/helm/chaos-mesh/values.schema.json
+++ b/helm/chaos-mesh/values.schema.json
@@ -834,6 +834,166 @@
                 }
             }
         },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "additionalLabels": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "jobLabel": {
+                    "type": "string"
+                },
+                "targetLabels": {
+                    "type": "array"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                },
+                "scheme": {
+                    "type": "string"
+                },
+                "tlsConfig": {
+                    "type": "object"
+                },
+                "honorLabels": {
+                    "type": "boolean"
+                },
+                "metricRelabelings": {
+                    "type": "array"
+                },
+                "relabelings": {
+                    "type": "array"
+                },
+                "controllerManager": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "chaosDaemon": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "dashboard": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "dnsServer": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        },
+                        "tlsConfig": {
+                            "type": "object"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
         "timezone": {
             "type": "string"
         },

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -505,6 +505,61 @@ dnsServer:
             topologyKey: kubernetes.io/hostname
           weight: 100
 
+# Prometheus Operator ServiceMonitor resources.
+#
+# The `prometheus.io/scrape` annotations this chart puts on its Services are
+# only honoured by a Prometheus configured with annotation-based service
+# discovery. Prometheus Operator ignores them and discovers targets through
+# ServiceMonitor resources instead, so enable this when running the operator.
+#
+# Requires the monitoring.coreos.com/v1 ServiceMonitor CRD to be installed.
+serviceMonitor:
+  # Create ServiceMonitor resources for the Chaos Mesh components.
+  enabled: false
+  # Namespace to create the ServiceMonitors in. Defaults to the release
+  # namespace. When set to something else, the ServiceMonitors still select the
+  # Services in the release namespace.
+  namespace: ""
+  # Extra labels for the ServiceMonitors, e.g. the label a Prometheus instance
+  # selects on (`release: kube-prometheus-stack` for kube-prometheus-stack).
+  additionalLabels: {}
+  # Extra annotations for the ServiceMonitors.
+  annotations: {}
+  # Label from the Service to use as the `job` label.
+  jobLabel: ""
+  # Service labels to copy onto the scraped metrics.
+  targetLabels: []
+
+  # Endpoint settings, applied to every component. Anything left empty is
+  # omitted so the Prometheus Operator applies its own default. Each component
+  # below may override any of these for itself.
+
+  # Scrape interval, e.g. "30s".
+  interval: ""
+  # Scrape timeout, e.g. "10s". Must not exceed the interval.
+  scrapeTimeout: ""
+  # Scheme to scrape with: http or https.
+  scheme: ""
+  # TLS settings, for use with `scheme: https`.
+  tlsConfig: {}
+  # Keep the target's labels when they collide with a scraped label.
+  honorLabels: false
+  # Relabeling applied to samples before ingestion.
+  metricRelabelings: []
+  # Relabeling applied to targets before scraping.
+  relabelings: []
+
+  # Which components to scrape. Each accepts `enabled` plus any of the endpoint
+  # settings above, overriding the global value for that component only.
+  controllerManager:
+    enabled: true
+  chaosDaemon:
+    enabled: true
+  dashboard:
+    enabled: true
+  dnsServer:
+    enabled: true
+
 prometheus:
   # Enable prometheus
   create: false


### PR DESCRIPTION
## What problem does this PR solve?

The chart annotates its Services with `prometheus.io/scrape`:

- `templates/controller-manager-service.yaml`
- `templates/chaos-daemon-service.yaml`
- `templates/dns-service.yaml`
- the dashboard Service in `templates/chaos-dashboard-deployment.yaml`

Those annotations are only acted on by a Prometheus configured for annotation-based service discovery. **Prometheus Operator ignores them entirely** — it discovers targets through `ServiceMonitor` resources. Installations running the operator (kube-prometheus-stack and friends) therefore get no Chaos Mesh metrics out of the box, and have to hand-write four ServiceMonitors alongside the release, duplicating the chart's port names and label selectors.

## What's changed and how does it work?

Adds an opt-in `serviceMonitor` section that creates one `ServiceMonitor` per component, each pointed at that component's metrics port:

| Component | Service | Port |
| --- | --- | --- |
| Controller manager | `chaos-mesh-controller-manager` | `http` (`controllerManager.env.METRICS_PORT`) |
| Chaos daemon | `chaos-daemon` | `http` (`chaosDaemon.httpPort`) |
| Dashboard | `chaos-dashboard` | `metric` (`dashboard.env.METRIC_PORT`) |
| DNS server | `chaos-dns-server` | `metrics` (9153) |

```yaml
serviceMonitor:
  enabled: true
  additionalLabels:
    release: kube-prometheus-stack
  interval: 30s
```

Behaviour worth calling out:

- **Disabled by default.** Existing installations are unaffected, and the `monitoring.coreos.com/v1` CRD is only needed when the feature is turned on.
- **Each component can be disabled individually**, and components the chart does not install (`dashboard.create`, `dnsServer.create`) are skipped automatically.
- **`interval`, `scrapeTimeout`, `scheme`, `tlsConfig`, `honorLabels`, `metricRelabelings` and `relabelings`** can be set globally and overridden per component — useful for scraping the daemon less often, since it runs on every node.
- **Empty settings are omitted** from the rendered resource, so the operator applies its own defaults rather than the chart hard-coding them.
- **`serviceMonitor.namespace`** allows creating the ServiceMonitors elsewhere; the `namespaceSelector` still targets the release namespace where the Services live.

The existing `prometheus.io/scrape` annotations and the bundled `prometheus.create` instance are left untouched, so this is purely additive.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

`helm/chaos-mesh/README.md` is updated in this PR with a "Prometheus Operator ServiceMonitors" section and three rows in the configuration table.

## Cherry-pick to release branches (optional)

- [x] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

Verified against a live cluster running Chaos Mesh 2.8.x with kube-prometheus-stack:

- `helm template` with default values renders **zero** ServiceMonitors.
- With the feature enabled, all four render; each selector matches exactly one Service, and each named port is that component's metrics port.
- `kubectl apply --dry-run=server` accepts every rendered ServiceMonitor against the real `monitoring.coreos.com/v1` CRD.
- Per-component overrides confirmed (global `interval: 30s` with `chaosDaemon.interval: 1m` renders both correctly), as is disabling a single component.
- `values.schema.json` was extended, and rejects wrong types (`serviceMonitor.enabled` as a string fails with `got string, want boolean`).
- `helm lint` passes with the feature both disabled and enabled.

### Side effects

- [ ] **Breaking backward compatibility**

