### PR TITLE
ci: fix path filter exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          predicate-quantifier: some-with-excludes
           filters: |
             go:
               - Makefile

--- a/.github/workflows/ci_skip.yml
+++ b/.github/workflows/ci_skip.yml
@@ -21,12 +21,15 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          predicate-quantifier: some-with-excludes
           filters: |
             go:
               - Makefile
               - go.*
               - '**.go'
               - 'helm/**'
+              - '!helm/**/*.md'
+              - '.github/actions/build-chaos-mesh-build-env/**'
             ui:
               - 'ui/pnpm-lock.yaml'
               - '**.js'


### PR DESCRIPTION
## Summary

- use `some-with-excludes` so the Go filter does not match every non-Helm-Markdown file
- keep `ci_skip.yml`'s Go filter aligned with `ci.yml` so required CI jobs remain complementary

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/ci_skip.yml`
- `git diff --check`

Follow-up to #5070.