### PR TITLE
fix(webhook): match SubjectAccessReview verb to admission operation (cherry-pick #5082 to release-2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 - Fix an API call in the Dashboard UI [#4743](https://github.com/chaos-mesh/chaos-mesh/pull/4743)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)
+- Use the admission operation as the SubjectAccessReview verb in the auth webhook so foreground cascading deletion no longer hangs [#5079](https://github.com/chaos-mesh/chaos-mesh/issues/5079)
 
 ### Security
 

--- a/pkg/webhook/validate_auth.go
+++ b/pkg/webhook/validate_auth.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	admissionv1 "k8s.io/api/admission/v1"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -102,8 +103,10 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 
 	requireClusterPrivileges, affectedNamespaces := affectedNamespaces(chaos)
 
+	verb := sarVerb(req.Operation)
+
 	if requireClusterPrivileges {
-		allow, err := v.auth(username, groups, "", requestKind)
+		allow, err := v.auth(username, groups, "", requestKind, verb)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -116,7 +119,7 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 		v.logger.Info("start validating user", "user", username, "groups", groups, "namespace", affectedNamespaces)
 
 		for namespace := range affectedNamespaces {
-			allow, err := v.auth(username, groups, namespace, requestKind)
+			allow, err := v.auth(username, groups, namespace, requestKind, verb)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
@@ -132,7 +135,23 @@ func (v *AuthValidator) Handle(ctx context.Context, req admission.Request) admis
 	return admission.Allowed("")
 }
 
-func (v *AuthValidator) auth(username string, groups []string, namespace string, chaosKind string) (bool, error) {
+// sarVerb maps the admission operation to the verb checked in the
+// SubjectAccessReview, so the permission check matches the action
+// the user is actually performing.
+func sarVerb(op admissionv1.Operation) string {
+	switch op {
+	case admissionv1.Create:
+		return "create"
+	case admissionv1.Update:
+		return "update"
+	default:
+		// The webhook only registers create and update. Fall back to
+		// the lowercase operation name for any other value.
+		return strings.ToLower(string(op))
+	}
+}
+
+func (v *AuthValidator) auth(username string, groups []string, namespace string, chaosKind string, verb string) (bool, error) {
 	resourceName, err := v.resourceFor(chaosKind)
 	if err != nil {
 		return false, err
@@ -141,7 +160,7 @@ func (v *AuthValidator) auth(username string, groups []string, namespace string,
 		Spec: authv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &authv1.ResourceAttributes{
 				Namespace: namespace,
-				Verb:      "create",
+				Verb:      verb,
 				Group:     "chaos-mesh.org",
 				Resource:  resourceName,
 			},

--- a/pkg/webhook/validate_auth_test.go
+++ b/pkg/webhook/validate_auth_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package webhook
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+func TestSarVerb(t *testing.T) {
+	cases := []struct {
+		operation admissionv1.Operation
+		want      string
+	}{
+		{admissionv1.Create, "create"},
+		{admissionv1.Update, "update"},
+		{admissionv1.Delete, "delete"},
+	}
+
+	for _, c := range cases {
+		got := sarVerb(c.operation)
+		if got != c.want {
+			t.Errorf("sarVerb(%q) = %q, want %q", c.operation, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

Cherry-pick #5082 to `release-2.7`. Ref #5079: foreground cascading deletion of a `Schedule` hangs because the `vauth.kb.io` webhook always checks the `create` verb in its `SubjectAccessReview`, so the garbage collector's UPDATE that removes the `foregroundDeletion` finalizer is denied.

## What's changed and how does it work?

Same as #5082: the auth webhook now derives the `SubjectAccessReview` verb from the admission operation (CREATE checks `create`, UPDATE checks `update`, anything else falls back to the lowercase operation name).

This branch predates two refactors on master, so the cherry-pick was adapted to the older code shape in `validate_auth.go`: this branch's `auth()` still takes `(username string, groups []string, ...)` and aliases authorization/v1 as `authv1`. The fix keeps that local shape and only adds the `sarVerb()` helper, a trailing `verb` parameter on `auth()`, and threads the verb through both call sites. The `sarVerb` unit test ported unchanged. `go build` and `go test ./pkg/webhook/` pass on this branch.

## Related changes

- [ ] This change also requires further updates to the [website](https://github.com/chaos-mesh/website) (e.g. docs)
- [ ] This change also requires further updates to the `UI interface`

## Cherry-pick to release branches (optional)

> This PR should be cherry-picked to the following release branches:

- [ ] release-2.8
- [ ] release-2.7

## Checklist

### CHANGELOG

> Must include at least one of them.

- [ ] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

> Must include at least one of them.

- [ ] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] **Breaking backward compatibility**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission authorization checks in a security-sensitive webhook; behavior shifts from always requiring create to matching the real operation (notably update), which fixes deletion but may surface RBAC gaps users previously masked.
> 
> **Overview**
> Fixes **foreground cascading deletion** hanging on resources like `Schedule` when the `vauth.kb.io` auth webhook is enabled. The validator always used **`create`** in `SubjectAccessReview`, so the garbage collector’s **UPDATE** (e.g. clearing `foregroundDeletion` finalizers) could be denied even when the caller had update rights.
> 
> The webhook now maps the admission **operation** to the SAR **verb** via `sarVerb()` (`create` / `update`, with a lowercase fallback), threads that through `auth()`, and documents the fix in **CHANGELOG**. Unit tests cover `sarVerb` mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5532866d1fe4c72c060e2f002c3a4a7efb7f528a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->