### PR TITLE
fix(ui): prevent total status chart from shrinking on dashboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix a TypeError crash in the Dashboard UI when opening the details page of a Workflow-type schedule [#5034](https://github.com/chaos-mesh/chaos-mesh/pull/5034)
 - Fixed jvm latency experiment not working for jdk version 19 and higher [#4821](https://github.com/chaos-mesh/chaos-mesh/pull/4821)
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
+- Prevent Total Experiments Status chart from shrinking on dashboard navigation [#5077](https://github.com/chaos-mesh/chaos-mesh/pull/5077)
 
 ### Security
 

--- a/ui/app/src/pages/Dashboard/index.tsx
+++ b/ui/app/src/pages/Dashboard/index.tsx
@@ -25,6 +25,7 @@ import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined'
 import { Box, Grid, Grow, IconButton, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { TourProvider } from '@reactour/tour'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 
 import EventsChart from '@/components/EventsChart'
@@ -54,6 +55,7 @@ const NumPanel: ReactFCWithChildren<{ title: ReactNode; num?: number; background
 
 export default function Dashboard() {
   const theme = useTheme()
+  const [animationDone, setAnimationDone] = useState(false)
   const steps = [
     {
       selector: '.tutorial-dashboard',
@@ -133,7 +135,7 @@ export default function Dashboard() {
       )}
       showCloseButton={false}
     >
-      <Grow in={true} style={{ transformOrigin: '0 0 0' }}>
+      <Grow in={true} style={{ transformOrigin: '0 0 0' }} onEntered={() => setAnimationDone(true)}>
         <Grid container spacing={6}>
           <Grid container spacing={6} alignContent="flex-start" item xs={12} lg={8}>
             <Grid item xs={4}>
@@ -163,16 +165,18 @@ export default function Dashboard() {
             <Grid item xs={12}>
               <Paper>
                 <PaperTop title={i18n('common.timeline')} boxProps={{ mb: 3 }} />
-                {events && <EventsChart events={events} position="relative" height={300} />}
+                {events && animationDone && <EventsChart events={events} position="relative" height={300} />}
               </Paper>
             </Grid>
           </Grid>
 
-          <Grid container spacing={6} item xs={12} lg={4}>
+          <Grid container spacing={6} alignContent="flex-start" item xs={12} lg={4}>
             <Grid item xs={12}>
               <Paper>
                 <PaperTop title={i18n('dashboard.totalStatus')} boxProps={{ sx: { mb: 3 } }} />
-                {experiments && <TotalStatus position="relative" height={experiments.length > 0 ? 300 : '100%'} />}
+                {experiments && animationDone && (
+                  <TotalStatus position="relative" height={experiments.length > 0 ? 300 : '100%'} />
+                )}
               </Paper>
             </Grid>
             <Grid item xs={12}>

--- a/ui/app/src/pages/Dashboard/index.tsx
+++ b/ui/app/src/pages/Dashboard/index.tsx
@@ -165,7 +165,12 @@ export default function Dashboard() {
             <Grid item xs={12}>
               <Paper>
                 <PaperTop title={i18n('common.timeline')} boxProps={{ mb: 3 }} />
-                {events && animationDone && <EventsChart events={events} position="relative" height={300} />}
+                {events &&
+                  (animationDone ? (
+                    <EventsChart events={events} position="relative" height={300} />
+                  ) : (
+                    <Box height={300} />
+                  ))}
               </Paper>
             </Grid>
           </Grid>
@@ -174,9 +179,12 @@ export default function Dashboard() {
             <Grid item xs={12}>
               <Paper>
                 <PaperTop title={i18n('dashboard.totalStatus')} boxProps={{ sx: { mb: 3 } }} />
-                {experiments && animationDone && (
-                  <TotalStatus position="relative" height={experiments.length > 0 ? 300 : '100%'} />
-                )}
+                {experiments &&
+                  (animationDone ? (
+                    <TotalStatus position="relative" height={experiments.length > 0 ? 300 : '100%'} />
+                  ) : (
+                    <Box height={experiments.length > 0 ? 300 : '100%'} />
+                  ))}
               </Paper>
             </Grid>
             <Grid item xs={12}>


### PR DESCRIPTION
## What problem does this PR solve?

Close #5062 

When returning to the dashboard view via client-side routing, the Material-UI `<Grow>` animation changes container scale from 0.75 to 1. Because CSS scale transitions do not trigger layout reflows or `ResizeObserver` events after completion, Nivo's `<ResponsivePie>` (and `<EventsChart>`) initially compute layout dimensions using intermediate animation frames. This causes the charts to render at a reduced scale, leaving empty whitespace and cutting off legends.

## What's changed and how does it work?


* Gated chart rendering until the container entrance animation completes to ensure Nivo correctly calculates dimensions at full scale.
* Added `alignContent="flex-start"` to prevent right-hand cards from stretching to match the left column.

#### How to verify

1. Build the UI and start the local dashboard:
   ```bash
   UI=1 make ui && UI=1 make local/chaos-dashboard && ./bin/chaos-dashboard
   ```

2. Open the dashboard in a browser at http://localhost:2333, navigate to another page (e.g. **Workflows**), and navigate back. Verify that both the timeline events chart and total status donut chart recalculate to their full containers' sizes.

#### After Demo

[Screencast From 2026-08-25 15-31-55.webm](https://github.com/user-attachments/assets/fadc76ef-1700-465d-933d-cf0f68717068)

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [x] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```
