### PR TITLE
fix(bpm): release identifiers after failed process starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Release background process identifiers after failed startup so chaos injection can be retried, and stop children whose process metadata cannot be read.
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/pkg/bpm/bpm.go
+++ b/pkg/bpm/bpm.go
@@ -119,7 +119,7 @@ type BackgroundProcessManager struct {
 	metricsCollector *metricsCollector
 }
 
-func startProcess(cmd *ManagedCommand) (*Process, error) {
+func startProcess(cmd *ManagedCommand) (_ *Process, err error) {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, errors.Wrap(err, "create stdin pipe")
@@ -134,14 +134,20 @@ func startProcess(cmd *ManagedCommand) (*Process, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "start command `%s`", cmd.String())
 	}
+	defer func() {
+		if err != nil {
+			// Registration can still fail while reading process metadata. Stop
+			// and reap the child before its identifier becomes available again.
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
 
 	newProcess := &Process{
 		Uid:   uuid.NewString(),
 		Cmd:   cmd,
 		Pipes: Pipes{Stdin: stdin, Stdout: stdout},
 	}
-
-	newProcess.ctx, newProcess.stopped = context.WithCancel(context.Background())
 
 	// keep compatible with v2.x
 	// TODO: remove in v3.x
@@ -160,6 +166,7 @@ func startProcess(cmd *ManagedCommand) (*Process, error) {
 		Pid:        int(proc.Pid),
 		CreateTime: ct,
 	}
+	newProcess.ctx, newProcess.stopped = context.WithCancel(context.Background())
 	return newProcess, nil
 }
 
@@ -218,6 +225,9 @@ func (m *BackgroundProcessManager) StartProcess(ctx context.Context, cmd *Manage
 
 	process, err := startProcess(cmd)
 	if err != nil {
+		if cmd.Identifier != nil {
+			m.identifiers.Delete(*cmd.Identifier)
+		}
 		return nil, err
 	}
 

--- a/pkg/bpm/bpm_linux_test.go
+++ b/pkg/bpm/bpm_linux_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bpm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestStartProcessCleansUpWhenMetadataFails(t *testing.T) {
+	// gopsutil reads process metadata from HOST_PROC on Linux. An empty
+	// directory makes CreateTime fail after the child has started.
+	t.Setenv("HOST_PROC", t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := StartBackgroundProcessManager(nil, logr.Discard())
+	defer m.Shutdown(context.Background())
+	cmd := DefaultProcessBuilder("sleep", "30").
+		SetIdentifier("metadata-failure").
+		SetContext(ctx).
+		Build(ctx)
+	defer func() {
+		// Reap the child even when the regression makes this test fail.
+		if cmd.Process != nil && cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
+
+	proc, err := m.StartProcess(ctx, cmd)
+	if err == nil || !strings.Contains(err.Error(), "get process create time") {
+		t.Fatalf("expected a process metadata error, got process %v and error %v", proc, err)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("startup failure left the child running or unreaped")
+	}
+	if identifiers := m.GetIdentifiers(); len(identifiers) != 0 {
+		t.Fatalf("startup failure retained identifiers: %v", identifiers)
+	}
+}

--- a/pkg/bpm/bpm_test.go
+++ b/pkg/bpm/bpm_test.go
@@ -18,7 +18,9 @@ package bpm
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -51,6 +53,67 @@ func WaitProcess(m *BackgroundProcessManager, proc *Process, exceedTime time.Dur
 var _ = Describe("background process manager", func() {
 	logger := log.NewZapLoggerWithWriter(GinkgoWriter)
 	m := StartBackgroundProcessManager(nil, logger)
+
+	Context("failed startup", func() {
+		DescribeTable("releases the identifier for a retry", func(prepare func(*ManagedCommand)) {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+			identifier := RandomeIdentifier()
+			cmd := DefaultProcessBuilder("sleep", "30").
+				SetIdentifier(identifier).
+				SetContext(ctx).
+				Build(ctx)
+			prepare(cmd)
+
+			proc, err := m.StartProcess(ctx, cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(proc).To(BeNil())
+			Expect(m.GetIdentifiers()).NotTo(ContainElement(identifier))
+
+			retry := DefaultProcessBuilder("sleep", "30").
+				SetIdentifier(identifier).
+				SetContext(ctx).
+				Build(ctx)
+			proc, err = m.StartProcess(ctx, retry)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m.KillBackgroundProcess(ctx, proc.Uid)).To(Succeed())
+		},
+			Entry("when stdin is already configured", func(cmd *ManagedCommand) {
+				cmd.Stdin = strings.NewReader("")
+			}),
+			Entry("when stdout is already configured", func(cmd *ManagedCommand) {
+				cmd.Stdout = io.Discard
+			}),
+			Entry("when the executable does not exist", func(cmd *ManagedCommand) {
+				cmd.Path = filepath.Join(GinkgoT().TempDir(), "missing-executable")
+			}),
+		)
+
+		It("keeps the live owner's identifier after duplicate attempts", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+			identifier := RandomeIdentifier()
+			cmd := DefaultProcessBuilder("sleep", "30").
+				SetIdentifier(identifier).
+				SetContext(ctx).
+				Build(ctx)
+			proc, err := m.StartProcess(ctx, cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := 0; i < 2; i++ {
+				duplicate := DefaultProcessBuilder("sleep", "30").
+					SetIdentifier(identifier).
+					SetContext(ctx).
+					Build(ctx)
+				_, err := m.StartProcess(ctx, duplicate)
+				Expect(err).To(MatchError(fmt.Sprintf("process with identifier %s is running", identifier)))
+				Expect(duplicate.Process).To(BeNil())
+				Expect(m.GetIdentifiers()).To(ContainElement(identifier))
+			}
+
+			Expect(m.KillBackgroundProcess(ctx, proc.Uid)).To(Succeed())
+		})
+	})
 
 	Context("normally exited process", func() {
 		It("should work", func() {


### PR DESCRIPTION
## What problem does this PR solve?

A failed background-process startup reserves its identifier indefinitely. Later HTTPChaos or IOChaos requests for the same container fail with "process with identifier ... is running", even when no process exists. This can turn a transient startup failure into a persistent injection failure.

## What's changed and how does it work?

Release the identifier when startup fails after this call acquired it. Duplicate requests still preserve the live owner's reservation. If the child starts but process-metadata lookup fails, terminate and reap it before releasing the identifier.

## Validation and reproduction

Added regression tests for stdin/stdout setup failures, a missing executable, failed process metadata lookup, and repeated duplicate requests against a live owner. The startup regressions failed on the base revision and pass with this change.

Passed on Linux arm64 with Go 1.25.12:

```sh
go test -race ./pkg/bpm -count=1
go vet ./pkg/bpm
```

Focused goimports and git diff --check passed. Tests start only harmless local sleep processes and clean them up; no Kubernetes experiments were run.

## Risk and rollback

This affects shared background-process startup, including HTTPChaos and IOChaos helper processes. Successful registrations and live-owner exclusion retain their current behavior. On metadata failure, the newly started child is now killed and reaped before another request may reuse the identifier; cleanup can wait for the child to exit.

Watch for startup failures and missing or unexpected helper processes. Revert and redeploy the daemon to roll back. There are no API, CRD, or persistent-state changes.

## Related changes

- [ ] This change requires UI or website updates

## Checklist

- [x] Updated CHANGELOG.md
- [x] Unit tests
- [ ] E2E tests

## DCO

Commits are signed off.
