### PR TITLE
fix(podchaos): recover overlapping pod failures safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Preserve the original container images until all overlapping PodChaos pod-failure experiments recover.
+
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/controllers/chaosimpl/podchaos/podfailure/impl.go
+++ b/controllers/chaosimpl/podchaos/podfailure/impl.go
@@ -17,9 +17,15 @@ package podfailure
 
 import (
 	"context"
+	"encoding/json"
+	"slices"
+	"strings"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
@@ -31,120 +37,202 @@ import (
 
 var _ impltypes.ChaosImpl = (*Impl)(nil)
 
+const stateAnnotation = "chaos-mesh.org/pod-failure"
+
+type failureState struct {
+	Owners         []types.UID       `json:"owners"`
+	Containers     map[string]string `json:"containers"`
+	InitContainers map[string]string `json:"initContainers,omitempty"`
+}
+
 type Impl struct {
 	client.Client
 }
 
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
-	podchaos := obj.(*v1alpha1.PodChaos)
-
-	var origin v1.Pod
-	namespacedName, err := controller.ParseNamespacedName(records[index].Id)
+	chaos := obj.(*v1alpha1.PodChaos)
+	name, err := controller.ParseNamespacedName(records[index].Id)
 	if err != nil {
 		return v1alpha1.NotInjected, err
 	}
-	err = impl.Get(ctx, namespacedName, &origin)
+	err = impl.updatePod(ctx, name, func(pod *v1.Pod) (bool, error) {
+		state, err := readState(pod)
+		if err != nil {
+			return false, err
+		}
+		if state == nil {
+			ownLegacy, anyLegacy := legacyInjection(pod, chaos)
+			if ownLegacy {
+				// Preserve retries of an injection made before shared ownership was introduced.
+				return false, nil
+			}
+			if anyLegacy {
+				return false, errors.New("waiting for an existing legacy pod-failure experiment to recover")
+			}
+			state = &failureState{
+				Containers:     make(map[string]string),
+				InitContainers: make(map[string]string),
+			}
+			for _, container := range pod.Spec.Containers {
+				state.Containers[container.Name] = container.Image
+			}
+			for _, container := range pod.Spec.InitContainers {
+				state.InitContainers[container.Name] = container.Image
+			}
+		}
+		if slices.Contains(state.Owners, chaos.UID) {
+			return false, nil
+		}
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].Image = config.ControllerCfg.PodFailurePauseImage
+		}
+		for i := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].Image = config.ControllerCfg.PodFailurePauseImage
+		}
+		state.Owners = append(state.Owners, chaos.UID)
+		return true, writeState(pod, state)
+	})
 	if err != nil {
-		// TODO: handle this error
 		return v1alpha1.NotInjected, err
 	}
-	pod := origin.DeepCopy()
-	for index := range pod.Spec.Containers {
-		originImage := pod.Spec.Containers[index].Image
-		name := pod.Spec.Containers[index].Name
-
-		key := annotation.GenKeyForImage(podchaos, name, false)
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-
-		// If the annotation is already existed, we could skip the reconcile for this container
-		if _, ok := pod.Annotations[key]; ok {
-			continue
-		}
-		pod.Annotations[key] = originImage
-		pod.Spec.Containers[index].Image = config.ControllerCfg.PodFailurePauseImage
-	}
-
-	for index := range pod.Spec.InitContainers {
-		originImage := pod.Spec.InitContainers[index].Image
-		name := pod.Spec.InitContainers[index].Name
-
-		key := annotation.GenKeyForImage(podchaos, name, true)
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-
-		// If the annotation is already existed, we could skip the reconcile for this container
-		if _, ok := pod.Annotations[key]; ok {
-			continue
-		}
-		pod.Annotations[key] = originImage
-		pod.Spec.InitContainers[index].Image = config.ControllerCfg.PodFailurePauseImage
-	}
-
-	err = impl.Patch(ctx, pod, client.MergeFrom(&origin))
-	if err != nil {
-		// TODO: handle this error
-		return v1alpha1.NotInjected, err
-	}
-
 	return v1alpha1.Injected, nil
 }
 
 func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
-	podchaos := obj.(*v1alpha1.PodChaos)
-
-	var origin v1.Pod
-	namespacedName, err := controller.ParseNamespacedName(records[index].Id)
+	chaos := obj.(*v1alpha1.PodChaos)
+	name, err := controller.ParseNamespacedName(records[index].Id)
 	if err != nil {
-		// This error is not expected to exist
 		return v1alpha1.NotInjected, err
 	}
-	err = impl.Get(ctx, namespacedName, &origin)
-	if err != nil {
-		// TODO: handle this error
-		if k8sError.IsNotFound(err) {
-			return v1alpha1.NotInjected, nil
+	err = impl.updatePod(ctx, name, func(pod *v1.Pod) (bool, error) {
+		state, err := readState(pod)
+		if err != nil {
+			return false, err
 		}
+		if state == nil {
+			return recoverLegacyImages(pod, chaos), nil
+		}
+		owner := slices.Index(state.Owners, chaos.UID)
+		if owner < 0 {
+			return false, nil
+		}
+		state.Owners = slices.Delete(state.Owners, owner, owner+1)
+		if len(state.Owners) != 0 {
+			return true, writeState(pod, state)
+		}
+		for i, container := range pod.Spec.Containers {
+			pod.Spec.Containers[i].Image = state.Containers[container.Name]
+		}
+		for i, container := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].Image = state.InitContainers[container.Name]
+		}
+		delete(pod.Annotations, stateAnnotation)
+		return true, nil
+	})
+	if err != nil && !k8sError.IsNotFound(err) {
 		return v1alpha1.Injected, err
 	}
-	pod := origin.DeepCopy()
-	for index := range pod.Spec.Containers {
-		name := pod.Spec.Containers[index].Name
-		key := annotation.GenKeyForImage(podchaos, name, false)
-
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-		// check annotation
-		if image, ok := pod.Annotations[key]; ok {
-			pod.Spec.Containers[index].Image = image
-			delete(pod.Annotations, key)
-		}
-	}
-
-	for index := range pod.Spec.InitContainers {
-		name := pod.Spec.InitContainers[index].Name
-		key := annotation.GenKeyForImage(podchaos, name, true)
-
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-		// check annotation
-		if image, ok := pod.Annotations[key]; ok {
-			pod.Spec.InitContainers[index].Image = image
-			delete(pod.Annotations, key)
-		}
-	}
-
-	err = impl.Patch(ctx, pod, client.MergeFrom(&origin))
-	if err != nil {
-		// TODO: handle this error
-		return v1alpha1.Injected, err
-	}
-
 	return v1alpha1.NotInjected, nil
+}
+
+func (impl *Impl) updatePod(ctx context.Context, name types.NamespacedName, mutate func(*v1.Pod) (bool, error)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var original v1.Pod
+		if err := impl.Get(ctx, name, &original); err != nil {
+			return err
+		}
+		pod := original.DeepCopy()
+		changed, err := mutate(pod)
+		if err != nil || !changed {
+			return err
+		}
+		return impl.Patch(ctx, pod, client.MergeFromWithOptions(&original, client.MergeFromWithOptimisticLock{}))
+	})
+}
+
+func readState(pod *v1.Pod) (*failureState, error) {
+	raw, ok := pod.Annotations[stateAnnotation]
+	if !ok {
+		return nil, nil
+	}
+	var state failureState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return nil, errors.Wrap(err, "read pod-failure state")
+	}
+	if len(state.Owners) == 0 {
+		return nil, errors.New("pod-failure state has no owners")
+	}
+	owners := make(map[types.UID]struct{}, len(state.Owners))
+	for _, owner := range state.Owners {
+		if _, duplicate := owners[owner]; owner == "" || duplicate {
+			return nil, errors.New("pod-failure state has an empty or duplicate owner")
+		}
+		owners[owner] = struct{}{}
+	}
+	for _, container := range pod.Spec.Containers {
+		if image, ok := state.Containers[container.Name]; !ok || image == "" {
+			return nil, errors.Errorf("pod-failure state has no original image for container %s", container.Name)
+		}
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if image, ok := state.InitContainers[container.Name]; !ok || image == "" {
+			return nil, errors.Errorf("pod-failure state has no original image for init container %s", container.Name)
+		}
+	}
+	return &state, nil
+}
+
+func writeState(pod *v1.Pod, state *failureState) error {
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return errors.Wrap(err, "write pod-failure state")
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[stateAnnotation] = string(raw)
+	return nil
+}
+
+// Legacy annotations lack experiment UIDs, so they cannot safely share the new state.
+func legacyInjection(pod *v1.Pod, chaos *v1alpha1.PodChaos) (own, found bool) {
+	for index, containers := range [][]v1.Container{pod.Spec.Containers, pod.Spec.InitContainers} {
+		for _, container := range containers {
+			ownKey := annotation.GenKeyForImage(chaos, container.Name, index == 1)
+			suffix := container.Name + "-normal"
+			if index == 1 {
+				suffix = container.Name + "-init"
+			}
+			for key := range pod.Annotations {
+				if key == suffix || strings.HasPrefix(key, annotation.AnnotationPrefix+"-") && strings.HasSuffix(key, "-pod-failure-"+suffix+"-image") {
+					found = true
+					own = own || key == ownKey
+				}
+			}
+		}
+	}
+	return
+}
+
+func recoverLegacyImages(pod *v1.Pod, chaos *v1alpha1.PodChaos) bool {
+	changed := false
+	for i, container := range pod.Spec.Containers {
+		key := annotation.GenKeyForImage(chaos, container.Name, false)
+		if image, ok := pod.Annotations[key]; ok {
+			pod.Spec.Containers[i].Image = image
+			delete(pod.Annotations, key)
+			changed = true
+		}
+	}
+	for i, container := range pod.Spec.InitContainers {
+		key := annotation.GenKeyForImage(chaos, container.Name, true)
+		if image, ok := pod.Annotations[key]; ok {
+			pod.Spec.InitContainers[i].Image = image
+			delete(pod.Annotations, key)
+			changed = true
+		}
+	}
+	return changed
 }
 
 func NewImpl(c client.Client) *Impl {

--- a/controllers/chaosimpl/podchaos/podfailure/impl_test.go
+++ b/controllers/chaosimpl/podchaos/podfailure/impl_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podfailure
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/config"
+	"github.com/chaos-mesh/chaos-mesh/pkg/annotation"
+)
+
+const testPauseImage = "registry.k8s.io/pause:3.9"
+
+func newTestPod(t *testing.T) (client.Client, *v1.Pod, []*v1alpha1.Record) {
+	t.Helper()
+	g := gomega.NewWithT(t)
+	oldPauseImage := config.ControllerCfg.PodFailurePauseImage
+	config.ControllerCfg.PodFailurePauseImage = testPauseImage
+	t.Cleanup(func() { config.ControllerCfg.PodFailurePauseImage = oldPauseImage })
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "applications", Name: "app-0", UID: "pod-uid",
+			Annotations: map[string]string{"example.com/keep": "value"},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "app", Image: "app:v1"},
+				{Name: "sidecar", Image: "sidecar:v1"},
+			},
+			InitContainers: []v1.Container{{Name: "init", Image: "init:v1"}},
+		},
+	}
+	scheme := runtime.NewScheme()
+	g.Expect(v1.AddToScheme(scheme)).To(gomega.Succeed())
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).Build()
+	return c, pod, []*v1alpha1.Record{{Id: "applications/app-0"}}
+}
+
+func testChaos(namespace, name, uid string) *v1alpha1.PodChaos {
+	return &v1alpha1.PodChaos{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uid)},
+		Spec:       v1alpha1.PodChaosSpec{Action: v1alpha1.PodFailureAction},
+	}
+}
+
+func expectImages(t *testing.T, c client.Client, original *v1.Pod, paused bool) *v1.Pod {
+	t.Helper()
+	g := gomega.NewWithT(t)
+	actual := &v1.Pod{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(original), actual)).To(gomega.Succeed())
+	for i, container := range original.Spec.Containers {
+		expected := container.Image
+		if paused {
+			expected = testPauseImage
+		}
+		g.Expect(actual.Spec.Containers[i].Image).To(gomega.Equal(expected))
+	}
+	for i, container := range original.Spec.InitContainers {
+		expected := container.Image
+		if paused {
+			expected = testPauseImage
+		}
+		g.Expect(actual.Spec.InitContainers[i].Image).To(gomega.Equal(expected))
+	}
+	g.Expect(actual.Annotations["example.com/keep"]).To(gomega.Equal("value"))
+	return actual
+}
+
+func TestPodFailureOverlappingExperiments(t *testing.T) {
+	for _, names := range []struct{ firstNamespace, firstName, secondNamespace, secondName string }{
+		{"experiments", "first", "experiments", "second"},
+		{"team-a", "same-name", "team-b", "same-name"},
+		{"experiments", strings.Repeat("a", 63), "experiments", strings.Repeat("b", 63)},
+	} {
+		for _, reverse := range []bool{false, true} {
+			name := names.firstNamespace + "/" + names.firstName + "-" + names.secondNamespace + "/" + names.secondName
+			if reverse {
+				name += "-reverse"
+			}
+			t.Run(name, func(t *testing.T) {
+				g := gomega.NewWithT(t)
+				c, original, records := newTestPod(t)
+				impl := NewImpl(c)
+				a := testChaos(names.firstNamespace, names.firstName, "first-uid")
+				b := testChaos(names.secondNamespace, names.secondName, "second-uid")
+				for _, chaos := range []*v1alpha1.PodChaos{a, a, b} {
+					phase, err := impl.Apply(context.Background(), 0, records, chaos)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(phase).To(gomega.Equal(v1alpha1.Injected))
+				}
+				expectImages(t, c, original, true)
+				if reverse {
+					a, b = b, a
+				}
+				for _, chaos := range []*v1alpha1.PodChaos{testChaos("unrelated", "other", "other-uid"), a, a} {
+					phase, err := impl.Recover(context.Background(), 0, records, chaos)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(phase).To(gomega.Equal(v1alpha1.NotInjected))
+					expectImages(t, c, original, true)
+				}
+				phase, err := impl.Recover(context.Background(), 0, records, b)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(phase).To(gomega.Equal(v1alpha1.NotInjected))
+				actual := expectImages(t, c, original, false)
+				g.Expect(actual.Annotations).To(gomega.Equal(original.Annotations))
+				_, err = impl.Recover(context.Background(), 0, records, b)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				expectImages(t, c, original, false)
+			})
+		}
+	}
+}
+
+func injectLegacy(t *testing.T, c client.Client, original *v1.Pod, chaos *v1alpha1.PodChaos) {
+	t.Helper()
+	g := gomega.NewWithT(t)
+	pod := &v1.Pod{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(original), pod)).To(gomega.Succeed())
+	for i, container := range pod.Spec.Containers {
+		pod.Annotations[annotation.GenKeyForImage(chaos, container.Name, false)] = container.Image
+		pod.Spec.Containers[i].Image = testPauseImage
+	}
+	for i, container := range pod.Spec.InitContainers {
+		pod.Annotations[annotation.GenKeyForImage(chaos, container.Name, true)] = container.Image
+		pod.Spec.InitContainers[i].Image = testPauseImage
+	}
+	g.Expect(c.Update(context.Background(), pod)).To(gomega.Succeed())
+}
+
+func TestPodFailureLegacyRecoveryAndRetry(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c, original, records := newTestPod(t)
+	impl := NewImpl(c)
+	a := testChaos("experiments", "legacy", "legacy-uid")
+	injectLegacy(t, c, original, a)
+	before := expectImages(t, c, original, true)
+	phase, err := impl.Apply(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(phase).To(gomega.Equal(v1alpha1.Injected))
+	after := expectImages(t, c, original, true)
+	g.Expect(after.Annotations).To(gomega.Equal(before.Annotations))
+	phase, err = impl.Recover(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(phase).To(gomega.Equal(v1alpha1.NotInjected))
+	g.Expect(expectImages(t, c, original, false).Annotations).To(gomega.Equal(original.Annotations))
+}
+
+func TestPodFailureDoesNotOverlapLegacyInjection(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c, original, records := newTestPod(t)
+	a := testChaos("experiments", "legacy", "legacy-uid")
+	injectLegacy(t, c, original, a)
+	before := expectImages(t, c, original, true)
+	phase, err := NewImpl(c).Apply(context.Background(), 0, records, testChaos("experiments", "new", "new-uid"))
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(phase).To(gomega.Equal(v1alpha1.NotInjected))
+	g.Expect(expectImages(t, c, original, true).Annotations).To(gomega.Equal(before.Annotations))
+}
+
+type interleavingClient struct {
+	client.Client
+	beforePatch func()
+}
+
+func (c *interleavingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.beforePatch != nil {
+		beforePatch := c.beforePatch
+		c.beforePatch = nil
+		beforePatch()
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func TestPodFailureConcurrentApply(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c, original, records := newTestPod(t)
+	a := testChaos("experiments", "a", "a-uid")
+	b := testChaos("experiments", "b", "b-uid")
+	interleaved := &interleavingClient{Client: c, beforePatch: func() {
+		_, err := NewImpl(c).Apply(context.Background(), 0, records, b)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}}
+	_, err := NewImpl(interleaved).Apply(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	_, err = NewImpl(c).Recover(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, true)
+	_, err = NewImpl(c).Recover(context.Background(), 0, records, b)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, false)
+}
+
+func TestPodFailureApplyDuringRecovery(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c, original, records := newTestPod(t)
+	a := testChaos("experiments", "a", "a-uid")
+	b := testChaos("experiments", "b", "b-uid")
+	_, err := NewImpl(c).Apply(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	interleaved := &interleavingClient{Client: c, beforePatch: func() {
+		_, err := NewImpl(c).Apply(context.Background(), 0, records, b)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}}
+	_, err = NewImpl(interleaved).Recover(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, true)
+	_, err = NewImpl(c).Recover(context.Background(), 0, records, b)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, false)
+}
+
+func TestPodFailureInvalidStateDoesNotChangePod(t *testing.T) {
+	for _, raw := range []string{
+		"not-json",
+		`{"owners":[]}`,
+		`{"owners":["owner-uid","owner-uid"],"containers":{"app":"app:v1","sidecar":"sidecar:v1"},"initContainers":{"init":"init:v1"}}`,
+		`{"owners":[""],"containers":{"app":"app:v1","sidecar":"sidecar:v1"},"initContainers":{"init":"init:v1"}}`,
+		`{"owners":["owner-uid"],"containers":{"app":"","sidecar":"sidecar:v1"},"initContainers":{"init":"init:v1"}}`,
+		`{"owners":["owner-uid"],"containers":{"app":"app:v1"}}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			c, original, records := newTestPod(t)
+			pod := &v1.Pod{}
+			g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(original), pod)).To(gomega.Succeed())
+			pod.Annotations[stateAnnotation] = raw
+			g.Expect(c.Update(context.Background(), pod)).To(gomega.Succeed())
+			before := pod.DeepCopy()
+			chaos := testChaos("experiments", "owner", "owner-uid")
+			phase, err := NewImpl(c).Apply(context.Background(), 0, records, chaos)
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(phase).To(gomega.Equal(v1alpha1.NotInjected))
+			phase, err = NewImpl(c).Recover(context.Background(), 0, records, chaos)
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(phase).To(gomega.Equal(v1alpha1.Injected))
+			g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(original), pod)).To(gomega.Succeed())
+			g.Expect(pod).To(gomega.Equal(before))
+		})
+	}
+}
+
+func TestPodFailureNewOwnerPausesUpdatedImages(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c, original, records := newTestPod(t)
+	a := testChaos("experiments", "a", "a-uid")
+	b := testChaos("experiments", "b", "b-uid")
+	_, err := NewImpl(c).Apply(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	pod := expectImages(t, c, original, true)
+	pod.Spec.Containers[0].Image = "app:v2"
+	pod.Spec.InitContainers[0].Image = "init:v2"
+	g.Expect(c.Update(context.Background(), pod)).To(gomega.Succeed())
+	_, err = NewImpl(c).Apply(context.Background(), 0, records, b)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, true)
+	_, err = NewImpl(c).Recover(context.Background(), 0, records, a)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, true)
+	_, err = NewImpl(c).Recover(context.Background(), 0, records, b)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	expectImages(t, c, original, false)
+}


### PR DESCRIPTION
## What problem does this PR solve?

Overlapping `pod-failure` experiments can leave a pod using the pause image after both experiments report successful recovery. If A saves the application image and B starts while A is active, B saves the pause image. Recovering A and then B restores the pause image and deletes both backups.

## What's changed and how does it work?

Store one original-image snapshot and the active experiment UIDs in a shared pod annotation. Each experiment adds or removes its UID; the final recovery restores regular and init-container images. UID ownership also separates experiments with the same name in different namespaces and avoids collisions caused by long annotation keys.

Update ownership and pod images together with an optimistic merge patch and conflict retries. Preserve idempotent apply/recover behavior, reject malformed recovery state, and keep the existing recovery path for experiments injected by older controllers.

## Reproduction and validation

The fake-client regression tests fail against the previous implementation and pass with this change. They cover both recovery orders, repeated operations, cross-namespace and long names, interleaved apply/recover writes, edited container images, malformed state, and legacy recovery.

```sh
go test ./controllers/chaosimpl/podchaos/... ./pkg/annotation/...
go vet ./controllers/chaosimpl/podchaos/... ./pkg/annotation/...
```

Both commands passed. Changed files were formatted with `goimports`. No cluster fault injection or full containerized repository checks were run.

## Downsides

The shared annotation is a new internal recovery format. Legacy annotations do not contain experiment UIDs: distinct legacy experiments are kept separate from new injections, but old same-name or long-name collisions remain ambiguous and cannot be reconstructed reliably. This change does not repair pods already left with only a pause-image backup by the old implementation.

## Risk and rollback

The change affects only `PodChaos` with `action: pod-failure`. Watch for failed annotation patches and experiments stuck recovering. Pause/delete active pod-failure experiments and verify recovery before reverting and redeploying the controller: older versions cannot interpret the new shared annotation.

## Related changes

- [ ] This change also requires further updates to the website
- [ ] This change also requires further updates to the UI interface

## Checklist

### CHANGELOG

- [x] I have updated `CHANGELOG.md`

### Tests

- [x] Unit test
- [ ] E2E test
- [ ] Manual cluster test

### Side effects

- [x] New internal recovery format; recover active experiments before downgrading

## DCO

Commits are signed off.
