### PR TITLE
fix(webhook): match SubjectAccessReview verb to admission operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 - Fix dashboard UI token validation and infinite auth lockout loop [#5046](https://github.com/chaos-mesh/chaos-mesh/pull/5046)
 - Fix convert netem delay/jitter as durations instead of strings [#5074](https://github.com/chaos-mesh/chaos-mesh/pull/5074)
 - Stabilize StatusCheck controller tests on slower runners [#5072](https://github.com/chaos-mesh/chaos-mesh/pull/5072)
+- Use the admission operation as the SubjectAccessReview verb in the auth webhook so foreground cascading deletion no longer hangs [#5079](https://github.com/chaos-mesh/chaos-mesh/issues/5079)
 
 ### Security
 

--- a/pkg/webhook/validate_auth.go
+++ b/pkg/webhook/validate_auth.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	authzv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,8 +104,10 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 
 	requireClusterPrivileges, affectedNamespaces := affectedNamespaces(chaos)
 
+	verb := sarVerb(req.Operation)
+
 	if requireClusterPrivileges {
-		allow, err := v.auth(req.UserInfo, "", requestKind)
+		allow, err := v.auth(req.UserInfo, "", requestKind, verb)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -117,7 +120,7 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 		v.logger.Info("start validating user", "user", username, "groups", groups, "namespace", affectedNamespaces)
 
 		for namespace := range affectedNamespaces {
-			allow, err := v.auth(req.UserInfo, namespace, requestKind)
+			allow, err := v.auth(req.UserInfo, namespace, requestKind, verb)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
@@ -133,7 +136,23 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 	return admission.Allowed("")
 }
 
-func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosKind string) (bool, error) {
+// sarVerb maps the admission operation to the verb checked in the
+// SubjectAccessReview, so the permission check matches the action
+// the user is actually performing.
+func sarVerb(op admissionv1.Operation) string {
+	switch op {
+	case admissionv1.Create:
+		return "create"
+	case admissionv1.Update:
+		return "update"
+	default:
+		// The webhook only registers create and update. Fall back to
+		// the lowercase operation name for any other value.
+		return strings.ToLower(string(op))
+	}
+}
+
+func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosKind string, verb string) (bool, error) {
 	resourceName, err := v.resourceFor(chaosKind)
 	if err != nil {
 		return false, err
@@ -143,7 +162,7 @@ func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosK
 		Spec: authzv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &authzv1.ResourceAttributes{
 				Namespace: namespace,
-				Verb:      "create",
+				Verb:      verb,
 				Group:     "chaos-mesh.org",
 				Resource:  resourceName,
 			},

--- a/pkg/webhook/validate_auth_test.go
+++ b/pkg/webhook/validate_auth_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package webhook
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+func TestSarVerb(t *testing.T) {
+	cases := []struct {
+		operation admissionv1.Operation
+		want      string
+	}{
+		{admissionv1.Create, "create"},
+		{admissionv1.Update, "update"},
+		{admissionv1.Delete, "delete"},
+	}
+
+	for _, c := range cases {
+		got := sarVerb(c.operation)
+		if got != c.want {
+			t.Errorf("sarVerb(%q) = %q, want %q", c.operation, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

Close #5079

Foreground cascading deletion of a `Schedule` (for example via Argo CD foreground deletion) hangs forever. The garbage collector needs to send an UPDATE to remove the `foregroundDeletion` finalizer once all children are gone, but the `vauth.kb.io` validating webhook rejects it:

```
admission webhook "vauth.kb.io" denied the request:
system:serviceaccount:kube-system:generic-garbage-collector is forbidden on cluster
```

Root cause: the auth webhook always uses `create` as the `SubjectAccessReview` verb, even for UPDATE requests. The garbage collector service account (`system:controller:generic-garbage-collector`) has `update`/`patch`/`delete` on all resources but no `create`, so the check can never pass and the finalizer is never removed.

## What's changed and how does it work?

The auth webhook now derives the `SubjectAccessReview` verb from the admission operation instead of hardcoding `create`:

- CREATE requests check the `create` verb on the affected namespaces, same as before.
- UPDATE requests (including patches, which the API server reports as UPDATE) now check the `update` verb.
- Any other operation falls back to the lowercase operation name, so the check never silently falls back to `create`.

With this change, the garbage collector's finalizer-removal UPDATE passes the check through its own RBAC (`update`), and foreground cascading deletion completes. The security model is unchanged: the webhook still validates the requester's permission on every namespace affected by the selector, it just checks the verb that matches the action being performed.

Note one intentional semantic shift: a user whose role grants only `create` (but not `update`) on chaos resources will now be denied on UPDATE, which matches standard RBAC semantics.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

## DCO

If you find the DCO check fails, please run commands like below to fix it:

> [!TIP]
> Depends on actual situations, for example, if the failed commit isn't the most recent
> one, you can use `git rebase -i HEAD~n` to re-signoff the commit.

```shell
git commit --amend --signoff
git push --force
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization behavior on UPDATE in a validating webhook; tighter RBAC alignment but may deny callers who previously passed with create-only grants.
> 
> **Overview**
> Fixes **foreground cascading deletion** hanging when the generic garbage collector tries to **UPDATE** Chaos Mesh resources to drop finalizers.
> 
> The `vauth.kb.io` auth validating webhook no longer hardcodes **`create`** on `SubjectAccessReview`. It maps the admission **operation** to the SAR verb via new **`sarVerb`** (`create` / `update`, with a lowercase fallback for other ops) and passes that through **`AuthValidator.auth`**. UPDATE paths (including GC finalizer removal) are checked against **`update`** RBAC instead of incorrectly requiring **`create`**.
> 
> **CHANGELOG** documents the fix ([#5079](https://github.com/chaos-mesh/chaos-mesh/issues/5079)). **`TestSarVerb`** covers the mapping. Users with only **`create`** and not **`update`** will now be denied on updates, which aligns with normal Kubernetes RBAC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ae939541e59387fdc647dd9c0fc74ea65f5150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->