### PR TITLE
fix(timechaos): persist recovery state across daemon restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Preserve TimeChaos task and vDSO recovery state across Chaos Daemon restarts.
+
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/controllers/chaosimpl/timechaos/impl.go
+++ b/controllers/chaosimpl/timechaos/impl.go
@@ -23,24 +23,37 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	impltypes "github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/types"
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/controller"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
 	timeUtils "github.com/chaos-mesh/chaos-mesh/pkg/time/utils"
 )
 
 var _ impltypes.ChaosImpl = (*Impl)(nil)
 
+const waitForApply v1alpha1.Phase = "Not Injected/Wait"
+
+type containerRecordDecoder interface {
+	DecodeContainerRecord(context.Context, *v1alpha1.Record, v1alpha1.InnerObject) (utils.DecodedContainerRecord, error)
+}
+
 type Impl struct {
 	client.Client
 	Log     logr.Logger
-	decoder *utils.ContainerRecordDecoder
+	decoder containerRecordDecoder
 }
 
 func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {
+	failurePhase := v1alpha1.NotInjected
+	if records[index].Phase == waitForApply {
+		failurePhase = waitForApply
+	}
 	decodedContainer, err := impl.decoder.DecodeContainerRecord(ctx, records[index], obj)
 	pbClient := decodedContainer.PbClient
 	containerId := decodedContainer.ContainerId
@@ -48,18 +61,29 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		defer pbClient.Close()
 	}
 	if err != nil {
-		return v1alpha1.NotInjected, err
+		// The decoder wraps every Pod Get error as ErrContainerNotFound. Only
+		// a separate confirmed NotFound may finish an ambiguous prior RPC.
+		if failurePhase == waitForApply && errors.Is(err, utils.ErrContainerNotFound) {
+			name, _, parseErr := controller.ParseNamespacedNameContainer(records[index].Id)
+			if parseErr == nil {
+				var pod corev1.Pod
+				if getErr := impl.Client.Get(ctx, name, &pod); apierrors.IsNotFound(getErr) {
+					return v1alpha1.NotInjected, nil
+				}
+			}
+		}
+		return failurePhase, err
 	}
 
 	timechaos := obj.(*v1alpha1.TimeChaos)
 	mask, err := timeUtils.EncodeClkIds(timechaos.Spec.ClockIds)
 	if err != nil {
-		return v1alpha1.NotInjected, err
+		return failurePhase, err
 	}
 
 	duration, err := time.ParseDuration(timechaos.Spec.TimeOffset)
 	if err != nil {
-		return v1alpha1.NotInjected, err
+		return failurePhase, err
 	}
 
 	sec, nsec := secAndNSecFromDuration(duration)
@@ -74,7 +98,10 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		PodContainerName: fmt.Sprintf("%s:%s", decodedContainer.Pod.GetUID(), decodedContainer.ContainerName),
 	})
 	if err != nil {
-		return v1alpha1.NotInjected, err
+		// The daemon may have injected before the response was lost. Preserve
+		// an intermediate phase so stopping/deleting still finishes Apply and
+		// then calls Recover. The daemon reconciles repeated Apply by task UID.
+		return waitForApply, err
 	}
 
 	return v1alpha1.Injected, nil

--- a/controllers/chaosimpl/timechaos/impl.go
+++ b/controllers/chaosimpl/timechaos/impl.go
@@ -116,8 +116,16 @@ func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Re
 	}
 	if err != nil {
 		if errors.Is(err, utils.ErrContainerNotFound) {
-			// pretend the disappeared container has been recovered
-			return v1alpha1.NotInjected, nil
+			// A read failure or temporarily missing container status does not
+			// prove that the affected processes are gone. Only confirmed Pod
+			// deletion can finish recovery without contacting the daemon.
+			name, _, parseErr := controller.ParseNamespacedNameContainer(records[index].Id)
+			if parseErr == nil {
+				var pod corev1.Pod
+				if getErr := impl.Client.Get(ctx, name, &pod); apierrors.IsNotFound(getErr) {
+					return v1alpha1.NotInjected, nil
+				}
+			}
 		}
 		return v1alpha1.Injected, err
 	}

--- a/controllers/chaosimpl/timechaos/impl_test.go
+++ b/controllers/chaosimpl/timechaos/impl_test.go
@@ -26,8 +26,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"
@@ -110,5 +112,41 @@ func TestTimeChaosApplyPreservesPendingPhaseOnTransientDecodeError(t *testing.T)
 	phase, err = impl.Apply(context.Background(), 0, records, timeChaosTestObject())
 	if phase != v1alpha1.NotInjected || err != nil {
 		t.Fatalf("confirmed missing pod: phase=%s err=%v", phase, err)
+	}
+}
+
+func TestTimeChaosRecoveryRequiresConfirmedPodDeletion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod"}}
+	otherContainer := pod.DeepCopy()
+	otherContainer.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "sidecar", ContainerID: "containerd://sidecar"}}
+	for _, test := range []struct {
+		name    string
+		client  client.Client
+		deleted bool
+	}{
+		{name: "API timeout", client: &testTimePodClient{getErr: apierrors.NewTimeoutError("API timeout", 1)}},
+		{name: "API forbidden", client: &testTimePodClient{getErr: apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod", errors.New("denied"))}},
+		{name: "container statuses temporarily absent", client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()},
+		{name: "target container temporarily absent", client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(otherContainer).Build()},
+		{name: "pod deleted", client: fake.NewClientBuilder().WithScheme(scheme).Build(), deleted: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Use the real decoder: it wraps both read failures and missing
+			// container status as ErrContainerNotFound. No case reaches a daemon.
+			impl := &Impl{Client: test.client, Log: logr.Discard(), decoder: utils.NewContainerRecordDecoder(test.client, nil)}
+			records := []*v1alpha1.Record{{Id: "default/pod/app", Phase: v1alpha1.Injected}}
+			phase, err := impl.Recover(context.Background(), 0, records, timeChaosTestObject())
+			if test.deleted {
+				if phase != v1alpha1.NotInjected || err != nil {
+					t.Fatalf("confirmed deleted pod: phase=%s err=%v", phase, err)
+				}
+			} else if phase != v1alpha1.Injected || err == nil {
+				t.Fatalf("lost cleanup without confirming deletion: phase=%s err=%v", phase, err)
+			}
+		})
 	}
 }

--- a/controllers/chaosimpl/timechaos/impl_test.go
+++ b/controllers/chaosimpl/timechaos/impl_test.go
@@ -1,0 +1,114 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package timechaos
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/utils"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+)
+
+type testTimeDaemon struct {
+	pb.ChaosDaemonClient
+	applyErr  error
+	applied   int
+	recovered int
+}
+
+func (d *testTimeDaemon) Close() error { return nil }
+func (d *testTimeDaemon) SetTimeOffset(context.Context, *pb.TimeRequest, ...grpc.CallOption) (*empty.Empty, error) {
+	d.applied++
+	return &empty.Empty{}, d.applyErr
+}
+func (d *testTimeDaemon) RecoverTimeOffset(context.Context, *pb.TimeRequest, ...grpc.CallOption) (*empty.Empty, error) {
+	d.recovered++
+	return &empty.Empty{}, nil
+}
+
+type testTimeDecoder struct {
+	daemon *testTimeDaemon
+	err    error
+}
+
+func (d *testTimeDecoder) DecodeContainerRecord(context.Context, *v1alpha1.Record, v1alpha1.InnerObject) (utils.DecodedContainerRecord, error) {
+	return utils.DecodedContainerRecord{PbClient: d.daemon, ContainerId: "container", ContainerName: "app", Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-uid"}}}, d.err
+}
+
+type testTimePodClient struct {
+	client.Client
+	getErr error
+}
+
+func (c *testTimePodClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return c.getErr
+}
+
+func timeChaosTestObject() *v1alpha1.TimeChaos {
+	return &v1alpha1.TimeChaos{ObjectMeta: metav1.ObjectMeta{UID: "experiment-uid"}, Spec: v1alpha1.TimeChaosSpec{TimeOffset: "1s", ClockIds: []string{"CLOCK_REALTIME"}}}
+}
+
+func TestTimeChaosAmbiguousApplyKeepsCleanupPending(t *testing.T) {
+	daemon := &testTimeDaemon{applyErr: errors.New("reply lost")}
+	decoder := &testTimeDecoder{daemon: daemon}
+	impl := &Impl{Log: logr.Discard(), decoder: decoder}
+	records := []*v1alpha1.Record{{Id: "default/pod/app", Phase: v1alpha1.NotInjected}}
+	phase, err := impl.Apply(context.Background(), 0, records, timeChaosTestObject())
+	if phase != waitForApply || err == nil {
+		t.Fatalf("ambiguous apply: phase=%s err=%v", phase, err)
+	}
+	records[0].Phase = phase
+	daemon.applyErr = nil
+	// A stopped record in Not Injected/Wait is driven through Apply and Recover
+	// by the common records controller, rather than skipped as NotInjected.
+	phase, err = impl.Apply(context.Background(), 0, records, timeChaosTestObject())
+	if phase != v1alpha1.Injected || err != nil {
+		t.Fatalf("retry apply: phase=%s err=%v", phase, err)
+	}
+	records[0].Phase = phase
+	phase, err = impl.Recover(context.Background(), 0, records, timeChaosTestObject())
+	if phase != v1alpha1.NotInjected || err != nil || daemon.recovered != 1 {
+		t.Fatalf("cleanup: phase=%s err=%v recovered=%d", phase, err, daemon.recovered)
+	}
+}
+
+func TestTimeChaosApplyPreservesPendingPhaseOnTransientDecodeError(t *testing.T) {
+	decoder := &testTimeDecoder{daemon: &testTimeDaemon{}, err: utils.ErrContainerNotFound}
+	podClient := &testTimePodClient{getErr: errors.New("API timeout")}
+	impl := &Impl{Log: logr.Discard(), decoder: decoder, Client: podClient}
+	records := []*v1alpha1.Record{{Id: "default/pod/app", Phase: waitForApply}}
+	phase, err := impl.Apply(context.Background(), 0, records, timeChaosTestObject())
+	if phase != waitForApply || err == nil {
+		t.Fatalf("lost pending cleanup: phase=%s err=%v", phase, err)
+	}
+	podClient.getErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "pod")
+	phase, err = impl.Apply(context.Background(), 0, records, timeChaosTestObject())
+	if phase != v1alpha1.NotInjected || err != nil {
+		t.Fatalf("confirmed missing pod: phase=%s err=%v", phase, err)
+	}
+}

--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -40,7 +40,6 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
-	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/tasks"
 	grpcUtils "github.com/chaos-mesh/chaos-mesh/pkg/grpc"
 	"github.com/chaos-mesh/chaos-mesh/pkg/log"
 	"github.com/chaos-mesh/chaos-mesh/pkg/metrics"
@@ -110,12 +109,7 @@ func NewDaemonServerWithCRClient(crClient crclients.ContainerRuntimeInfoClient, 
 		backgroundProcessManager: bpm.StartBackgroundProcessManager(reg, log),
 		tproxyLocker:             new(sync.Map),
 		rootLogger:               log,
-		timeChaosServer: TimeChaosServer{
-			podContainerNameProcessMap: tasks.NewPodProcessMap(),
-			manager:                    tasks.NewTaskManager(logr.New(log.GetSink()).WithName("TimeChaos")),
-			nameLocker:                 tasks.NewLockMap[tasks.PodContainerName](),
-			logger:                     logr.New(log.GetSink()).WithName("TimeChaos"),
-		},
+		timeChaosServer:          newTimeChaosServer(logr.New(log.GetSink()).WithName("TimeChaos")),
 	}
 }
 

--- a/pkg/chaosdaemon/time_server_darwin.go
+++ b/pkg/chaosdaemon/time_server_darwin.go
@@ -27,6 +27,10 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/tasks"
 )
 
+func newTimeChaosServer(logger logr.Logger) TimeChaosServer {
+	return TimeChaosServer{logger: logger}
+}
+
 type TimeChaosServer struct {
 	podContainerNameProcessMap tasks.PodContainerNameProcessMap
 	manager                    tasks.TaskManager

--- a/pkg/chaosdaemon/time_server_linux.go
+++ b/pkg/chaosdaemon/time_server_linux.go
@@ -20,56 +20,21 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 
-	"github.com/chaos-mesh/chaos-mesh/pkg/cerr"
 	pb "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
-	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/tasks"
 	"github.com/chaos-mesh/chaos-mesh/pkg/time"
 )
 
 type TimeChaosServer struct {
-	podContainerNameProcessMap tasks.PodContainerNameProcessMap
-	manager                    tasks.TaskManager
-
-	nameLocker tasks.LockMap[tasks.PodContainerName]
-	logger     logr.Logger
+	manager *time.PersistentTimeChaos
+	logger  logr.Logger
 }
 
-func (s *TimeChaosServer) SetPodContainerNameProcess(idName tasks.PodContainerName, sysID tasks.SysPID) {
-	s.podContainerNameProcessMap.Write(idName, sysID)
-}
-
-func (s *TimeChaosServer) DelPodContainerNameProcess(idName tasks.PodContainerName) {
-	s.podContainerNameProcessMap.Delete(idName)
-}
-
-func (s *TimeChaosServer) SetTimeOffset(uid tasks.TaskID, id tasks.PodContainerName, config time.Config) error {
-	paras := time.ConfigCreatorParas{
-		Logger:        s.logger,
-		Config:        config,
-		PodProcessMap: &s.podContainerNameProcessMap,
+func newTimeChaosServer(logger logr.Logger) TimeChaosServer {
+	return TimeChaosServer{
+		manager: time.NewPersistentTimeChaos("/host-run/chaos-daemon/timechaos", logger),
+		logger:  logger,
 	}
-
-	unlock := s.nameLocker.Lock(id)
-	defer unlock()
-	// We assume the base time skew is not sensitive with process changes which
-	// means time skew will not return error when the task target pod changes container id & IsID.
-	// We assume controller will never update tasks.
-	// According to the above, we do not handle error from s.manager.Apply like
-	// ErrDuplicateEntity(task TaskID).
-	err := s.manager.Create(uid, id, &config, paras)
-	if err != nil {
-		if errors.Cause(err) == cerr.ErrDuplicateEntity {
-			err := s.manager.Apply(uid, id, &config)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *DaemonServer) SetTimeOffset(ctx context.Context, req *pb.TimeRequest) (*empty.Empty, error) {
@@ -83,8 +48,7 @@ func (s *DaemonServer) SetTimeOffset(ctx context.Context, req *pb.TimeRequest) (
 		return nil, err
 	}
 
-	s.timeChaosServer.SetPodContainerNameProcess(tasks.PodContainerName(req.PodContainerName), tasks.SysPID(pid))
-	err = s.timeChaosServer.SetTimeOffset(req.Uid, tasks.PodContainerName(req.PodContainerName),
+	err = s.timeChaosServer.manager.Apply(req.Uid, req.PodContainerName, req.ContainerId, int(pid),
 		time.NewConfig(req.Sec, req.Nsec, req.ClkIdsMask))
 	if err != nil {
 		logger.Error(err, "error while applying chaos")
@@ -104,22 +68,9 @@ func (s *DaemonServer) RecoverTimeOffset(ctx context.Context, req *pb.TimeReques
 		return nil, err
 	}
 
-	nameID := tasks.PodContainerName(req.PodContainerName)
-
-	s.timeChaosServer.SetPodContainerNameProcess(nameID, tasks.SysPID(pid))
-
-	unlock := s.timeChaosServer.nameLocker.Lock(nameID)
-	defer unlock()
-
-	err = s.timeChaosServer.manager.Recover(req.Uid, nameID)
-	if err != nil {
+	if err := s.timeChaosServer.manager.Recover(req.Uid, req.PodContainerName, req.ContainerId, int(pid)); err != nil {
 		logger.Error(err, "error while recovering chaos")
 		return nil, err
-	}
-
-	if len(s.timeChaosServer.manager.GetUIDsWithPID(nameID)) == 0 {
-		s.timeChaosServer.DelPodContainerNameProcess(nameID)
-		s.timeChaosServer.nameLocker.Del(nameID)
 	}
 
 	return &empty.Empty{}, nil

--- a/pkg/time/fake_image_linux.go
+++ b/pkg/time/fake_image_linux.go
@@ -17,6 +17,7 @@ package time
 
 import (
 	"bytes"
+	"encoding/binary"
 	"runtime"
 
 	"github.com/go-logr/logr"
@@ -46,6 +47,12 @@ type FakeImage struct {
 	OriginAddress uint64
 	// fakeEntry stores the fake entry
 	fakeEntry *mapreader.Entry
+	// validateProcess runs after ptrace has stopped the process, before using
+	// addresses from a persisted recovery record.
+	validateProcess func(int) error
+	// saveRecovery records the original code before the first write to the vDSO.
+	saveRecovery       func() error
+	recoveryCandidates []imageRecovery
 
 	logger logr.Logger
 }
@@ -71,11 +78,20 @@ func (it *FakeImage) AttachToProcess(pid int, variables map[string]uint64) (err 
 		return errors.Wrapf(err, "ptrace on target process, pid: %d", pid)
 	}
 	defer func() {
-		err = program.Detach()
-		if err != nil {
-			it.logger.Error(err, "fail to detach program", "pid", program.Pid())
+		if detachErr := program.Detach(); detachErr != nil {
+			it.logger.Error(detachErr, "fail to detach program", "pid", program.Pid())
+			if err == nil {
+				err = detachErr
+			} else {
+				err = errors.Wrapf(err, "detach also failed: %v", detachErr)
+			}
 		}
 	}()
+	if it.validateProcess != nil {
+		if err := it.validateProcess(pid); err != nil {
+			return err
+		}
+	}
 
 	vdsoEntry, err := FindVDSOEntry(program)
 	if err != nil {
@@ -92,18 +108,29 @@ func (it *FakeImage) AttachToProcess(pid int, variables map[string]uint64) (err 
 		if err != nil {
 			return errors.Wrapf(err, "injecting fake image , PID : %d", pid)
 		}
-		defer func() {
-			if err != nil {
-				errIn := it.TryReWriteFakeImage(program)
-				if errIn != nil {
-					it.logger.Error(errIn, "rewrite fail, recover fail")
-				}
-				it.OriginFuncCode = nil
-				it.OriginAddress = 0
+	} else {
+		// A fork can inherit a patch without an explicit record of its own.
+		// Save the adopted originals before changing any of its code or data.
+		if it.saveRecovery != nil {
+			if err := it.saveRecovery(); err != nil {
+				return err
 			}
-		}()
+		}
+		if err := program.JumpToFakeFunc(it.OriginAddress, fakeEntry.StartAddress); err != nil {
+			if restoreErr := it.TryReWriteFakeImage(program); restoreErr != nil {
+				return errors.Wrapf(err, "restore after failed jump: %v", restoreErr)
+			}
+			return err
+		}
 	}
 
+	defer func() {
+		if err != nil {
+			if restoreErr := it.TryReWriteFakeImage(program); restoreErr != nil {
+				err = errors.Wrapf(err, "restore after failed update: %v", restoreErr)
+			}
+		}
+	}()
 	for k, v := range variables {
 		err = it.SetVarUint64(program, fakeEntry, k, v)
 
@@ -116,10 +143,14 @@ func (it *FakeImage) AttachToProcess(pid int, variables map[string]uint64) (err 
 }
 
 func FindVDSOEntry(program *ptrace.TracedProgram) (*mapreader.Entry, error) {
+	return findVDSOEntry(program.Entries)
+}
+
+func findVDSOEntry(entries []mapreader.Entry) (*mapreader.Entry, error) {
 	var vdsoEntry *mapreader.Entry
-	for index := range program.Entries {
+	for index := range entries {
 		// reverse loop is faster
-		e := program.Entries[len(program.Entries)-index-1]
+		e := entries[len(entries)-index-1]
 		if e.Path == vdsoEntryName {
 			vdsoEntry = &e
 			break
@@ -132,61 +163,166 @@ func FindVDSOEntry(program *ptrace.TracedProgram) (*mapreader.Entry, error) {
 }
 
 // FindInjectedImage find injected image to avoid redundant inject.
-func (it *FakeImage) FindInjectedImage(program *ptrace.TracedProgram, varNum int) (*mapreader.Entry, error) {
-	it.logger.Info("finding injected image")
-
-	// minus tailing variable part
-	// every variable has 8 bytes
-	if it.fakeEntry != nil {
-		content, err := program.ReadSlice(it.fakeEntry.StartAddress, it.fakeEntry.EndAddress-it.fakeEntry.StartAddress)
-		if err != nil {
-			it.logger.Info("ReadSlice fail")
-			return nil, nil
-		}
-		if varNum*8 > len(it.content) {
-			return nil, errors.New("variable num bigger than content num")
-		}
-		contentWithoutVariable := (*content)[:len(it.content)-varNum*varLength]
-		expectedContentWithoutVariable := it.content[:len(it.content)-varNum*varLength]
-		it.logger.Info("successfully read slice", "content", contentWithoutVariable, "expected content", expectedContentWithoutVariable)
-
-		if bytes.Equal(contentWithoutVariable, expectedContentWithoutVariable) {
-			it.logger.Info("slice found")
-			return it.fakeEntry, nil
-		}
-		it.logger.Info("slice not found")
-	}
-	return nil, nil
+func (it *FakeImage) FindInjectedImage(program *ptrace.TracedProgram, _ int) (*mapreader.Entry, error) {
+	return it.findSavedImage(program, program.Entries)
 }
 
-// InjectFakeImage Usage CheckList:
-// When error : TryReWriteFakeImage after InjectFakeImage.
-func (it *FakeImage) InjectFakeImage(program *ptrace.TracedProgram,
+func (it *FakeImage) findSavedImage(program imageProgram, entries []mapreader.Entry) (*mapreader.Entry, error) {
+	var firstErr error
+	candidates := append([]imageRecovery{snapshotImageRecovery(it)}, it.recoveryCandidates...)
+	for _, candidate := range candidates {
+		if candidate.FakeEntry == nil || len(candidate.OriginalCode) != 16 {
+			continue
+		}
+		found, err := it.matchesSavedImage(program, entries, candidate)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if found {
+			restoreImageRecovery(it, candidate)
+			return it.fakeEntry, nil
+		}
+	}
+	return nil, firstErr
+}
+
+func (it *FakeImage) matchesSavedImage(program imageProgram, entries []mapreader.Entry, candidate imageRecovery) (bool, error) {
+	// A replacement daemon may contain a different compiled fake clock. Check
+	// the payload saved at injection time, rather than the new embedded object.
+	if len(candidate.Content) == 0 {
+		return false, errors.New("saved time chaos image has no validation payload")
+	}
+	varNum := len(candidate.Offsets)
+	vdso, err := findVDSOEntry(entries)
+	if err != nil {
+		return false, err
+	}
+	address, _, err := program.FindSymbolInEntry(it.symbolName, vdso)
+	if err != nil {
+		return false, err
+	}
+	if address != candidate.OriginalAddress {
+		return false, nil
+	}
+	current, err := program.ReadSlice(address, 16)
+	if err != nil {
+		return false, err
+	}
+	restored := bytes.Equal(*current, candidate.OriginalCode)
+	mapped := false
+	for _, entry := range entries {
+		if entry.StartAddress <= candidate.FakeEntry.StartAddress && candidate.FakeEntry.StartAddress < entry.EndAddress && uint64(len(candidate.Content)) <= entry.EndAddress-candidate.FakeEntry.StartAddress {
+			mapped = true
+			break
+		}
+	}
+	// An exec keeps the PID/start time but discards the old address space.
+	if !mapped {
+		if !restored && matchesTimePatch(*current, candidate.OriginalCode, timeJump(candidate.FakeEntry.StartAddress)) {
+			return false, errors.New("time chaos jump remains but its saved image is unmapped")
+		}
+		return false, nil
+	}
+	content, err := program.ReadSlice(candidate.FakeEntry.StartAddress, uint64(len(candidate.Content)))
+	if err != nil {
+		return false, err
+	}
+	if varNum < 0 || varNum*varLength > len(candidate.Content) {
+		return false, errors.New("invalid fake image variable count")
+	}
+	size := len(candidate.Content) - varNum*varLength
+	if !bytes.Equal((*content)[:size], candidate.Content[:size]) {
+		if !restored {
+			return false, errors.New("time chaos jump remains but its saved image has changed")
+		}
+		return false, nil
+	}
+	if !matchesTimePatch(*current, candidate.OriginalCode, timeJump(candidate.FakeEntry.StartAddress)) {
+		return false, errors.New("vDSO code differs from the saved time chaos patch")
+	}
+	return true, nil
+}
+
+// PtraceWriteSlice writes machine words separately. A daemon crash can leave
+// either the jump or its restoration only partly written; both are recoverable.
+func matchesTimePatch(current, original, jump []byte) bool {
+	if len(current) != 16 || len(original) != 16 || len(jump) != 16 {
+		return false
+	}
+	for i := 0; i < 16; i += 8 {
+		if !bytes.Equal(current[i:i+8], original[i:i+8]) && !bytes.Equal(current[i:i+8], jump[i:i+8]) {
+			return false
+		}
+	}
+	return true
+}
+
+func timeJump(address uint64) []byte {
+	instructions := make([]byte, 16)
+	if runtime.GOARCH == "arm64" {
+		binary.LittleEndian.PutUint32(instructions, 0x58000049)
+		binary.LittleEndian.PutUint32(instructions[4:], 0xD61F0120)
+		binary.LittleEndian.PutUint64(instructions[8:], address)
+	} else {
+		instructions[0], instructions[1] = 0x48, 0xb8
+		binary.LittleEndian.PutUint64(instructions[2:], address)
+		instructions[10], instructions[11] = 0xff, 0xe0
+	}
+	return instructions
+}
+
+type imageProgram interface {
+	MmapSlice([]byte) (*mapreader.Entry, error)
+	FindSymbolInEntry(string, *mapreader.Entry) (uint64, uint64, error)
+	ReadSlice(uint64, uint64) (*[]byte, error)
+	JumpToFakeFunc(uint64, uint64) error
+	PtraceWriteSlice(uint64, []byte) error
+}
+
+// InjectFakeImage saves restoration data before replacing the vDSO function.
+func (it *FakeImage) InjectFakeImage(program imageProgram,
 	vdsoEntry *mapreader.Entry) (*mapreader.Entry, error) {
 	fakeEntry, err := program.MmapSlice(it.content)
 	if err != nil {
 		return nil, errors.Wrapf(err, "mmap fake image")
 	}
 	it.fakeEntry = fakeEntry
-	originAddr, size, err := program.FindSymbolInEntry(it.symbolName, vdsoEntry)
+	originAddr, _, err := program.FindSymbolInEntry(it.symbolName, vdsoEntry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "find origin %s in vdso", it.symbolName)
 	}
-	funcBytes, err := program.ReadSlice(originAddr, size)
+	funcBytes, err := program.ReadSlice(originAddr, 16)
 	if err != nil {
 		return nil, errors.Wrapf(err, "ReadSlice failed")
 	}
-	err = program.JumpToFakeFunc(originAddr, fakeEntry.StartAddress)
-	if err != nil {
-		errIn := it.TryReWriteFakeImage(program)
-		if errIn != nil {
-			it.logger.Error(errIn, "rewrite fail, recover fail")
-		}
-		return nil, errors.Wrapf(err, "override origin %s", it.symbolName)
+	// Without a journal, adopting an existing hook would save the hook itself
+	// as the original function, making later recovery ineffective.
+	jump := timeJump(0)
+	hooked := bytes.Equal((*funcBytes)[:8], jump[:8])
+	if runtime.GOARCH == "amd64" {
+		hooked = bytes.Equal((*funcBytes)[:2], jump[:2]) && bytes.Equal((*funcBytes)[10:], jump[10:])
+	}
+	if hooked {
+		return nil, errors.New("time chaos patch has no matching recovery state")
 	}
 
 	it.OriginFuncCode = *funcBytes
 	it.OriginAddress = originAddr
+	if it.saveRecovery != nil {
+		if err := it.saveRecovery(); err != nil {
+			return nil, errors.Wrap(err, "save time skew recovery state")
+		}
+	}
+	err = program.JumpToFakeFunc(originAddr, fakeEntry.StartAddress)
+	if err != nil {
+		if restoreErr := program.PtraceWriteSlice(originAddr, it.OriginFuncCode); restoreErr != nil {
+			return nil, errors.Wrapf(err, "override %s; restore also failed: %v", it.symbolName, restoreErr)
+		}
+		return nil, errors.Wrapf(err, "override origin %s", it.symbolName)
+	}
 	return fakeEntry, nil
 }
 
@@ -196,20 +332,22 @@ func (it *FakeImage) TryReWriteFakeImage(program *ptrace.TracedProgram) error {
 		if err != nil {
 			return err
 		}
-		it.OriginFuncCode = nil
-		it.OriginAddress = 0
+		if it.saveRecovery == nil {
+			it.OriginFuncCode = nil
+			it.OriginAddress = 0
+		}
 	}
 	return nil
 }
 
 // Recover the injected image. If injected image not found ,
 // Recover will not return error.
-func (it *FakeImage) Recover(pid int, vars map[string]uint64) error {
+func (it *FakeImage) Recover(pid int, vars map[string]uint64) (err error) {
 	runtime.LockOSThread()
 	defer func() {
 		runtime.UnlockOSThread()
 	}()
-	if it.OriginFuncCode == nil {
+	if it.OriginFuncCode == nil && len(it.recoveryCandidates) == 0 {
 		return nil
 	}
 	program, err := ptrace.Trace(pid, it.logger.WithName("ptrace").WithValues("pid", pid))
@@ -217,11 +355,20 @@ func (it *FakeImage) Recover(pid int, vars map[string]uint64) error {
 		return errors.Wrapf(err, "ptrace on target process, pid: %d", pid)
 	}
 	defer func() {
-		err = program.Detach()
-		if err != nil {
-			it.logger.Error(err, "fail to detach program", "pid", program.Pid())
+		if detachErr := program.Detach(); detachErr != nil {
+			it.logger.Error(detachErr, "fail to detach program", "pid", program.Pid())
+			if err == nil {
+				err = detachErr
+			} else {
+				err = errors.Wrapf(err, "detach also failed: %v", detachErr)
+			}
 		}
 	}()
+	if it.validateProcess != nil {
+		if err := it.validateProcess(pid); err != nil {
+			return err
+		}
+	}
 
 	fakeEntry, err := it.FindInjectedImage(program, len(vars))
 	if err != nil {
@@ -231,6 +378,11 @@ func (it *FakeImage) Recover(pid int, vars map[string]uint64) error {
 		return nil
 	}
 
+	if it.saveRecovery != nil {
+		if err := it.saveRecovery(); err != nil {
+			return err
+		}
+	}
 	err = it.TryReWriteFakeImage(program)
 	return err
 }

--- a/pkg/time/persistent_linux.go
+++ b/pkg/time/persistent_linux.go
@@ -1,0 +1,453 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/tasks"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mapreader"
+)
+
+// PersistentTimeChaos keeps the desired tasks and recovery data on the host, so
+// replacing the daemon does not lose the information needed to undo a vDSO patch.
+// The directory must survive daemon container replacement (for example /host-run).
+type PersistentTimeChaos struct {
+	directory string
+	logger    logr.Logger
+	bootID    func() (string, error)
+	identity  func(int) (processIdentity, error)
+	children  func(int, string, string) ([]processIdentity, error)
+	cgroup    func(int) (string, error)
+	execute   func(*processRecovery, *Config, []processRecovery, func() error) error
+}
+
+type processIdentity struct {
+	PID       int    `json:"pid"`
+	StartTime string `json:"startTime"`
+}
+
+type imageRecovery struct {
+	OriginalCode    []byte           `json:"originalCode,omitempty"`
+	OriginalAddress uint64           `json:"originalAddress,omitempty"`
+	FakeEntry       *mapreader.Entry `json:"fakeEntry,omitempty"`
+	Content         []byte           `json:"content,omitempty"`
+	Offsets         map[string]int   `json:"offsets,omitempty"`
+}
+
+type processRecovery struct {
+	ContainerID  string          `json:"containerID"`
+	Identity     processIdentity `json:"identity"`
+	ClockGetTime imageRecovery   `json:"clockGetTime"`
+	GetTimeOfDay imageRecovery   `json:"getTimeOfDay"`
+}
+
+type persistentConfig struct {
+	Seconds     int64  `json:"seconds"`
+	Nanoseconds int64  `json:"nanoseconds"`
+	ClockIDs    uint64 `json:"clockIDs"`
+}
+
+type timeJournal struct {
+	Version          int                         `json:"version"`
+	BootID           string                      `json:"bootID"`
+	ContainerID      string                      `json:"containerID"`
+	PodContainerName string                      `json:"podContainerName"`
+	Cgroup           string                      `json:"cgroup"`
+	Tasks            map[string]persistentConfig `json:"tasks"`
+	// Completed is retained for idempotent Recover RPC retries, including a
+	// successful recovery whose response was lost before a daemon restart.
+	Completed map[string]bool             `json:"completed"`
+	Processes map[string]*processRecovery `json:"processes"`
+}
+
+// NewPersistentTimeChaos creates a coordinator backed by a host-mounted directory.
+func NewPersistentTimeChaos(directory string, logger logr.Logger) *PersistentTimeChaos {
+	p := &PersistentTimeChaos{
+		directory: directory,
+		logger:    logger,
+		bootID: func() (string, error) {
+			data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+			return strings.TrimSpace(string(data)), err
+		},
+		identity: readProcessIdentity,
+		children: func(pid int, cgroup, containerID string) ([]processIdentity, error) {
+			return enumerateTimeProcesses("/proc", pid, cgroup, containerID)
+		},
+		cgroup: func(pid int) (string, error) {
+			data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+			return string(data), err
+		},
+	}
+	p.execute = p.executeProcess
+	return p
+}
+
+// Apply reconciles the aggregate offset for all desired tasks on the container.
+func (p *PersistentTimeChaos) Apply(uid, podContainerName, containerID string, pid int, config Config) error {
+	return p.reconcile(uid, podContainerName, containerID, pid, &config)
+}
+
+// Recover removes a task and restores the remaining aggregate or original code.
+func (p *PersistentTimeChaos) Recover(uid, podContainerName, containerID string, pid int) error {
+	return p.reconcile(uid, podContainerName, containerID, pid, nil)
+}
+
+func (p *PersistentTimeChaos) reconcile(uid, podContainerName, containerID string, pid int, config *Config) error {
+	if uid == "" || podContainerName == "" || containerID == "" || pid <= 0 {
+		return errors.New("time chaos requires a task UID, container identity and positive PID")
+	}
+	bootID, err := p.bootID()
+	if err != nil {
+		return errors.Wrap(err, "read boot identity")
+	}
+	if bootID == "" {
+		return errors.New("empty boot identity")
+	}
+	// Hash the complete identity; RPC fields must never become path components.
+	key := fmt.Sprintf("%x", sha256.Sum256([]byte(bootID+"\x00"+podContainerName)))
+	if err := os.MkdirAll(p.directory, 0700); err != nil {
+		return err
+	}
+	lock, err := os.OpenFile(filepath.Join(p.directory, key+".lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	// Also serialize separate daemon processes during a DaemonSet replacement.
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+
+	path := filepath.Join(p.directory, key+".json")
+	journal := timeJournal{Version: 1, BootID: bootID, ContainerID: containerID, PodContainerName: podContainerName,
+		Tasks: make(map[string]persistentConfig), Completed: make(map[string]bool), Processes: make(map[string]*processRecovery)}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &journal); err != nil {
+			return errors.Wrap(err, "decode time chaos recovery journal")
+		}
+		if journal.Version != 1 || journal.BootID != bootID || journal.PodContainerName != podContainerName || journal.Tasks == nil || journal.Completed == nil || journal.Processes == nil {
+			return errors.New("invalid time chaos recovery journal")
+		}
+		if err := validateTimeJournal(&journal); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	} else if config == nil {
+		// A pre-upgrade experiment has no durable originals. Never report it as
+		// recovered just because the daemon has no in-memory task.
+		return errors.New("time chaos recovery journal not found; cannot recover an experiment injected without durable state")
+	}
+
+	if journal.Cgroup == "" || (config != nil && journal.ContainerID != containerID) {
+		journal.Cgroup, err = p.cgroup(pid)
+		if err != nil {
+			return errors.Wrap(err, "read container process cgroup")
+		}
+	}
+
+	oldConfig, hadConfig := journal.Tasks[uid]
+	wasCompleted := journal.Completed[uid]
+	if config != nil {
+		journal.ContainerID = containerID
+		journal.Tasks[uid] = persistentConfig{config.deltaSeconds, config.deltaNanoSeconds, config.clockIDsMask}
+		delete(journal.Completed, uid)
+	} else {
+		if _, exists := journal.Tasks[uid]; !exists && !journal.Completed[uid] {
+			return errors.New("time chaos task not found in recovery journal")
+		}
+		delete(journal.Tasks, uid)
+		journal.Completed[uid] = true
+	}
+	save := func() error { return writeTimeJournal(path, &journal) }
+	// Persist intent first. A retry after any crash reconciles this desired set,
+	// rather than adding/subtracting an offset for a second time.
+	if err := save(); err != nil {
+		return err
+	}
+
+	reconcileErr := p.reconcileProcesses(&journal, containerID, pid, save)
+	if reconcileErr == nil || config == nil {
+		return reconcileErr
+	}
+	// Failed Apply remains pending in the controller. Restore the previous
+	// desired set so an unrelated task does not include this failed change in
+	// its aggregate while the original request waits to be retried.
+	if hadConfig {
+		journal.Tasks[uid] = oldConfig
+	} else {
+		delete(journal.Tasks, uid)
+	}
+	if wasCompleted {
+		journal.Completed[uid] = true
+	} else {
+		delete(journal.Completed, uid)
+	}
+	// Keep a tombstone so a concurrent/lost-response recovery remains safe.
+	if !hadConfig {
+		journal.Completed[uid] = true
+	}
+	if err := save(); err != nil {
+		return errors.Wrapf(reconcileErr, "save apply rollback: %v", err)
+	}
+	if err := p.reconcileProcesses(&journal, containerID, pid, save); err != nil {
+		return errors.Wrapf(reconcileErr, "apply rollback also failed: %v", err)
+	}
+	return reconcileErr
+}
+
+func (p *PersistentTimeChaos) reconcileProcesses(journal *timeJournal, containerID string, pid int, save func() error) error {
+
+	var aggregate *Config
+	if len(journal.Tasks) != 0 {
+		merged := NewConfig(0, 0, 0)
+		for _, task := range journal.Tasks {
+			c := NewConfig(task.Seconds, task.Nanoseconds, task.ClockIDs)
+			if err := merged.Merge(&c); err != nil {
+				return err
+			}
+		}
+		aggregate = &merged
+	}
+
+	var templates []processRecovery
+	for _, process := range journal.Processes {
+		templates = append(templates, *process)
+	}
+	// Include current container members as well as saved processes: fork
+	// inherits patches, and a child may be reparented before the next request.
+	processed := make(map[string]bool)
+	for round := 0; round < 5; round++ {
+		var selected []processIdentity
+		var discoveryErr error
+		if journal.ContainerID == containerID {
+			leader, err := p.identity(pid)
+			if err == nil {
+				selected = append(selected, leader)
+			} else if !os.IsNotExist(err) {
+				discoveryErr = err
+			}
+			children, err := p.children(pid, journal.Cgroup, containerID)
+			if err != nil {
+				discoveryErr = err
+			} else {
+				selected = append(selected, children...)
+			}
+		}
+		for _, identity := range selected {
+			key := processIdentityKey(identity)
+			if _, exists := journal.Processes[key]; !exists {
+				journal.Processes[key] = &processRecovery{Identity: identity, ContainerID: containerID}
+			}
+		}
+
+		if err := save(); err != nil {
+			return err
+		}
+		keys := make([]string, 0, len(journal.Processes))
+		for key := range journal.Processes {
+			if !processed[key] {
+				keys = append(keys, key)
+			}
+		}
+		if len(keys) == 0 {
+			return discoveryErr
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			a, b := journal.Processes[keys[i]].Identity.PID, journal.Processes[keys[j]].Identity.PID
+			if a == b {
+				return keys[i] < keys[j]
+			}
+			if a == pid {
+				return true
+			}
+			if b == pid {
+				return false
+			}
+			return a < b
+		})
+		var failures []string
+		if discoveryErr != nil {
+			failures = append(failures, discoveryErr.Error())
+		}
+		for _, key := range keys {
+			process := journal.Processes[key]
+			processed[key] = true
+			current, err := p.identity(process.Identity.PID)
+			if os.IsNotExist(err) || (err == nil && current != process.Identity) {
+				continue
+			}
+			if err == nil {
+				desired := aggregate
+				if process.ContainerID != containerID {
+					desired = nil
+				}
+				err = p.execute(process, desired, templates, save)
+			}
+			templates = append(templates, *process)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("pid %d: %v", process.Identity.PID, err))
+			}
+		}
+		if len(failures) != 0 {
+			return errors.New(strings.Join(failures, "; "))
+		}
+		// Rescan after restoring parents. A fork created between the previous
+		// scan and ptrace attachment can still have inherited the old patch.
+	}
+	return errors.New("time chaos process group is changing; retry reconciliation")
+}
+
+func processIdentityKey(identity processIdentity) string {
+	return strconv.Itoa(identity.PID) + ":" + identity.StartTime
+}
+
+func validateTimeJournal(journal *timeJournal) error {
+	for key, process := range journal.Processes {
+		if process == nil || process.Identity.PID <= 0 || process.ContainerID == "" || key != processIdentityKey(process.Identity) {
+			return errors.New("invalid process in time chaos recovery journal")
+		}
+		if _, err := strconv.ParseUint(process.Identity.StartTime, 10, 64); err != nil {
+			return errors.Wrap(err, "invalid recovery process start time")
+		}
+		for _, image := range []imageRecovery{process.ClockGetTime, process.GetTimeOfDay} {
+			if len(image.OriginalCode) == 0 && image.OriginalAddress == 0 && image.FakeEntry == nil {
+				continue
+			}
+			if len(image.OriginalCode) != 16 || image.OriginalAddress == 0 || image.FakeEntry == nil || len(image.Content) == 0 || image.FakeEntry.StartAddress == 0 || image.FakeEntry.EndAddress <= image.FakeEntry.StartAddress || uint64(len(image.Content)) > image.FakeEntry.EndAddress-image.FakeEntry.StartAddress || len(image.Offsets)*varLength >= len(image.Content) {
+				return errors.New("incomplete image in time chaos recovery journal")
+			}
+			for _, offset := range image.Offsets {
+				if offset < 0 || offset > len(image.Content)-varLength {
+					return errors.New("invalid variable offset in time chaos recovery journal")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func writeTimeJournal(path string, journal *timeJournal) (err error) {
+	data, err := json.Marshal(journal)
+	if err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".timechaos-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(file.Name(), path); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func (p *PersistentTimeChaos) executeProcess(process *processRecovery, config *Config, templates []processRecovery, save func() error) error {
+	c := NewConfig(0, 0, 0)
+	if config != nil {
+		c = *config
+	}
+	skew, err := GetSkew(p.logger, c)
+	if err != nil {
+		return err
+	}
+	restoreImageRecovery(skew.clockGetTime, process.ClockGetTime)
+	restoreImageRecovery(skew.getTimeOfDay, process.GetTimeOfDay)
+	validate := func(pid int) error {
+		identity, err := p.identity(pid)
+		if err != nil {
+			return err
+		}
+		if identity != process.Identity {
+			return errors.New("process identity changed before ptrace attachment")
+		}
+		return nil
+	}
+	saveImages := func() error {
+		process.ClockGetTime = snapshotImageRecovery(skew.clockGetTime)
+		process.GetTimeOfDay = snapshotImageRecovery(skew.getTimeOfDay)
+		return save()
+	}
+	for _, template := range templates {
+		if template.ContainerID != process.ContainerID {
+			continue
+		}
+		if len(template.ClockGetTime.OriginalCode) != 0 {
+			skew.clockGetTime.recoveryCandidates = append(skew.clockGetTime.recoveryCandidates, template.ClockGetTime)
+		}
+		if len(template.GetTimeOfDay.OriginalCode) != 0 {
+			skew.getTimeOfDay.recoveryCandidates = append(skew.getTimeOfDay.recoveryCandidates, template.GetTimeOfDay)
+		}
+	}
+	for _, image := range []*FakeImage{skew.clockGetTime, skew.getTimeOfDay} {
+		image.validateProcess = validate
+		image.saveRecovery = saveImages
+	}
+	if config != nil {
+		return skew.Inject(tasks.SysPID(process.Identity.PID))
+	}
+	return skew.Recover(tasks.SysPID(process.Identity.PID))
+}
+
+func snapshotImageRecovery(image *FakeImage) imageRecovery {
+	return imageRecovery{
+		OriginalCode:    append([]byte(nil), image.OriginFuncCode...),
+		OriginalAddress: image.OriginAddress,
+		FakeEntry:       image.fakeEntry,
+		Content:         append([]byte(nil), image.content...),
+		Offsets:         image.offset,
+	}
+}
+
+func restoreImageRecovery(image *FakeImage, recovery imageRecovery) {
+	image.OriginFuncCode = append([]byte(nil), recovery.OriginalCode...)
+	image.OriginAddress = recovery.OriginalAddress
+	image.fakeEntry = recovery.FakeEntry
+	if len(recovery.Content) != 0 {
+		image.content = append([]byte(nil), recovery.Content...)
+		image.offset = recovery.Offsets
+	}
+}

--- a/pkg/time/persistent_linux_test.go
+++ b/pkg/time/persistent_linux_test.go
@@ -1,0 +1,498 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/mapreader"
+)
+
+type simulatedTimeProcesses struct {
+	identities map[int]string
+	offsets    map[int]Config
+	children   []uint32
+	failPID    int
+	writes     int
+}
+
+func (f *simulatedTimeProcesses) manager(directory string) *PersistentTimeChaos {
+	p := NewPersistentTimeChaos(directory, logr.Discard())
+	p.bootID = func() (string, error) { return "boot-one", nil }
+	p.identity = func(pid int) (processIdentity, error) {
+		start, ok := f.identities[pid]
+		if !ok {
+			return processIdentity{}, os.ErrNotExist
+		}
+		return processIdentity{pid, start}, nil
+	}
+	p.children = func(int, string, string) ([]processIdentity, error) {
+		var result []processIdentity
+		for _, pid := range f.children {
+			result = append(result, processIdentity{int(pid), f.identities[int(pid)]})
+		}
+		return result, nil
+	}
+	p.cgroup = func(int) (string, error) { return "0::/pod/container", nil }
+	p.execute = func(process *processRecovery, c *Config, _ []processRecovery, save func() error) error {
+		if len(process.ClockGetTime.OriginalCode) == 0 {
+			process.ClockGetTime = imageRecovery{OriginalCode: bytes.Repeat([]byte{0x90}, 16), OriginalAddress: 0x1000, Content: []byte{1, 2, 3}, FakeEntry: &mapreader.Entry{StartAddress: 0x2000, EndAddress: 0x2100}}
+		}
+		// The simulated injector follows the same required write-before-patch
+		// contract as FakeImage. The tests recreate managers from these files.
+		if err := save(); err != nil {
+			return err
+		}
+		f.writes++
+		if process.Identity.PID == f.failPID {
+			return errors.New("simulated write failure")
+		}
+		if c == nil {
+			delete(f.offsets, process.Identity.PID)
+		} else {
+			f.offsets[process.Identity.PID] = *c
+		}
+		return nil
+	}
+	return p
+}
+
+func newSimulatedTimeProcesses() *simulatedTimeProcesses {
+	return &simulatedTimeProcesses{identities: map[int]string{100: "1000", 101: "1001"}, offsets: make(map[int]Config), children: []uint32{101}}
+}
+
+func TestPersistentTimeChaosRestartPreservesOverlappingTasks(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	first := NewConfig(10, 5, 1)
+	second := NewConfig(20, 7, 2)
+	if err := processes.manager(directory).Apply("first", "pod:app", "container", 100, first); err != nil {
+		t.Fatal(err)
+	}
+	// Every RPC uses a fresh manager, just like replacing the daemon.
+	if err := processes.manager(directory).Apply("second", "pod:app", "container", 100, second); err != nil {
+		t.Fatal(err)
+	}
+	if got := processes.offsets[100]; got != NewConfig(30, 12, 3) {
+		t.Fatalf("aggregate after restart = %+v", got)
+	}
+	if err := processes.manager(directory).Recover("first", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+	if got := processes.offsets[100]; got != second {
+		t.Fatalf("remaining offset = %+v", got)
+	}
+	if err := processes.manager(directory).Recover("second", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+	if len(processes.offsets) != 0 {
+		t.Fatalf("unrecovered processes: %+v", processes.offsets)
+	}
+	// Lost successful replies must be safe to retry even after another restart.
+	if err := processes.manager(directory).Recover("second", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistentTimeChaosApplyRetryDoesNotDoubleOffset(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	config := NewConfig(10, 5, 1)
+	for i := 0; i < 2; i++ {
+		if err := processes.manager(directory).Apply("task", "pod:app", "container", 100, config); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := processes.offsets[100]; got != config {
+		t.Fatalf("retried offset = %+v", got)
+	}
+}
+
+func TestPersistentTimeChaosRecoveryRetriesFailedChildAfterRestart(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	if err := processes.manager(directory).Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	// The parent exits and the child is reparented. Its durable record remains.
+	delete(processes.identities, 100)
+	processes.children = nil
+	processes.failPID = 101
+	if err := processes.manager(directory).Recover("task", "pod:app", "container", 100); err == nil {
+		t.Fatal("expected child recovery failure")
+	}
+	if _, ok := processes.offsets[101]; !ok {
+		t.Fatal("failed child unexpectedly recovered")
+	}
+	processes.failPID = 0
+	if err := processes.manager(directory).Recover("task", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := processes.offsets[101]; ok {
+		t.Fatal("child offset survived retry")
+	}
+}
+
+func TestPersistentTimeChaosFailedApplyRetainsRecoveryState(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	processes.failPID = 101
+	if err := processes.manager(directory).Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err == nil {
+		t.Fatal("expected apply failure")
+	}
+	processes.failPID = 0
+	if err := processes.manager(directory).Recover("task", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+	if len(processes.offsets) != 0 {
+		t.Fatalf("unrecovered state: %+v", processes.offsets)
+	}
+}
+
+func TestPersistentTimeChaosPIDReuseDoesNotRestoreOldProcess(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	if err := processes.manager(directory).Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	processes.identities[101] = "new-start"
+	processes.children = nil
+	p := processes.manager(directory)
+	execute := p.execute
+	p.execute = func(process *processRecovery, c *Config, templates []processRecovery, save func() error) error {
+		if process.Identity.PID == 101 {
+			t.Fatal("attempted to restore a reused PID")
+		}
+		return execute(process, c, templates, save)
+	}
+	if err := p.Recover("task", "pod:app", "container", 100); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistentTimeChaosRequiresJournalForRecovery(t *testing.T) {
+	processes := newSimulatedTimeProcesses()
+	p := processes.manager(t.TempDir())
+	if err := p.Recover("task", "pod:app", "container", 100); err == nil || !strings.Contains(err.Error(), "journal not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processes.writes != 0 {
+		t.Fatal("wrote to a process without recovery state")
+	}
+}
+
+func TestPersistentTimeChaosRejectsCorruptJournalBeforeWrites(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	p := processes.manager(directory)
+	if err := p.Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	files, err := filepath.Glob(filepath.Join(directory, "*.json"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("journal files: %v %v", files, err)
+	}
+	if err := os.WriteFile(files[0], []byte("{truncated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writes := processes.writes
+	if err := processes.manager(directory).Recover("task", "pod:app", "container", 100); err == nil {
+		t.Fatal("accepted corrupt journal")
+	}
+	if processes.writes != writes {
+		t.Fatal("wrote to processes despite corrupt journal")
+	}
+}
+
+func TestPersistentTimeChaosJournalsAreContainerScoped(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	for _, container := range []string{"container-a", "container-b"} {
+		if err := processes.manager(directory).Apply("same-task", "pod:"+container, container, 100, NewConfig(5, 0, 1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, _ := filepath.Glob(filepath.Join(directory, "*.json"))
+	if len(files) != 2 {
+		t.Fatalf("expected independent journals, got %v", files)
+	}
+	data, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var journal timeJournal
+	if err := json.Unmarshal(data, &journal); err != nil {
+		t.Fatal(err)
+	}
+	if len(journal.Processes) != 2 || len(journal.Tasks) != 1 {
+		t.Fatalf("incomplete journal: %+v", journal)
+	}
+}
+
+type simulatedImageProgram struct {
+	original []byte
+	jumped   bool
+	jumpErr  error
+}
+
+func (p *simulatedImageProgram) MmapSlice([]byte) (*mapreader.Entry, error) {
+	return &mapreader.Entry{StartAddress: 0x2000, EndAddress: 0x2100}, nil
+}
+func (p *simulatedImageProgram) FindSymbolInEntry(string, *mapreader.Entry) (uint64, uint64, error) {
+	return 0x1000, uint64(len(p.original)), nil
+}
+func (p *simulatedImageProgram) ReadSlice(_ uint64, size uint64) (*[]byte, error) {
+	if size != 16 {
+		return nil, errors.New("must read exactly overwritten bytes")
+	}
+	copied := append([]byte(nil), p.original...)
+	return &copied, nil
+}
+func (p *simulatedImageProgram) PtraceWriteSlice(_ uint64, data []byte) error {
+	p.original = append([]byte(nil), data...)
+	return nil
+}
+func (p *simulatedImageProgram) JumpToFakeFunc(uint64, uint64) error {
+	p.jumped = true
+	return p.jumpErr
+}
+
+func TestPersistentFakeImageSavesOriginalBeforeJump(t *testing.T) {
+	program := &simulatedImageProgram{original: bytes.Repeat([]byte{0x90}, 16)}
+	image := NewFakeImage("clock_gettime", []byte{1, 2, 3}, nil, logr.Discard())
+	saved := false
+	image.saveRecovery = func() error {
+		if program.jumped {
+			t.Fatal("jump preceded durable recovery record")
+		}
+		if !reflect.DeepEqual(image.OriginFuncCode, program.original) || image.OriginAddress != 0x1000 || image.fakeEntry.StartAddress != 0x2000 {
+			t.Fatal("incomplete recovery snapshot")
+		}
+		saved = true
+		return nil
+	}
+	if _, err := image.InjectFakeImage(program, &mapreader.Entry{}); err != nil {
+		t.Fatal(err)
+	}
+	if !saved || !program.jumped {
+		t.Fatal("injection was not completed")
+	}
+}
+
+func TestPersistentFakeImageJournalFailurePreventsJump(t *testing.T) {
+	program := &simulatedImageProgram{original: bytes.Repeat([]byte{0x90}, 16)}
+	image := NewFakeImage("clock_gettime", []byte{1, 2, 3}, nil, logr.Discard())
+	sentinel := errors.New("disk full")
+	image.saveRecovery = func() error { return sentinel }
+	if _, err := image.InjectFakeImage(program, &mapreader.Entry{}); !errors.Is(err, sentinel) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if program.jumped {
+		t.Fatal("modified vDSO without durable originals")
+	}
+}
+
+func TestPersistentFakeImageRejectsUntrackedHook(t *testing.T) {
+	program := &simulatedImageProgram{original: timeJump(0x3000)}
+	image := NewFakeImage("clock_gettime", []byte{1, 2, 3}, nil, logr.Discard())
+	if _, err := image.InjectFakeImage(program, &mapreader.Entry{}); err == nil {
+		t.Fatal("accepted an untracked original hook")
+	}
+	if program.jumped {
+		t.Fatal("overwrote an untracked hook")
+	}
+}
+
+func TestPersistentFakeImageRecognizesInterruptedPatchAndRestore(t *testing.T) {
+	original := bytes.Repeat([]byte{0x90}, 16)
+	jump := timeJump(0x2000)
+	for _, current := range [][]byte{original, jump, append(append([]byte{}, original[:8]...), jump[8:]...), append(append([]byte{}, jump[:8]...), original[8:]...)} {
+		if !matchesTimePatch(current, original, jump) {
+			t.Fatalf("rejected recoverable bytes %x", current)
+		}
+	}
+	foreign := append([]byte(nil), jump...)
+	foreign[15] ^= 1
+	if matchesTimePatch(foreign, original, jump) {
+		t.Fatal("accepted unrelated vDSO code")
+	}
+}
+
+func TestPersistentTimeChaosRecoverAfterContainerRestart(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	if err := processes.manager(directory).Apply("task", "pod:app", "old-container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	processes.identities[200] = "replacement"
+	p := processes.manager(directory)
+	execute := p.execute
+	p.execute = func(process *processRecovery, c *Config, templates []processRecovery, save func() error) error {
+		if process.Identity.PID == 200 {
+			t.Fatal("touched replacement container")
+		}
+		if c != nil {
+			t.Fatal("injected during old-container recovery")
+		}
+		return execute(process, c, templates, save)
+	}
+	if err := p.Recover("task", "pod:app", "new-container", 200); err != nil {
+		t.Fatal(err)
+	}
+	if len(processes.offsets) != 0 {
+		t.Fatalf("old container offset remains: %+v", processes.offsets)
+	}
+}
+
+func TestPersistentTimeChaosFailedApplyDoesNotContaminateNextTask(t *testing.T) {
+	directory := t.TempDir()
+	processes := newSimulatedTimeProcesses()
+	processes.failPID = 101
+	if err := processes.manager(directory).Apply("failed", "pod:app", "container", 100, NewConfig(10, 0, 1)); err == nil {
+		t.Fatal("expected failure")
+	}
+	processes.failPID = 0
+	expected := NewConfig(20, 0, 1)
+	if err := processes.manager(directory).Apply("next", "pod:app", "container", 100, expected); err != nil {
+		t.Fatal(err)
+	}
+	if got := processes.offsets[100]; got != expected {
+		t.Fatalf("failed task contributed offset: %+v", got)
+	}
+}
+
+func TestPersistentTimeChaosRejectsReusedDiscoveredPID(t *testing.T) {
+	processes := newSimulatedTimeProcesses()
+	p := processes.manager(t.TempDir())
+	p.children = func(int, string, string) ([]processIdentity, error) {
+		return []processIdentity{{101, "old-start"}}, nil
+	}
+	execute := p.execute
+	p.execute = func(process *processRecovery, c *Config, templates []processRecovery, save func() error) error {
+		if process.Identity.PID == 101 {
+			t.Fatal("injected PID reused after discovery")
+		}
+		return execute(process, c, templates, save)
+	}
+	if err := p.Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistentTimeChaosRecoversKnownProcessesWhenDiscoveryFails(t *testing.T) {
+	processes := newSimulatedTimeProcesses()
+	directory := t.TempDir()
+	if err := processes.manager(directory).Apply("task", "pod:app", "container", 100, NewConfig(5, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	p := processes.manager(directory)
+	p.children = func(int, string, string) ([]processIdentity, error) { return nil, errors.New("proc unavailable") }
+	if err := p.Recover("task", "pod:app", "container", 100); err == nil {
+		t.Fatal("expected discovery failure")
+	}
+	if len(processes.offsets) != 0 {
+		t.Fatalf("known processes were not recovered: %+v", processes.offsets)
+	}
+}
+
+type simulatedRecoveryProgram struct {
+	simulatedImageProgram
+	memory  map[uint64][]byte
+	readErr error
+}
+
+func (p *simulatedRecoveryProgram) ReadSlice(address, size uint64) (*[]byte, error) {
+	if p.readErr != nil {
+		return nil, p.readErr
+	}
+	data, ok := p.memory[address]
+	if !ok || uint64(len(data)) < size {
+		return nil, errors.New("unmapped simulated read")
+	}
+	copied := append([]byte(nil), data[:size]...)
+	return &copied, nil
+}
+
+func TestPersistentFakeImageRecognizesSavedPayloadAcrossDaemonBuilds(t *testing.T) {
+	original := bytes.Repeat([]byte{0x90}, 16)
+	saved := imageRecovery{OriginalCode: original, OriginalAddress: 0x1000, FakeEntry: &mapreader.Entry{StartAddress: 0x2000, EndAddress: 0x2010}, Content: []byte{1, 2, 3}}
+	entries := []mapreader.Entry{{StartAddress: 0x1000, EndAddress: 0x1100, Path: vdsoEntryName}, {StartAddress: 0x2000, EndAddress: 0x3000}}
+	p := &simulatedRecoveryProgram{memory: map[uint64][]byte{0x1000: timeJump(0x2000), 0x2000: {1, 2, 3}}}
+	image := NewFakeImage("clock_gettime", []byte{9, 9, 9}, nil, logr.Discard())
+	found, err := image.matchesSavedImage(p, entries, saved)
+	if err != nil || !found {
+		t.Fatalf("failed to recognize injecting build: found=%v err=%v", found, err)
+	}
+	restoreImageRecovery(image, saved)
+	if !bytes.Equal(image.content, saved.Content) {
+		t.Fatal("did not preserve injecting payload on adoption")
+	}
+	p.memory[0x2000] = []byte{9, 9, 9}
+	if _, err := image.matchesSavedImage(p, entries, saved); err == nil {
+		t.Fatal("reported active damaged image as recovered")
+	}
+	if _, err := image.matchesSavedImage(p, entries[:1], saved); err == nil {
+		t.Fatal("reported active unmapped image as recovered")
+	}
+	p.memory[0x1000] = original
+	if found, err := image.matchesSavedImage(p, entries[:1], saved); found || err != nil {
+		t.Fatalf("clean exec should not restore stale addresses: %v %v", found, err)
+	}
+	p.readErr = errors.New("permission denied")
+	if _, err := image.matchesSavedImage(p, entries, saved); err == nil {
+		t.Fatal("swallowed process read failure")
+	}
+}
+
+func TestPersistentTimeChaosRejectsIncompleteProcessRecords(t *testing.T) {
+	for _, process := range []*processRecovery{nil, {Identity: processIdentity{PID: 100, StartTime: "bad"}, ContainerID: "container"}, {Identity: processIdentity{PID: 100, StartTime: "1000"}, ContainerID: "container", ClockGetTime: imageRecovery{OriginalCode: []byte{1}}}} {
+		key := "100:1000"
+		if process != nil {
+			key = processIdentityKey(process.Identity)
+		}
+		if err := validateTimeJournal(&timeJournal{Processes: map[string]*processRecovery{key: process}}); err == nil {
+			t.Fatalf("accepted malformed process %+v", process)
+		}
+	}
+}
+
+func TestPersistentFakeImageTriesAllInheritedCandidates(t *testing.T) {
+	original := bytes.Repeat([]byte{0x90}, 16)
+	first := imageRecovery{OriginalCode: original, OriginalAddress: 0x1000, FakeEntry: &mapreader.Entry{StartAddress: 0x2000, EndAddress: 0x2010}, Content: []byte{1, 2, 3}}
+	second := imageRecovery{OriginalCode: original, OriginalAddress: 0x1000, FakeEntry: &mapreader.Entry{StartAddress: 0x3000, EndAddress: 0x3010}, Content: []byte{4, 5, 6}}
+	entries := []mapreader.Entry{{StartAddress: 0x1000, EndAddress: 0x1100, Path: vdsoEntryName}, {StartAddress: 0x2000, EndAddress: 0x4000}}
+	program := &simulatedRecoveryProgram{memory: map[uint64][]byte{0x1000: timeJump(0x3000), 0x2000: {9, 9, 9}, 0x3000: {4, 5, 6}}}
+	image := NewFakeImage("clock_gettime", []byte{0}, nil, logr.Discard())
+	image.recoveryCandidates = []imageRecovery{first, second}
+	entry, err := image.findSavedImage(program, entries)
+	if err != nil || entry == nil || entry.StartAddress != 0x3000 {
+		t.Fatalf("failed to try matching later candidate: entry=%+v err=%v", entry, err)
+	}
+	image = NewFakeImage("clock_gettime", []byte{0}, nil, logr.Discard())
+	image.recoveryCandidates = []imageRecovery{first}
+	if _, err := image.findSavedImage(program, entries); err == nil {
+		t.Fatal("discarded mismatch error when no candidate matched")
+	}
+}

--- a/pkg/time/processes_linux.go
+++ b/pkg/time/processes_linux.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type timeProcessStat struct {
+	Identity processIdentity
+	Parent   int
+}
+
+func parseTimeProcessStat(pid int, data []byte) (timeProcessStat, error) {
+	// comm is parenthesized and can contain spaces and closing parentheses.
+	end := strings.LastIndexByte(string(data), ')')
+	if end < 0 {
+		return timeProcessStat{}, errors.New("malformed process stat")
+	}
+	fields := strings.Fields(string(data[end+1:]))
+	if len(fields) <= 19 {
+		return timeProcessStat{}, errors.New("truncated process stat")
+	}
+	if fields[0] == "Z" || fields[0] == "X" {
+		return timeProcessStat{}, os.ErrNotExist
+	}
+	parent, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return timeProcessStat{}, errors.Wrap(err, "invalid parent PID")
+	}
+	start, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return timeProcessStat{}, errors.Wrap(err, "invalid process start time")
+	}
+	return timeProcessStat{processIdentity{PID: pid, StartTime: strconv.FormatUint(start, 10)}, parent}, nil
+}
+
+func readProcessIdentity(pid int) (processIdentity, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return processIdentity{}, err
+	}
+	stat, err := parseTimeProcessStat(pid, data)
+	return stat.Identity, err
+}
+
+// Root cgroups are shared by unrelated processes and must not be used to infer
+// container membership. The ancestry walk is still available in that case.
+func isContainerCgroup(cgroup string) bool {
+	nonRoot := false
+	for _, line := range strings.Split(strings.TrimSpace(cgroup), "\n") {
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) != 3 || fields[2] == "" {
+			return false
+		}
+		if fields[2] != "/" {
+			nonRoot = true
+		}
+	}
+	return nonRoot
+}
+
+// Shared non-root cgroups are not sufficient to identify a container. Require
+// its runtime ID as a complete path component or a recognized systemd scope.
+func cgroupNamesContainer(cgroup, containerID string) bool {
+	if _, id, found := strings.Cut(containerID, "://"); found {
+		containerID = id
+	}
+	if len(containerID) < 12 {
+		return false
+	}
+	for _, c := range containerID {
+		if !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') {
+			return false
+		}
+	}
+	for _, line := range strings.Split(strings.TrimSpace(cgroup), "\n") {
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) != 3 {
+			return false
+		}
+		for _, component := range strings.Split(fields[2], "/") {
+			if component == containerID {
+				return true
+			}
+			for _, prefix := range []string{"docker-", "cri-containerd-", "crio-"} {
+				if component == prefix+containerID+".scope" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func enumerateTimeProcesses(procRoot string, leader int, cgroup, containerID string) ([]processIdentity, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	children := make(map[int][]int)
+	identities := make(map[int]processIdentity)
+	members := map[int]bool{leader: true}
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(procRoot, entry.Name(), "stat"))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		stat, err := parseTimeProcessStat(pid, data)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		children[stat.Parent] = append(children[stat.Parent], pid)
+		identities[pid] = stat.Identity
+		if isContainerCgroup(cgroup) && cgroupNamesContainer(cgroup, containerID) {
+			data, err := os.ReadFile(filepath.Join(procRoot, entry.Name(), "cgroup"))
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(string(data)) == strings.TrimSpace(cgroup) {
+				members[pid] = true
+			}
+		}
+	}
+	queue := make([]int, 0, len(members))
+	for member := range members {
+		queue = append(queue, member)
+	}
+	visited := make(map[int]bool)
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		if visited[parent] {
+			continue
+		}
+		visited[parent] = true
+		for _, child := range children[parent] {
+			members[child] = true
+			queue = append(queue, child)
+		}
+	}
+	result := make([]processIdentity, 0, len(members))
+	for pid := range members {
+		if pid != leader {
+			result = append(result, identities[pid])
+		}
+	}
+	return result, nil
+}

--- a/pkg/time/processes_linux_test.go
+++ b/pkg/time/processes_linux_test.go
@@ -1,0 +1,99 @@
+// Copyright 2021 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package time
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func processStatFixture(pid, parent int, comm string) []byte {
+	fields := []string{"S", fmt.Sprint(parent)}
+	for len(fields) < 19 {
+		fields = append(fields, "0")
+	}
+	fields = append(fields, "1234")
+	return []byte(fmt.Sprintf("%d (%s) %s", pid, comm, strings.Join(fields, " ")))
+}
+
+func TestPersistentProcessStatHandlesSpacesAndParentheses(t *testing.T) {
+	stat, err := parseTimeProcessStat(10, processStatFixture(10, 2, "a worker) name"))
+	if err != nil || stat.Parent != 2 || stat.Identity.StartTime != "1234" {
+		t.Fatalf("stat=%+v err=%v", stat, err)
+	}
+	if _, err := parseTimeProcessStat(10, []byte("10 (truncated) S 2")); err == nil {
+		t.Fatal("accepted truncated stat")
+	}
+}
+
+func TestPersistentProcessDiscoveryPreservesAncestryAndContainerBoundary(t *testing.T) {
+	root := t.TempDir()
+	id := strings.Repeat("a", 64)
+	cgroup := "5:memory:/kubepods/" + id + "\n4:rdma:/\n"
+	add := func(pid, parent int, cg string) {
+		path := filepath.Join(root, fmt.Sprint(pid))
+		if err := os.Mkdir(path, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "stat"), processStatFixture(pid, parent, "worker with spaces)"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "cgroup"), []byte(cg), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add(100, 1, cgroup)
+	add(101, 100, cgroup)
+	add(102, 101, "0::/nested\n")
+	add(103, 1, cgroup)
+	add(104, 103, "0::/nested\n")
+	add(200, 1, "0::/unrelated\n")
+	selected, err := enumerateTimeProcesses(root, 100, cgroup, "containerd://"+id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pids []int
+	for _, identity := range selected {
+		pids = append(pids, identity.PID)
+		if identity.StartTime != "1234" {
+			t.Fatal("lost selected identity")
+		}
+	}
+	sort.Ints(pids)
+	if !reflect.DeepEqual(pids, []int{101, 102, 103, 104}) {
+		t.Fatalf("wrong process selection: %v", pids)
+	}
+	selected, err = enumerateTimeProcesses(root, 100, cgroup, "containerd://"+strings.Repeat("b", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pids = nil
+	for _, identity := range selected {
+		pids = append(pids, identity.PID)
+	}
+	sort.Ints(pids)
+	if !reflect.DeepEqual(pids, []int{101, 102}) {
+		t.Fatalf("expanded into unverified shared cgroup: %v", pids)
+	}
+	if isContainerCgroup("0::/\n") || isContainerCgroup("") {
+		t.Fatal("accepted root cgroup")
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

A daemon restart discards the task manager and the original vDSO bytes for active TimeChaos experiments. The application processes keep their time offsets, but duration expiry or deletion cannot recover them because the replacement daemon returns `TaskID not found`.

Related to #3454, which reports that recovery error; this PR specifically addresses daemon replacement after an injection completed.

## What's changed and how does it work?

Persist desired task configurations and per-process restoration snapshots on the node through the existing `/host-run` mount. Record original clock instructions before modifying them and replace journals atomically. Per-container file locks serialize daemon instances.

Reconcile task UIDs idempotently and recompute the remaining aggregate when one overlapping experiment recovers. Validate boot/process identity and the recorded instructions and payload before restoring a process. Keep recovery scoped to saved targets, descendants, and verified container cgroups, including when an application container is replaced.

Keep an intermediate controller record phase after an ambiguous injection RPC failure so stop/delete cannot skip recovery. Failed applies restore the previous desired task set and attempt rollback. Recovery confirms Pod deletion before clearing cleanup responsibility; transient API errors and temporarily missing container status keep recovery pending.

## Validation

Passed on Linux arm64 with Go 1.25.12 and CGO enabled:

- `go test -mod=readonly -race ./pkg/time ./controllers/chaosimpl/timechaos -run '^(TestPersistent|TestTimeChaos)' -count=1`
- `go vet -mod=readonly ./pkg/time ./controllers/chaosimpl/timechaos ./pkg/chaosdaemon`
- `go test -mod=readonly ./pkg/chaosdaemon -run '^$'` (compile only)
- Focused `goimports` and `git diff --check`. Focused `revive` completed with no errors and documentation/naming/unused-parameter warnings.

Regression tests recreate the coordinator against its saved journal, exercise overlapping tasks and request retries, preserve failed child recovery, handle container replacement and PID reuse, validate saved images across daemon builds, and keep cleanup pending after a lost RPC response. Recovery regression tests use the real container-record decoder with fake Kubernetes clients to distinguish API timeouts, forbidden reads, missing container status, missing target containers, and confirmed Pod deletion. The four non-deletion cases failed before the correction and pass afterward. Process and clock-image tests use controlled fakes; no live ptrace or Kubernetes fault-injection tests were run.

## Downsides

Journaling adds synchronous host I/O to injection and recovery. Recovery snapshots and completed-task markers are retained for retries; long-lived containers with many experiments or processes can accumulate state, and this draft does not add journal garbage collection.

An injection RPC error remains pending because the controller cannot reliably distinguish a rejected request from an applied request whose response was lost. Under the common records state machine, stopping such an experiment retries Apply before Recover. A persistent injection failure can therefore retain the experiment finalizer; this draft prioritizes retaining cleanup responsibility over declaring uncertain targets recovered. Recovery also stays pending while the Pod still exists but the target container cannot be resolved; it can finish when the container becomes available or the Pod is confirmed deleted.

## Risk and rollback

This changes only Kubernetes TimeChaos handling and the shared clock-image restoration logic. Existing experiments injected before this version have no durable originals and cannot be recovered retroactively by the journal. Finish those experiments before upgrading. Custom daemon deployments must provide persistent, writable storage at `/host-run/chaos-daemon/timechaos`.

The fix covers completed injections followed by daemon replacement. It does not make arbitrary daemon death during a ptrace syscall or instruction write atomic for the target process.

Watch for journal errors, failed recovery events, and increased injection latency. Recover all active TimeChaos experiments before reverting/redeploying an older daemon, because older versions cannot consume the new recovery state. Keep the journal files while any associated recovery remains outstanding.

## Related changes

- [ ] This change also requires further updates to the UI interface

## Checklist

### CHANGELOG

- [x] I have updated `CHANGELOG.md`

### Tests

- [x] Unit test
- [ ] E2E test
- [ ] Manual cluster test

### Side effects

- [x] New persistent recovery state; finish active experiments before changing between old and new daemon versions

## DCO

Commits are signed off.
