### PR TITLE
fix(networkchaos): isolate generated rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Prevent NetworkChaos experiments with the same name in different namespaces from sharing IP sets and iptables chains on a pod. Existing stored rule names remain valid until the experiment is recovered or reapplied.
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/controllers/podnetworkchaos/ipset/ipset.go
+++ b/controllers/podnetworkchaos/ipset/ipset.go
@@ -95,7 +95,7 @@ func BuildSetIPSet(sets []v1alpha1.RawIPSet, networkchaos *v1alpha1.NetworkChaos
 
 // GenerateIPSetName generates name for ipset
 func GenerateIPSetName(networkchaos *v1alpha1.NetworkChaos, namePostFix string) string {
-	return netutils.CompressName(networkchaos.Name, 27, namePostFix)
+	return netutils.GenerateRuleName(networkchaos.Namespace, networkchaos.Name, namePostFix, 27)
 }
 
 // FlushIPSets makes grpc calls to chaosdaemon to save ipset

--- a/controllers/podnetworkchaos/ipset/ipset_test.go
+++ b/controllers/podnetworkchaos/ipset/ipset_test.go
@@ -16,41 +16,50 @@
 package ipset
 
 import (
+	"strings"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 )
 
-func Test_generateIPSetName(t *testing.T) {
-	g := NewWithT(t)
-	postfix := "alongpostfix"
-
-	t.Run("name with postfix", func(t *testing.T) {
-		chaosName := "test"
-
-		networkChaos := &v1alpha1.NetworkChaos{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: chaosName,
-			},
+func TestGenerateIPSetName(t *testing.T) {
+	identities := []types.NamespacedName{
+		{Namespace: "team-a", Name: "isolate"},
+		{Namespace: "team-b", Name: "isolate"},
+		{Namespace: "a", Name: "b-c"},
+		{Namespace: "a-b", Name: "c"},
+		{Namespace: "a", Name: "b"},
+		{Namespace: "b", Name: "b"},
+		{Namespace: strings.Repeat("n", 63), Name: strings.Repeat("a", 253)},
+		{Namespace: strings.Repeat("n", 63), Name: strings.Repeat("a", 252) + "b"},
+	}
+	seen := map[string]string{}
+	for _, identity := range identities {
+		chaos := &v1alpha1.NetworkChaos{ObjectMeta: metav1.ObjectMeta{
+			Namespace: identity.Namespace,
+			Name:      identity.Name,
+		}}
+		for _, role := range []string{"src", "tgt", "nesrc", "netgt", "basrc", "batgt"} {
+			for _, setType := range []string{"net_", "netport_", "set_"} {
+				postfix := setType + role
+				name := GenerateIPSetName(chaos, postfix)
+				if len(name) > 27 || len(name+"old") > 31 {
+					t.Fatalf("IP set name %q exceeds the daemon's name limits", name)
+				}
+				if previous, ok := seen[name]; ok {
+					t.Fatalf("IP set name %q is shared by %s and %s/%s", name, previous, identity, postfix)
+				}
+				seen[name] = identity.String() + "/" + postfix
+				// Names follow namespace/name ownership and do not depend on a UID.
+				recreated := chaos.DeepCopy()
+				recreated.UID = "replacement-uid"
+				if GenerateIPSetName(recreated, postfix) != name {
+					t.Fatal("IP set name changed for the same namespace/name")
+				}
+			}
 		}
-
-		name := GenerateIPSetName(networkChaos, postfix)
-
-		g.Expect(name).Should(Equal(chaosName + "_" + postfix))
-	})
-
-	t.Run("length equal 27", func(t *testing.T) {
-		networkChaos := &v1alpha1.NetworkChaos{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-metav1object",
-			},
-		}
-
-		name := GenerateIPSetName(networkChaos, postfix)
-
-		g.Expect(len(name)).Should(Equal(27))
-	})
+	}
 }

--- a/controllers/podnetworkchaos/iptable/iptable.go
+++ b/controllers/podnetworkchaos/iptable/iptable.go
@@ -69,9 +69,9 @@ func SetIptablesChains(ctx context.Context, pbClient chaosdaemonclient.ChaosDaem
 func GenerateName(direction pb.Chain_Direction, networkchaos *v1alpha1.NetworkChaos) (chainName string) {
 	switch direction {
 	case pb.Chain_INPUT:
-		chainName = "INPUT/" + netutils.CompressName(networkchaos.Name, 21, "")
+		chainName = "INPUT/" + netutils.GenerateRuleName(networkchaos.Namespace, networkchaos.Name, "", 21)
 	case pb.Chain_OUTPUT:
-		chainName = "OUTPUT/" + netutils.CompressName(networkchaos.Name, 20, "")
+		chainName = "OUTPUT/" + netutils.GenerateRuleName(networkchaos.Namespace, networkchaos.Name, "", 20)
 	}
 
 	return

--- a/controllers/podnetworkchaos/iptable/iptable_test.go
+++ b/controllers/podnetworkchaos/iptable/iptable_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package iptable
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+)
+
+func TestGenerateName(t *testing.T) {
+	seen := map[string]bool{}
+	for _, namespace := range []string{"team-a", "team-b"} {
+		for _, name := range []string{"a", "isolate", strings.Repeat("a", 253)} {
+			chaos := &v1alpha1.NetworkChaos{ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			}}
+			for _, direction := range []pb.Chain_Direction{pb.Chain_INPUT, pb.Chain_OUTPUT} {
+				chain := GenerateName(direction, chaos)
+				if len(chain) > 27 || !strings.HasPrefix(chain, direction.String()+"/") {
+					t.Fatalf("invalid chain name %q for %s", chain, direction)
+				}
+				if seen[chain] {
+					t.Fatalf("duplicate chain name %q for %s/%s", chain, namespace, name)
+				}
+				seen[chain] = true
+				recreated := chaos.DeepCopy()
+				recreated.UID = "replacement-uid"
+				if GenerateName(direction, recreated) != chain {
+					t.Fatal("chain name changed for the same namespace/name")
+				}
+			}
+		}
+	}
+}

--- a/controllers/podnetworkchaos/netutils/len.go
+++ b/controllers/podnetworkchaos/netutils/len.go
@@ -17,9 +17,20 @@ package netutils
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 )
+
+// GenerateRuleName hashes a namespaced resource and a rule suffix into a kernel
+// object name. length must be between 1 and 64. The full name budget is used for
+// the hash so that long suffixes do not reduce the collision resistance.
+func GenerateRuleName(namespace, name, suffix string, length int) string {
+	// Match RawRuleSource's namespace/name ownership, including across recreation
+	// of the resource. Kubernetes names cannot contain the separating slashes.
+	sum := sha256.Sum256([]byte(namespace + "/" + name + "/" + suffix))
+	return hex.EncodeToString(sum[:])[:length]
+}
 
 // CompressName compresses name to targetLength with specified postfix
 // targetLength < 7 or targetLength-7-len(namePostFix) < 0 are not allowed

--- a/controllers/podnetworkchaos/networkchaos_identity_test.go
+++ b/controllers/podnetworkchaos/networkchaos_identity_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package podnetworkchaos
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/networkchaos/partition"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/networkchaos/podnetworkchaosmanager"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/networkchaos/trafficcontrol"
+	impltypes "github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/types"
+	"github.com/chaos-mesh/chaos-mesh/controllers/podnetworkchaos/netutils"
+	daemonclient "github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/client"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+)
+
+// Exercise the real Apply/Recover transactions and the pod controller's RPC
+// conversion. The fake daemon records requests without running network commands.
+func TestNetworkChaosRuleIdentity(t *testing.T) {
+	for _, action := range []v1alpha1.NetworkChaosAction{v1alpha1.PartitionAction, v1alpha1.DelayAction} {
+		for _, legacy := range []bool{false, true} {
+			name := string(action) + "/new-rules"
+			if legacy {
+				name = string(action) + "/persisted-legacy-rules"
+			}
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+				scheme := runtime.NewScheme()
+				if err := corev1.AddToScheme(scheme); err != nil {
+					t.Fatal(err)
+				}
+				if err := v1alpha1.AddToScheme(scheme); err != nil {
+					t.Fatal(err)
+				}
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "workload", Name: "pod"},
+					Status: corev1.PodStatus{
+						Phase:             corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{{ContainerID: "containerd://test"}},
+					},
+				}
+				c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+				builder := podnetworkchaosmanager.NewBuilder(podnetworkchaosmanager.Params{
+					Client: c, Reader: c, Scheme: scheme, Logger: logr.Discard(),
+				})
+				var impl impltypes.ChaosImpl = partition.NewImpl(c, builder, logr.Discard())
+				if action == v1alpha1.DelayAction {
+					impl = trafficcontrol.NewImpl(c, builder, logr.Discard())
+				}
+				first := &v1alpha1.NetworkChaos{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "isolate", UID: "first"},
+					Spec: v1alpha1.NetworkChaosSpec{
+						Action: action, Direction: v1alpha1.To, ExternalTargets: []string{"192.0.2.1"},
+						TcParameter: v1alpha1.TcParameter{Delay: &v1alpha1.DelaySpec{Latency: "10ms", Jitter: "0ms", Correlation: "0"}},
+					},
+				}
+				second := first.DeepCopy()
+				second.Namespace, second.UID = "team-b", "second"
+				second.Spec.ExternalTargets = []string{"192.0.2.2"}
+				records := []*v1alpha1.Record{{Id: "workload/pod", SelectorKey: ".", Phase: v1alpha1.NotInjected}}
+				read := func() *v1alpha1.PodNetworkChaos {
+					t.Helper()
+					obj := &v1alpha1.PodNetworkChaos{}
+					if err := c.Get(ctx, client.ObjectKeyFromObject(pod), obj); err != nil {
+						t.Fatal(err)
+					}
+					return obj
+				}
+				apply := func(chaos *v1alpha1.NetworkChaos) {
+					t.Helper()
+					phase, err := impl.Apply(ctx, 0, records, chaos)
+					if err != nil || phase != "Not Injected/Wait" {
+						t.Fatalf("Apply returned phase %q, error %v", phase, err)
+					}
+				}
+				apply(first)
+				obj := read()
+				if legacy {
+					useLegacyRuleNames(obj, first.Name, action)
+					if err := c.Update(ctx, obj); err != nil {
+						t.Fatal(err)
+					}
+				}
+				firstSpec := rulesFromSource(obj.Spec, "team-a/isolate")
+				apply(second)
+				obj = read()
+				if !reflect.DeepEqual(rulesFromSource(obj.Spec, "team-a/isolate"), firstSpec) {
+					t.Fatal("adding the second experiment changed the first experiment's stored rules")
+				}
+				if len(obj.Spec.IPSets) != 6 || len(obj.Spec.Iptables)+len(obj.Spec.TrafficControls) != 2 {
+					t.Fatalf("expected two independent experiments, got %#v", obj.Spec)
+				}
+				assertIndependentNetworkRules(t, obj.Spec)
+				assertNetworkRuleRequests(t, pod, obj)
+
+				// Retrying an injection replaces only that source's rules.
+				beforeRetry := obj.Spec.DeepCopy()
+				apply(second)
+				obj = read()
+				if !reflect.DeepEqual(&obj.Spec, beforeRetry) {
+					t.Fatal("retrying Apply changed the stored rules")
+				}
+
+				// Recovery identifies ownership by Source, including legacy names.
+				secondSpec := rulesFromSource(obj.Spec, "team-b/isolate")
+				records[0].Phase = v1alpha1.Injected
+				phase, err := impl.Recover(ctx, 0, records, first)
+				if err != nil || phase != "Injected/Wait" {
+					t.Fatalf("Recover returned phase %q, error %v", phase, err)
+				}
+				obj = read()
+				if !reflect.DeepEqual(obj.Spec, secondSpec) {
+					t.Fatalf("recovery did not preserve only the second experiment: %#v", obj.Spec)
+				}
+				assertNetworkRuleRequests(t, pod, obj)
+			})
+		}
+	}
+}
+
+func rulesFromSource(spec v1alpha1.PodNetworkChaosSpec, source string) v1alpha1.PodNetworkChaosSpec {
+	result := v1alpha1.PodNetworkChaosSpec{}
+	for _, set := range spec.IPSets {
+		if set.Source == source {
+			result.IPSets = append(result.IPSets, set)
+		}
+	}
+	for _, chain := range spec.Iptables {
+		if chain.Source == source {
+			result.Iptables = append(result.Iptables, chain)
+		}
+	}
+	for _, tc := range spec.TrafficControls {
+		if tc.Source == source {
+			result.TrafficControls = append(result.TrafficControls, tc)
+		}
+	}
+	return result
+}
+
+func useLegacyRuleNames(obj *v1alpha1.PodNetworkChaos, name string, action v1alpha1.NetworkChaosAction) {
+	postfix := "tgt"
+	if action == v1alpha1.DelayAction {
+		postfix = "netgt"
+	}
+	names := map[string]string{}
+	for i := range obj.Spec.IPSets {
+		set := &obj.Spec.IPSets[i]
+		prefix := map[v1alpha1.IPSetType]string{
+			v1alpha1.NetIPSet: "net_", v1alpha1.NetPortIPSet: "netport_", v1alpha1.SetIPSet: "set_",
+		}[set.IPSetType]
+		legacy := netutils.CompressName(name, 27, prefix+postfix)
+		names[set.Name], set.Name = legacy, legacy
+	}
+	for i := range obj.Spec.IPSets {
+		for j, name := range obj.Spec.IPSets[i].SetNames {
+			obj.Spec.IPSets[i].SetNames[j] = names[name]
+		}
+	}
+	for i := range obj.Spec.Iptables {
+		obj.Spec.Iptables[i].Name = "OUTPUT/" + netutils.CompressName(name, 20, "")
+		for j, name := range obj.Spec.Iptables[i].IPSets {
+			obj.Spec.Iptables[i].IPSets[j] = names[name]
+		}
+	}
+	for i := range obj.Spec.TrafficControls {
+		obj.Spec.TrafficControls[i].IPSet = names[obj.Spec.TrafficControls[i].IPSet]
+	}
+}
+
+func assertIndependentNetworkRules(t *testing.T, spec v1alpha1.PodNetworkChaosSpec) {
+	t.Helper()
+	owners := map[string]string{}
+	for _, set := range spec.IPSets {
+		if previous, ok := owners[set.Name]; ok {
+			t.Fatalf("IP set %q is shared by %s and %s", set.Name, previous, set.Source)
+		}
+		owners[set.Name] = set.Source
+		if set.IPSetType == v1alpha1.NetIPSet {
+			want := map[string][]string{"team-a/isolate": {"192.0.2.1/32"}, "team-b/isolate": {"192.0.2.2/32"}}[set.Source]
+			if !reflect.DeepEqual(set.Cidrs, want) {
+				t.Fatalf("unexpected destination for %s: %v", set.Source, set.Cidrs)
+			}
+		}
+	}
+	checkOwner := func(name, source string) {
+		t.Helper()
+		if owners[name] != source {
+			t.Fatalf("%s references IP set %q owned by %q", source, name, owners[name])
+		}
+	}
+	for _, set := range spec.IPSets {
+		for _, name := range set.SetNames {
+			checkOwner(name, set.Source)
+		}
+	}
+	chains := map[string]bool{}
+	for _, chain := range spec.Iptables {
+		if chains[chain.Name] {
+			t.Fatalf("duplicate chain name %q", chain.Name)
+		}
+		chains[chain.Name] = true
+		for _, name := range chain.IPSets {
+			checkOwner(name, chain.Source)
+		}
+	}
+	for _, tc := range spec.TrafficControls {
+		checkOwner(tc.IPSet, tc.Source)
+	}
+}
+
+func assertNetworkRuleRequests(t *testing.T, pod *corev1.Pod, obj *v1alpha1.PodNetworkChaos) {
+	t.Helper()
+	d := &networkRuleClient{}
+	r := &Reconciler{Log: logr.Discard()}
+	ctx := context.Background()
+	if err := r.SetIPSets(ctx, pod, obj, d); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SetIptables(ctx, pod, obj, d); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SetTcs(ctx, pod, obj, d); err != nil {
+		t.Fatal(err)
+	}
+	if len(d.sets.Ipsets) != len(obj.Spec.IPSets) || len(d.chains.Chains) != len(obj.Spec.Iptables) || len(d.tcs.Tcs) != len(obj.Spec.TrafficControls) {
+		t.Fatal("daemon requests omitted stored rules")
+	}
+	for i, set := range d.sets.Ipsets {
+		stored := obj.Spec.IPSets[i]
+		if set.Name != stored.Name || !reflect.DeepEqual(set.SetNames, stored.SetNames) || !reflect.DeepEqual(set.Cidrs, stored.Cidrs) {
+			t.Fatalf("daemon IP set differs from persisted rule: %v", set)
+		}
+	}
+	for i, chain := range d.chains.Chains {
+		stored := obj.Spec.Iptables[i]
+		if chain.Name != stored.Name || !reflect.DeepEqual(chain.Ipsets, stored.IPSets) {
+			t.Fatalf("daemon chain differs from persisted rule: %v", chain)
+		}
+	}
+	for i, tc := range d.tcs.Tcs {
+		if tc.Ipset != obj.Spec.TrafficControls[i].IPSet {
+			t.Fatalf("daemon TC differs from persisted rule: %v", tc)
+		}
+	}
+}
+
+type networkRuleClient struct {
+	daemonclient.ChaosDaemonClientInterface
+	sets   *pb.IPSetsRequest
+	chains *pb.IptablesChainsRequest
+	tcs    *pb.TcsRequest
+}
+
+func (c *networkRuleClient) FlushIPSets(_ context.Context, request *pb.IPSetsRequest, _ ...grpc.CallOption) (*empty.Empty, error) {
+	c.sets = request
+	return &empty.Empty{}, nil
+}
+
+func (c *networkRuleClient) SetIptablesChains(_ context.Context, request *pb.IptablesChainsRequest, _ ...grpc.CallOption) (*empty.Empty, error) {
+	c.chains = request
+	return &empty.Empty{}, nil
+}
+
+func (c *networkRuleClient) SetTcs(_ context.Context, request *pb.TcsRequest, _ ...grpc.CallOption) (*empty.Empty, error) {
+	c.tcs = request
+	return &empty.Empty{}, nil
+}


### PR DESCRIPTION
## What problem does this PR solve?

NetworkChaos resources with the same name in different Kubernetes namespaces can generate identical IP-set and iptables-chain names when they select the same workload pod. PodNetworkChaos tracks ownership by namespace/name, but the daemon receives colliding names, allowing one experiment to overwrite another experiment's destination sets or partition rules.

## What's changed and how does it work?

Generate kernel rule names from the full namespace/name identity and IP-set role. Use the available name budget for the hash so long role suffixes do not weaken collision resistance. Preserve the existing 27-character limits, the daemon's temporary IP-set suffix space, and INPUT/OUTPUT chain prefixes.

Names follow namespace/name ownership, matching RawRuleSource and existing recovery transactions. Persisted PodNetworkChaos names are forwarded unchanged; this does not migrate active rules or change the CRD format.

## Validation and reproduction

New regressions failed on the base revision and pass with the fix. They apply same-name experiments from different namespaces through the real partition and filtered-delay implementations, verify separate destination sets and daemon requests, retry application, and recover one experiment while preserving the other. They also exercise mixed persisted legacy/new names and name-length boundaries.

Passed on Linux arm64 with Go 1.25.12:

```sh
go run github.com/pingcap/failpoint/failpoint-ctl enable ./pkg/mock
go test -mod=readonly -race ./controllers/podnetworkchaos/... ./controllers/chaosimpl/networkchaos/... -count=1
go run github.com/pingcap/failpoint/failpoint-ctl disable ./pkg/mock
go vet ./controllers/podnetworkchaos/... ./controllers/chaosimpl/networkchaos/...
```

Focused goimports and git diff --check passed. Tests use fake Kubernetes clients and record daemon requests; no live network changes or Kubernetes experiments were run.

## Downsides

Generated names no longer contain a readable experiment-name fragment. Use the persisted PodNetworkChaos Source fields to map kernel names to experiments. The fixed kernel name limits require truncated hashes (108 bits for IP sets, 84/80 bits for input/output chain suffixes).

## Risk and rollback

This changes newly generated NetworkChaos rule names. Existing stored names remain readable by both old and new controllers/daemons, and recovery continues to clear rules by Source. Already-colliding active experiments must be recovered and reapplied to receive distinct names; this change does not repair their stored names automatically.

Watch for unexpected shared names, missing destination filters, or failed recovery events. Revert and redeploy the controller to roll back; persisted rules remain consumable, but newly generated rules after downgrade regain the original cross-namespace collision risk. No CRD or data migration is required.

## Related changes

- [ ] This change requires UI or website updates

## Checklist

- [x] Updated CHANGELOG.md
- [x] Unit tests
- [ ] E2E tests

## DCO

Commits are signed off.
