### PR TITLE
fix(webhook): match SubjectAccessReview verb to admission operation (cherry-pick #5082 to release-2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 ### Fixed
 
 - Fix convert netem delay/jitter as durations instead of strings [#5074](https://github.com/chaos-mesh/chaos-mesh/pull/5074)
+- Use the admission operation as the SubjectAccessReview verb in the auth webhook so foreground cascading deletion no longer hangs [#5079](https://github.com/chaos-mesh/chaos-mesh/issues/5079)
 
 ### Security
 

--- a/pkg/webhook/validate_auth.go
+++ b/pkg/webhook/validate_auth.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	authzv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,8 +104,10 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 
 	requireClusterPrivileges, affectedNamespaces := affectedNamespaces(chaos)
 
+	verb := sarVerb(req.Operation)
+
 	if requireClusterPrivileges {
-		allow, err := v.auth(req.UserInfo, "", requestKind)
+		allow, err := v.auth(req.UserInfo, "", requestKind, verb)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -117,7 +120,7 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 		v.logger.Info("start validating user", "user", username, "groups", groups, "namespace", affectedNamespaces)
 
 		for namespace := range affectedNamespaces {
-			allow, err := v.auth(req.UserInfo, namespace, requestKind)
+			allow, err := v.auth(req.UserInfo, namespace, requestKind, verb)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
@@ -133,7 +136,23 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 	return admission.Allowed("")
 }
 
-func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosKind string) (bool, error) {
+// sarVerb maps the admission operation to the verb checked in the
+// SubjectAccessReview, so the permission check matches the action
+// the user is actually performing.
+func sarVerb(op admissionv1.Operation) string {
+	switch op {
+	case admissionv1.Create:
+		return "create"
+	case admissionv1.Update:
+		return "update"
+	default:
+		// The webhook only registers create and update. Fall back to
+		// the lowercase operation name for any other value.
+		return strings.ToLower(string(op))
+	}
+}
+
+func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosKind string, verb string) (bool, error) {
 	resourceName, err := v.resourceFor(chaosKind)
 	if err != nil {
 		return false, err
@@ -143,7 +162,7 @@ func (v *AuthValidator) auth(userInfo authnv1.UserInfo, namespace string, chaosK
 		Spec: authzv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &authzv1.ResourceAttributes{
 				Namespace: namespace,
-				Verb:      "create",
+				Verb:      verb,
 				Group:     "chaos-mesh.org",
 				Resource:  resourceName,
 			},

--- a/pkg/webhook/validate_auth_test.go
+++ b/pkg/webhook/validate_auth_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package webhook
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+func TestSarVerb(t *testing.T) {
+	cases := []struct {
+		operation admissionv1.Operation
+		want      string
+	}{
+		{admissionv1.Create, "create"},
+		{admissionv1.Update, "update"},
+		{admissionv1.Delete, "delete"},
+	}
+
+	for _, c := range cases {
+		got := sarVerb(c.operation)
+		if got != c.want {
+			t.Errorf("sarVerb(%q) = %q, want %q", c.operation, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

Cherry-pick #5082 to `release-2.8`. Ref #5079: foreground cascading deletion of a `Schedule` hangs because the `vauth.kb.io` webhook always checks the `create` verb in its `SubjectAccessReview`, so the garbage collector's UPDATE that removes the `foregroundDeletion` finalizer is denied.

## What's changed and how does it work?

Same as #5082: the auth webhook now derives the `SubjectAccessReview` verb from the admission operation (CREATE checks `create`, UPDATE checks `update`, anything else falls back to the lowercase operation name). The clean cherry-pick applied without code conflicts; only the CHANGELOG entry was re-anchored under this branch's `[Unreleased]` section.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the validating auth webhook and SubjectAccessReview verb selection; behavior changes for UPDATE admission requests but aligns checks with registered create/update operations rather than broadening RBAC.
> 
> **Overview**
> Fixes **foreground cascading deletion** hanging on resources such as `Schedule` when the `vauth.kb.io` auth webhook is enabled. The webhook always evaluated **`create`** in `SubjectAccessReview`, so Kubernetes garbage-collector **UPDATE** requests (for example removing the `foregroundDeletion` finalizer) were denied even when the caller had update rights.
> 
> The auth validator now maps `req.Operation` to the SAR verb via **`sarVerb`** (`create` / `update`, with a lowercase fallback for other operations) and passes that verb into **`auth`** instead of a hardcoded `"create"`. A small **`TestSarVerb`** unit test covers the mapping. **CHANGELOG** records the fix for [#5079](https://github.com/chaos-mesh/chaos-mesh/issues/5079).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb44d87ccafb179401bd7c1fdb4bcc0635f45c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->