### PR TITLE
fix(stresschaos): roll back CPU on memory startup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Stop CPU stressors when memory stressor startup fails in a combined StressChaos request.
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 
 	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/cgroups"
@@ -30,22 +31,44 @@ import (
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/util"
 )
 
+const stressRollbackTimeout = 10 * time.Second
+
+type stressorExecutor interface {
+	ExecCPUStressors(context.Context, *pb.ExecStressRequest) (*bpm.Process, error)
+	ExecMemoryStressors(context.Context, *pb.ExecStressRequest) (*bpm.Process, error)
+	CancelStressors(context.Context, *pb.CancelStressRequest) (*empty.Empty, error)
+}
+
 func (s *DaemonServer) ExecStressors(ctx context.Context,
 	req *pb.ExecStressRequest) (*pb.ExecStressResponse, error) {
 	log := s.getLoggerFromContext(ctx)
 	log.Info("Executing stressors", "request", req)
 
-	// cpuStressors
-	cpuProc, err := s.ExecCPUStressors(ctx, req)
+	resp, err := execStressors(ctx, req, s)
 	if err != nil {
-		// this error would be resolved by grpc server framework, it's the top level to print it.
-		s.rootLogger.Error(err, "exec cpu stressors", "containerID", req.Target, "cpuStressors", req.CpuStressors)
+		log.Error(err, "exec stressors", "containerID", req.Target)
+	}
+	return resp, err
+}
+
+func execStressors(ctx context.Context, req *pb.ExecStressRequest, executor stressorExecutor) (*pb.ExecStressResponse, error) {
+	cpuProc, err := executor.ExecCPUStressors(ctx, req)
+	if err != nil {
 		return nil, err
 	}
 
-	// memoryStressor
-	memoryProc, err := s.ExecMemoryStressors(ctx, req)
+	memoryProc, err := executor.ExecMemoryStressors(ctx, req)
 	if err != nil {
+		if cpuProc != nil {
+			// No process handles reach the controller on failure. Stop the CPU
+			// worker even if cancellation of the request caused memory startup to fail.
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stressRollbackTimeout)
+			defer cancel()
+			_, cleanupErr := executor.CancelStressors(cleanupCtx, &pb.CancelStressRequest{CpuInstanceUid: cpuProc.Uid})
+			if cleanupErr != nil {
+				return nil, errors.Wrapf(err, "roll back CPU stressor %s: %v", cpuProc.Uid, cleanupErr)
+			}
+		}
 		return nil, err
 	}
 

--- a/pkg/chaosdaemon/stress_server_linux_test.go
+++ b/pkg/chaosdaemon/stress_server_linux_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chaosdaemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+)
+
+type fakeStressorExecutor struct {
+	cpu             *bpm.Process
+	memory          *bpm.Process
+	cpuErr          error
+	memoryErr       error
+	cleanupErr      error
+	memoryCalls     int
+	runningCPU      int
+	cleanupRequests []*pb.CancelStressRequest
+	checkCleanup    func(context.Context)
+}
+
+func (f *fakeStressorExecutor) ExecCPUStressors(context.Context, *pb.ExecStressRequest) (*bpm.Process, error) {
+	if f.cpu != nil && f.cpuErr == nil {
+		f.runningCPU++
+	}
+	return f.cpu, f.cpuErr
+}
+
+func (f *fakeStressorExecutor) ExecMemoryStressors(context.Context, *pb.ExecStressRequest) (*bpm.Process, error) {
+	f.memoryCalls++
+	return f.memory, f.memoryErr
+}
+
+func (f *fakeStressorExecutor) CancelStressors(ctx context.Context, req *pb.CancelStressRequest) (*empty.Empty, error) {
+	if f.checkCleanup != nil {
+		f.checkCleanup(ctx)
+	}
+	f.cleanupRequests = append(f.cleanupRequests, req)
+	if f.cleanupErr == nil && f.cpu != nil && req.CpuInstanceUid == f.cpu.Uid {
+		f.runningCPU--
+	}
+	return &empty.Empty{}, f.cleanupErr
+}
+
+func TestExecStressorsRollsBackCPUOnMemoryFailure(t *testing.T) {
+	startupErr := errors.New("memory startup failed")
+	executor := &fakeStressorExecutor{
+		cpu:       &bpm.Process{Uid: "cpu-uid", Pair: bpm.ProcessPair{Pid: 123, CreateTime: 456}},
+		memoryErr: startupErr,
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		resp, err := execStressors(context.Background(), &pb.ExecStressRequest{}, executor)
+		if resp != nil || !errors.Is(err, startupErr) {
+			t.Fatalf("unexpected response: %+v, error: %v", resp, err)
+		}
+		if executor.runningCPU != 0 {
+			t.Fatalf("attempt %d left %d CPU workers", attempt, executor.runningCPU)
+		}
+	}
+	if len(executor.cleanupRequests) != 3 {
+		t.Fatalf("expected cleanup after each attempt, got %d", len(executor.cleanupRequests))
+	}
+	for _, req := range executor.cleanupRequests {
+		if req.CpuInstanceUid != "cpu-uid" || req.MemoryInstanceUid != "" || req.CpuInstance != "" {
+			t.Fatalf("cleanup did not use the CPU process UID: %+v", req)
+		}
+	}
+}
+
+func TestExecStressorsRollbackSurvivesCanceledRequest(t *testing.T) {
+	type contextKey struct{}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey{}, "request"))
+	cancel()
+	checked := false
+	executor := &fakeStressorExecutor{
+		cpu:       &bpm.Process{Uid: "cpu-uid"},
+		memoryErr: context.Canceled,
+		checkCleanup: func(cleanupCtx context.Context) {
+			checked = true
+			if cleanupCtx.Err() != nil || cleanupCtx.Value(contextKey{}) != "request" {
+				t.Fatalf("cleanup inherited cancellation or lost request context: %v", cleanupCtx.Err())
+			}
+			deadline, ok := cleanupCtx.Deadline()
+			if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stressRollbackTimeout {
+				t.Fatalf("cleanup has no bounded independent deadline: %v", deadline)
+			}
+		},
+	}
+	_, err := execStressors(ctx, &pb.ExecStressRequest{}, executor)
+	if !checked || !errors.Is(err, context.Canceled) || executor.runningCPU != 0 {
+		t.Fatalf("cleanup failed: checked=%v err=%v running=%d", checked, err, executor.runningCPU)
+	}
+}
+
+func TestExecStressorsReportsRollbackFailure(t *testing.T) {
+	startupErr := errors.New("memory startup failed")
+	executor := &fakeStressorExecutor{
+		cpu:        &bpm.Process{Uid: "cpu-uid"},
+		memoryErr:  startupErr,
+		cleanupErr: errors.New("stop timed out"),
+	}
+	resp, err := execStressors(context.Background(), &pb.ExecStressRequest{}, executor)
+	if resp != nil || !errors.Is(err, startupErr) || !strings.Contains(err.Error(), "cpu-uid") || !strings.Contains(err.Error(), "stop timed out") {
+		t.Fatalf("startup or cleanup error lost: response=%+v err=%v", resp, err)
+	}
+}
+
+func TestExecStressorsDoesNotCancelUnstartedWorkers(t *testing.T) {
+	startupErr := errors.New("startup failed")
+	for _, tc := range []struct {
+		name        string
+		executor    fakeStressorExecutor
+		memoryCalls int
+	}{
+		{name: "CPU failed", executor: fakeStressorExecutor{cpuErr: startupErr}},
+		{name: "memory only failed", executor: fakeStressorExecutor{memoryErr: startupErr}, memoryCalls: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := execStressors(context.Background(), &pb.ExecStressRequest{}, &tc.executor)
+			if resp != nil || !errors.Is(err, startupErr) || len(tc.executor.cleanupRequests) != 0 || tc.executor.memoryCalls != tc.memoryCalls {
+				t.Fatalf("unexpected startup/cleanup: response=%+v err=%v executor=%+v", resp, err, tc.executor)
+			}
+		})
+	}
+}
+
+func TestExecStressorsSuccessfulResponsePreservesHandles(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cpu    *bpm.Process
+		memory *bpm.Process
+	}{
+		{name: "both", cpu: &bpm.Process{Uid: "cpu", Pair: bpm.ProcessPair{Pid: 12, CreateTime: 34}}, memory: &bpm.Process{Uid: "memory", Pair: bpm.ProcessPair{Pid: 56, CreateTime: 78}}},
+		{name: "CPU only", cpu: &bpm.Process{Uid: "cpu", Pair: bpm.ProcessPair{Pid: 12, CreateTime: 34}}},
+		{name: "memory only", memory: &bpm.Process{Uid: "memory", Pair: bpm.ProcessPair{Pid: 56, CreateTime: 78}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeStressorExecutor{cpu: tc.cpu, memory: tc.memory}
+			resp, err := execStressors(context.Background(), &pb.ExecStressRequest{}, executor)
+			if err != nil || resp == nil || len(executor.cleanupRequests) != 0 {
+				t.Fatalf("successful startup rolled back: response=%+v err=%v", resp, err)
+			}
+			if tc.cpu != nil && (resp.CpuInstance != "12" || resp.CpuStartTime != 34 || resp.CpuInstanceUid != "cpu") {
+				t.Fatalf("CPU handle changed: %+v", resp)
+			}
+			if tc.memory != nil && (resp.MemoryInstance != "56" || resp.MemoryStartTime != 78 || resp.MemoryInstanceUid != "memory") {
+				t.Fatalf("memory handle changed: %+v", resp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

A combined StressChaos request can start CPU workers successfully and then fail to start memory workers. ExecStressors returns an error without returning the CPU handle, so the controller records NotInjected and subsequent retries can start more CPU workers. Stopping the experiment cannot recover those unrecorded workers.

## What's changed and how does it work?

Cancel the successfully started CPU process by its BPM UID before returning a memory-startup error. Cleanup uses an independent 10-second context so a canceled or expired injection request does not skip shutdown. Preserve the original startup error and include the worker UID and cleanup error if rollback fails.

A private executor interface allows the actual orchestration to be tested without starting stress processes. Successful CPU-only, memory-only and combined responses preserve their existing handles. This change is independent of #4950, which addresses errors during normal controller recovery.

## Validation and reproduction

Passed on Linux arm64 with Go 1.25.12 and CGO enabled:

```sh
go test -mod=readonly -race ./pkg/chaosdaemon -run '^TestExecStressors' -count=1
go vet -mod=readonly ./pkg/chaosdaemon
```

Regression tests cover three failed attempts without accumulating CPU workers, cleanup after request cancellation, reported rollback failure, startup paths without a CPU worker, and successful responses. Focused goimports and git diff --check passed. Tests use in-memory worker fakes; no live stress or Kubernetes experiments were run.

## Downsides

A failed combined startup can now take up to 10 additional seconds while CPU shutdown is attempted. If shutdown also fails or times out, the request returns an error identifying the incomplete rollback; this change cannot guarantee termination of an unresponsive worker.

## Risk and rollback

The behavior change is limited to a completed CPU startup followed by a memory-startup error. Failures inside the individual startup routines, lost successful RPC responses, and daemon restarts remain separate lifecycle concerns.

Watch for rollback errors and increased latency on failed combined injections. Revert and redeploy the daemon to roll back. No API, CRD, or persistent-state migration is needed.

## Related changes

- [ ] This change requires UI or website updates

## Checklist

- [x] Updated CHANGELOG.md
- [x] Unit tests
- [ ] E2E tests

## DCO

Commits are signed off.
