### PR TITLE
fix(httpchaos): retry missing TLS Secret data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Prevent HTTPChaos from reporting successful injection when the TLS Secret is missing a configured certificate, private key, or CA entry
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/controllers/podhttpchaos/controller.go
+++ b/controllers/podhttpchaos/controller.go
@@ -167,25 +167,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		cert, ok := secret.Data[tlsKeys.CertName]
 		if !ok {
-			err = errors.Wrapf(err, "get cert %s", tlsKeys.CertName)
+			err = errors.Errorf("certificate key %q not found in secret %s/%s", tlsKeys.CertName, secret.Namespace, secret.Name)
 			r.Recorder.Event(obj, "Warning", "Failed", err.Error())
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		key, ok := secret.Data[tlsKeys.KeyName]
 		if !ok {
-			err = errors.Wrapf(err, "get key %s", tlsKeys.KeyName)
+			err = errors.Errorf("private key %q not found in secret %s/%s", tlsKeys.KeyName, secret.Namespace, secret.Name)
 			r.Recorder.Event(obj, "Warning", "Failed", err.Error())
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		var ca []byte
 		if tlsKeys.CAName != nil {
 			ca, ok = secret.Data[*tlsKeys.CAName]
 			if !ok {
-				err = errors.Wrapf(err, "get ca %s", *tlsKeys.CAName)
+				err = errors.Errorf("CA key %q not found in secret %s/%s", *tlsKeys.CAName, secret.Namespace, secret.Name)
 				r.Recorder.Event(obj, "Warning", "Failed", err.Error())
-				return ctrl.Result{}, nil
+				return ctrl.Result{Requeue: true}, nil
 			}
 		}
 

--- a/controllers/podhttpchaos/controller_test.go
+++ b/controllers/podhttpchaos/controller_test.go
@@ -1,0 +1,161 @@
+// Copyright Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package podhttpchaos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/httpchaos"
+	"github.com/chaos-mesh/chaos-mesh/controllers/utils/chaosdaemon"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/tproxyconfig"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+)
+
+type httpChaosDaemon struct {
+	pb.ChaosDaemonClient
+	requests []*pb.ApplyHttpChaosRequest
+}
+
+func (d *httpChaosDaemon) Close() error { return nil }
+
+func (d *httpChaosDaemon) ApplyHttpChaos(_ context.Context, req *pb.ApplyHttpChaosRequest, _ ...grpc.CallOption) (*pb.ApplyHttpChaosResponse, error) {
+	d.requests = append(d.requests, req)
+	return &pb.ApplyHttpChaosResponse{Instance: 123, StartTime: 456, StatusCode: http.StatusOK}, nil
+}
+
+func TestReconcileMissingTLSData(t *testing.T) {
+	for _, missingKey := range []string{"tls.crt", "tls.key", "ca.crt"} {
+		t.Run(missingKey, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1.AddToScheme(scheme))
+			require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"},
+				Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{
+					Name: "app", ContainerID: "containerd://app",
+				}}},
+			}
+			abort := true
+			child := &v1alpha1.PodHttpChaos{
+				ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name, Generation: 2},
+				Spec: v1alpha1.PodHttpChaosSpec{
+					TLS: &v1alpha1.PodHttpChaosTLS{
+						SecretNamespace: pod.Namespace, SecretName: pod.Name,
+						CertName: "tls.crt", KeyName: "tls.key",
+					},
+					Rules: []v1alpha1.PodHttpChaosRule{{
+						Source: "default/experiment", Port: 443,
+						PodHttpChaosBaseRule: v1alpha1.PodHttpChaosBaseRule{
+							Target:  v1alpha1.PodHttpRequest,
+							Actions: v1alpha1.PodHttpChaosActions{Abort: &abort},
+						},
+					}},
+				},
+			}
+			if missingKey == "ca.crt" {
+				child.Spec.TLS.CAName = &missingKey
+			}
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},
+				Data: map[string][]byte{
+					"tls.crt": []byte("certificate"), "tls.key": []byte("private key"), "ca.crt": []byte("CA certificate"),
+				},
+			}
+			missingValue := secret.Data[missingKey]
+			delete(secret.Data, missingKey)
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&v1alpha1.PodHttpChaos{}).
+				WithObjects(pod, child, secret).Build()
+			daemon := &httpChaosDaemon{}
+			defer mock.With("MockChaosDaemonClient", daemon)()
+			require.NotNil(t, mock.On("MockChaosDaemonClient"), "enable pkg/mock failpoints before running this test")
+			r := &Reconciler{
+				Client: c, Log: logr.Discard(), Recorder: record.NewFakeRecorder(10),
+				ChaosDaemonClientBuilder: &chaosdaemon.ChaosDaemonClientBuilder{},
+			}
+			request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(child)}
+			parent := &v1alpha1.HTTPChaos{
+				Status: v1alpha1.HTTPChaosStatus{Instances: map[string]int64{"default/target": child.Generation}},
+			}
+			impl := httpchaos.NewImpl(c, nil, logr.Discard()).Impl
+			records := []*v1alpha1.Record{{Id: "default/target", Phase: "Not Injected/Wait"}}
+
+			for attempt := 0; attempt < 2; attempt++ {
+				require.NotPanics(t, func() {
+					result, err := r.Reconcile(ctx, request)
+					require.NoError(t, err)
+					require.True(t, result.Requeue, "Secret updates are not watched, so failed injection must retry")
+				})
+				require.NoError(t, c.Get(ctx, request.NamespacedName, child))
+				require.Contains(t, child.Status.FailedMessage, missingKey)
+				require.Equal(t, child.Generation, child.Status.ObservedGeneration)
+				require.Empty(t, daemon.requests)
+				phase, err := impl.Apply(ctx, 0, records, parent)
+				require.Error(t, err)
+				require.NotEqual(t, v1alpha1.Injected, phase)
+			}
+
+			// Repairing only the Secret must allow the same generation to be injected.
+			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(secret), secret))
+			secret.Data[missingKey] = missingValue
+			require.NoError(t, c.Update(ctx, secret))
+			result, err := r.Reconcile(ctx, request)
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result)
+			require.Len(t, daemon.requests, 1)
+			require.Equal(t, "containerd://app", daemon.requests[0].ContainerId)
+			var tlsConfig tproxyconfig.TLSConfig
+			require.NoError(t, json.Unmarshal([]byte(daemon.requests[0].Tls), &tlsConfig))
+			require.Equal(t, secret.Data["tls.crt"], tlsConfig.CertFile.Value)
+			require.Equal(t, secret.Data["tls.key"], tlsConfig.KeyFile.Value)
+			if child.Spec.TLS.CAName != nil {
+				require.NotNil(t, tlsConfig.CAFile)
+				require.Equal(t, secret.Data["ca.crt"], tlsConfig.CAFile.Value)
+			} else {
+				require.Nil(t, tlsConfig.CAFile)
+			}
+			require.NoError(t, c.Get(ctx, request.NamespacedName, child))
+			require.Empty(t, child.Status.FailedMessage)
+			require.EqualValues(t, 123, child.Status.Pid)
+			require.EqualValues(t, 456, child.Status.StartTime)
+			phase, err := impl.Apply(ctx, 0, records, parent)
+			require.NoError(t, err)
+			require.Equal(t, v1alpha1.Injected, phase)
+
+			_, err = r.Reconcile(ctx, request)
+			require.NoError(t, err)
+			require.Len(t, daemon.requests, 1)
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

If a TLS Secret exists but lacks the configured certificate, private-key, or CA entry, PodHTTPChaos calls `errors.Wrapf` with a nil error and then panics on `err.Error()`. Its deferred status update still records the generation with an empty failure message. The parent can consequently report `Injected` without any `ApplyHttpChaos` call, and later child reconciliation skips that generation.

## What's changed and how does it work?

Create a non-nil error for each missing entry and preserve it in `FailedMessage`. Request a rate-limited retry, following the controller's existing error convention, because Secret updates are not watched. The parent stays pending with an error until a subsequent attempt actually succeeds.

Regression tests cover missing certificate, private key, and optional CA data; repeated failed reconciliation; zero injection RPCs during failure; repairing only the Secret; the resulting TLS payload and parent `Injected` transition; and successful reconciliation idempotence.

Related: #4994 fixes Secret lookup and read errors. This PR covers the separate missing-data branches and can be applied independently.

## Validation and reproduction

The regression test fails on the base commit with a nil-pointer panic in all three cases, and passes with this change. It uses fake Kubernetes and daemon clients.

```sh
go run github.com/pingcap/failpoint/failpoint-ctl enable ./pkg/mock
trap 'go run github.com/pingcap/failpoint/failpoint-ctl disable ./pkg/mock' EXIT
go test -mod=readonly ./controllers/podhttpchaos ./controllers/chaosimpl/httpchaos/... -count=1
go vet ./controllers/podhttpchaos ./controllers/chaosimpl/httpchaos/...
```

Focused tests and vet passed with Go 1.25.12. Files were formatted with goimports. Revive completed with warnings for existing package/exported comments and the mock's required `ApplyHttpChaos` RPC spelling. Full containerized checks and live Kubernetes e2e tests were not run.

## Downsides

Missing Secret entries now cause rate-limited retries and warning events until repaired. Recovery also continues to report failure while required TLS data is missing.

## Risk and rollback

The change is limited to missing TLS data in the controller; no API or daemon changes are required. Previously misreported experiments still need reapplication after repairing their Secret so that the child gets a fresh generation. Revert this commit and redeploy the controller to roll back; this restores the previous false-success behavior.

## Related changes

- [ ] This change also requires further updates to the website
- [ ] This change also requires further updates to the UI interface

## Checklist

### CHANGELOG

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] Breaking backward compatibility

## DCO

The commit is signed off.
