### PR TITLE
fix(networkchaos): preserve overlapping selector roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For more information and how-to, see [RFC: Keep A Changelog](https://github.com/
 
 ### Fixed
 
+- Preserve both traffic directions when a NetworkChaos pod matches overlapping source and target selectors with `direction: both`.
 - Fixed helm chart template include for extra objects to use the correct render function [#4780](https://github.com/chaos-mesh/chaos-mesh/pull/4780)
 - Fix `install.sh` exiting when kubectl version prints warnings to stderr [#4796](https://github.com/chaos-mesh/chaos-mesh/pull/4796)
 - Remove caBundle placeholder in webhook templates when cert-manager is enabled to fix server-side apply conflicts [#4828](https://github.com/chaos-mesh/chaos-mesh/pull/4828)

--- a/controllers/chaosimpl/networkchaos/trafficcontrol/impl.go
+++ b/controllers/chaosimpl/networkchaos/trafficcontrol/impl.go
@@ -110,66 +110,58 @@ func (impl *Impl) Apply(ctx context.Context, index int, records []*v1alpha1.Reco
 		return v1alpha1.NotInjected, err
 	}
 
+	inSource := record.SelectorKey == "."
+	inTarget := record.SelectorKey == ".Target"
+	if !inSource && !inTarget {
+		impl.Log.Info("unknown selector key", "record", record)
+		return v1alpha1.NotInjected, nil
+	}
+
+	var sources, targets []*v1alpha1.Record
+	for _, selected := range records {
+		switch selected.SelectorKey {
+		case ".":
+			sources = append(sources, selected)
+		case ".Target":
+			targets = append(targets, selected)
+		}
+		if networkchaos.Spec.Direction == v1alpha1.Both && selected.Id == record.Id {
+			inSource = inSource || selected.SelectorKey == "."
+			inTarget = inTarget || selected.SelectorKey == ".Target"
+		}
+	}
+
+	applyTo := inSource && (networkchaos.Spec.Direction == v1alpha1.To || networkchaos.Spec.Direction == v1alpha1.Both)
+	applyFrom := inTarget && (networkchaos.Spec.Direction == v1alpha1.From || networkchaos.Spec.Direction == v1alpha1.Both)
+	if !applyTo && !applyFrom {
+		return v1alpha1.Injected, nil
+	}
+
+	// Both selector roles of an overlapping pod share one Source and one
+	// observed generation. Rebuild them together so either record, including a
+	// retry, commits the complete configuration instead of clearing the other role.
 	source := networkchaos.Namespace + "/" + networkchaos.Name
 	m := impl.builder.WithInit(source, types.NamespacedName{
 		Namespace: pod.Namespace,
 		Name:      pod.Name,
 	})
-
-	if record.SelectorKey == "." {
-		if networkchaos.Spec.Direction == v1alpha1.To || networkchaos.Spec.Direction == v1alpha1.Both {
-			var targets []*v1alpha1.Record
-			for _, record := range records {
-				if record.SelectorKey == ".Target" {
-					targets = append(targets, record)
-				}
-			}
-
-			err := impl.ApplyTc(ctx, m, targets, networkchaos, targetIPSetPostFix, networkchaos.Spec.Device)
-			if err != nil {
-				return v1alpha1.NotInjected, err
-			}
-
-			generationNumber, err := m.Commit(ctx, networkchaos)
-			if err != nil {
-				return v1alpha1.NotInjected, err
-			}
-
-			// modify the custom status
-			networkchaos.Status.Instances[record.Id] = generationNumber
-			return waitForApplySync, nil
+	if applyTo {
+		if err := impl.ApplyTc(ctx, m, targets, networkchaos, targetIPSetPostFix, networkchaos.Spec.Device); err != nil {
+			return v1alpha1.NotInjected, err
 		}
-
-		return v1alpha1.Injected, nil
-	} else if record.SelectorKey == ".Target" {
-		if networkchaos.Spec.Direction == v1alpha1.From || networkchaos.Spec.Direction == v1alpha1.Both {
-			var targets []*v1alpha1.Record
-			for _, record := range records {
-				if record.SelectorKey == "." {
-					targets = append(targets, record)
-				}
-			}
-
-			err := impl.ApplyTc(ctx, m, targets, networkchaos, sourceIPSetPostFix, networkchaos.Spec.TargetDevice)
-			if err != nil {
-				return v1alpha1.NotInjected, err
-			}
-
-			generationNumber, err := m.Commit(ctx, networkchaos)
-			if err != nil {
-				return v1alpha1.NotInjected, err
-			}
-
-			// modify the custom status
-			networkchaos.Status.Instances[record.Id] = generationNumber
-			return waitForApplySync, nil
-		}
-
-		return v1alpha1.Injected, nil
-	} else {
-		impl.Log.Info("unknown selector key", "record", record)
-		return v1alpha1.NotInjected, nil
 	}
+	if applyFrom {
+		if err := impl.ApplyTc(ctx, m, sources, networkchaos, sourceIPSetPostFix, networkchaos.Spec.TargetDevice); err != nil {
+			return v1alpha1.NotInjected, err
+		}
+	}
+	generationNumber, err := m.Commit(ctx, networkchaos)
+	if err != nil {
+		return v1alpha1.NotInjected, err
+	}
+
+	networkchaos.Status.Instances[record.Id] = generationNumber
+	return waitForApplySync, nil
 }
 
 func (impl *Impl) Recover(ctx context.Context, index int, records []*v1alpha1.Record, obj v1alpha1.InnerObject) (v1alpha1.Phase, error) {

--- a/controllers/chaosimpl/networkchaos/trafficcontrol/impl_test.go
+++ b/controllers/chaosimpl/networkchaos/trafficcontrol/impl_test.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package trafficcontrol
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/chaos-mesh/chaos-mesh/controllers/chaosimpl/networkchaos/podnetworkchaosmanager"
+	selectorpod "github.com/chaos-mesh/chaos-mesh/pkg/selector/pod"
+)
+
+func TestBidirectionalOverlap(t *testing.T) {
+	for _, targetFirst := range []bool{false, true} {
+		name := "source first"
+		if targetFirst {
+			name = "target first"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, targetDevice := range []string{"eth0", "net1"} {
+				t.Run(targetDevice, func(t *testing.T) {
+					f := newTrafficControlFixture(t, []string{"a", "overlap"}, []string{"overlap", "b"}, v1alpha1.Both, targetFirst)
+					f.chaos.Spec.Device, f.chaos.Spec.TargetDevice = "eth0", targetDevice
+					other := v1alpha1.RawTrafficControl{Type: v1alpha1.Netem, Source: "default/other", TcParameter: f.chaos.Spec.TcParameter}
+					if err := f.client.Create(f.ctx, &v1alpha1.PodNetworkChaos{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "overlap"},
+						Spec:       v1alpha1.PodNetworkChaosSpec{TrafficControls: []v1alpha1.RawTrafficControl{other}},
+					}); err != nil {
+						t.Fatal(err)
+					}
+					for i, record := range f.records {
+						f.apply(i)
+						if record.Id == "default/overlap" {
+							// Either role must commit both directions immediately.
+							f.assertRules("overlap", []expectedTrafficControl{
+								{device: "eth0", destinations: []string{"192.0.2.2/32", "192.0.2.3/32"}},
+								{device: targetDevice, destinations: []string{"192.0.2.1/32", "192.0.2.2/32"}},
+							})
+						}
+					}
+					f.assertRules("a", []expectedTrafficControl{{device: "eth0", destinations: []string{"192.0.2.2/32", "192.0.2.3/32"}}})
+					f.assertRules("b", []expectedTrafficControl{{device: targetDevice, destinations: []string{"192.0.2.1/32", "192.0.2.2/32"}}})
+
+					// A lost status update can retry either selector role. Rebuilding
+					// it must neither discard the other role nor append duplicates.
+					beforeRetry := f.read("overlap")
+					for i, record := range f.records {
+						if record.Id == "default/overlap" {
+							record.Phase = v1alpha1.NotInjected
+							f.apply(i)
+							got := f.read("overlap")
+							if !reflect.DeepEqual(got.Spec, beforeRetry.Spec) || got.Generation != beforeRetry.Generation {
+								t.Fatal("retry changed the complete pod configuration")
+							}
+						}
+					}
+					for i := range f.records {
+						if f.apply(i) != waitForApplySync {
+							t.Fatal("reported Injected before the pod configuration was observed")
+						}
+					}
+					f.acknowledge()
+					for i := range f.records {
+						if f.apply(i) != v1alpha1.Injected {
+							t.Fatal("expected Injected after the complete pod configuration was observed")
+						}
+					}
+
+					// Both records recover the same Source. Repeating that operation
+					// must be safe and preserve another experiment on the pod.
+					for i, record := range f.records {
+						phase, err := f.impl.Recover(f.ctx, i, f.records, f.chaos)
+						if err != nil || phase != waitForRecoverSync {
+							t.Fatalf("Recover returned %s, %v", phase, err)
+						}
+						record.Phase = phase
+					}
+					for _, pod := range []string{"a", "overlap", "b"} {
+						f.assertRules(pod, nil)
+					}
+					if got := f.read("overlap").Spec.TrafficControls; !reflect.DeepEqual(got, []v1alpha1.RawTrafficControl{other}) {
+						t.Fatalf("recovery changed the other experiment: %#v", got)
+					}
+					f.acknowledge()
+					for i := range f.records {
+						phase, err := f.impl.Recover(f.ctx, i, f.records, f.chaos)
+						if err != nil || phase != v1alpha1.NotInjected {
+							t.Fatalf("acknowledged recovery returned %s, %v", phase, err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTrafficControlWithoutOverlap(t *testing.T) {
+	for _, direction := range []v1alpha1.Direction{v1alpha1.To, v1alpha1.From, v1alpha1.Both} {
+		t.Run(string(direction), func(t *testing.T) {
+			f := newTrafficControlFixture(t, []string{"a"}, []string{"b"}, direction, false)
+			for i := range f.records {
+				f.apply(i)
+			}
+			if direction != v1alpha1.From {
+				f.assertRules("a", []expectedTrafficControl{{destinations: []string{"192.0.2.3/32"}}})
+			} else if err := f.client.Get(f.ctx, client.ObjectKey{Namespace: "default", Name: "a"}, &v1alpha1.PodNetworkChaos{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("inactive source should not have a PodNetworkChaos: %v", err)
+			}
+			if direction != v1alpha1.To {
+				f.assertRules("b", []expectedTrafficControl{{destinations: []string{"192.0.2.1/32"}}})
+			} else if err := f.client.Get(f.ctx, client.ObjectKey{Namespace: "default", Name: "b"}, &v1alpha1.PodNetworkChaos{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("inactive target should not have a PodNetworkChaos: %v", err)
+			}
+		})
+	}
+}
+
+type expectedTrafficControl struct {
+	device       string
+	destinations []string
+}
+
+type trafficControlFixture struct {
+	t       *testing.T
+	ctx     context.Context
+	client  client.Client
+	impl    *Impl
+	chaos   *v1alpha1.NetworkChaos
+	records []*v1alpha1.Record
+}
+
+func newTrafficControlFixture(t *testing.T, sources, targets []string, direction v1alpha1.Direction, targetFirst bool) *trafficControlFixture {
+	t.Helper()
+	f := &trafficControlFixture{t: t, ctx: context.Background()}
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	var pods []client.Object
+	for name, ip := range map[string]string{"a": "192.0.2.1", "overlap": "192.0.2.2", "b": "192.0.2.3"} {
+		pods = append(pods, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name}, Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: ip}})
+	}
+	f.client = &generationClient{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pods...).WithStatusSubresource(&v1alpha1.PodNetworkChaos{}).Build()}
+	selector := func(names []string) v1alpha1.PodSelector {
+		return v1alpha1.PodSelector{Mode: v1alpha1.AllMode, Selector: v1alpha1.PodSelectorSpec{Pods: map[string][]string{"default": names}}}
+	}
+	target := selector(targets)
+	f.chaos = &v1alpha1.NetworkChaos{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "delay"},
+		Spec: v1alpha1.NetworkChaosSpec{
+			Action: v1alpha1.DelayAction, Direction: direction, PodSelector: selector(sources), Target: &target,
+			TcParameter: v1alpha1.TcParameter{Delay: &v1alpha1.DelaySpec{Latency: "200ms"}},
+		},
+	}
+	if err := f.chaos.Default(f.ctx, f.chaos); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.chaos.ValidateCreate(f.ctx, f.chaos); err != nil {
+		t.Fatalf("invalid test experiment: %v", err)
+	}
+	keys := []string{".", ".Target"}
+	if targetFirst {
+		slices.Reverse(keys)
+	}
+	for _, key := range keys {
+		selected, err := selectorpod.SelectAndFilterPods(f.ctx, f.client, f.client, f.chaos.GetSelectorSpecs()[key].(*v1alpha1.PodSelector), true, "", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pod := range selected {
+			f.records = append(f.records, &v1alpha1.Record{Id: pod.Namespace + "/" + pod.Name, SelectorKey: key, Phase: v1alpha1.NotInjected})
+		}
+	}
+	builder := podnetworkchaosmanager.NewBuilder(podnetworkchaosmanager.Params{Client: f.client, Reader: f.client, Scheme: scheme, Logger: logr.Discard()})
+	f.impl = NewImpl(f.client, builder, logr.Discard())
+	return f
+}
+
+func (f *trafficControlFixture) apply(index int) v1alpha1.Phase {
+	f.t.Helper()
+	phase, err := f.impl.Apply(f.ctx, index, f.records, f.chaos)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.records[index].Phase = phase
+	return phase
+}
+
+func (f *trafficControlFixture) read(name string) *v1alpha1.PodNetworkChaos {
+	f.t.Helper()
+	obj := &v1alpha1.PodNetworkChaos{}
+	if err := f.client.Get(f.ctx, client.ObjectKey{Namespace: "default", Name: name}, obj); err != nil {
+		f.t.Fatal(err)
+	}
+	return obj
+}
+
+func (f *trafficControlFixture) acknowledge() {
+	f.t.Helper()
+	var objects v1alpha1.PodNetworkChaosList
+	if err := f.client.List(f.ctx, &objects); err != nil {
+		f.t.Fatal(err)
+	}
+	for _, obj := range objects.Items {
+		obj.Status.ObservedGeneration = obj.Generation
+		if err := f.client.Status().Update(f.ctx, &obj); err != nil {
+			f.t.Fatal(err)
+		}
+	}
+}
+
+func (f *trafficControlFixture) assertRules(pod string, want []expectedTrafficControl) {
+	f.t.Helper()
+	obj := f.read(pod)
+	sets := map[string]v1alpha1.RawIPSet{}
+	for _, set := range obj.Spec.IPSets {
+		if _, ok := sets[set.Name]; ok {
+			f.t.Fatalf("duplicate IP set %s", set.Name)
+		}
+		sets[set.Name] = set
+	}
+	var got []expectedTrafficControl
+	for _, tc := range obj.Spec.TrafficControls {
+		if tc.Source != "default/delay" {
+			continue
+		}
+		if tc.Type != v1alpha1.Netem || !reflect.DeepEqual(tc.TcParameter, f.chaos.Spec.TcParameter) {
+			f.t.Fatalf("traffic control changed the requested fault: %#v", tc)
+		}
+		var destinations []string
+		group, ok := sets[tc.IPSet]
+		if !ok || group.IPSetType != v1alpha1.SetIPSet || len(group.SetNames) != 2 {
+			f.t.Fatalf("invalid traffic control filter: %#v", tc)
+		}
+		for _, name := range group.SetNames {
+			set, ok := sets[name]
+			if !ok || set.Source != tc.Source {
+				f.t.Fatalf("missing or unowned IP set %s", name)
+			}
+			destinations = append(destinations, set.Cidrs...)
+		}
+		slices.Sort(destinations)
+		got = append(got, expectedTrafficControl{device: tc.Device, destinations: destinations})
+	}
+	if !reflect.DeepEqual(got, want) || len(sets) != 3*len(want) {
+		f.t.Fatalf("pod %s traffic controls = %#v (%d sets), want %#v", pod, got, len(sets), want)
+	}
+}
+
+// The fake client does not increment generations. Model that API-server behavior
+// to exercise the controller's wait phases without an envtest cluster.
+type generationClient struct {
+	client.Client
+}
+
+func (c *generationClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*v1alpha1.PodNetworkChaos); ok {
+		obj.SetGeneration(1)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *generationClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if chaos, ok := obj.(*v1alpha1.PodNetworkChaos); ok {
+		old := &v1alpha1.PodNetworkChaos{}
+		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), old); err != nil {
+			return err
+		}
+		// Compare the API representation: omitempty fields can be empty slices
+		// in a transaction and nil after the fake client's serialization.
+		oldSpec, err := json.Marshal(old.Spec)
+		if err != nil {
+			return err
+		}
+		newSpec, err := json.Marshal(chaos.Spec)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(oldSpec, newSpec) {
+			chaos.Generation = old.Generation + 1
+		}
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}

--- a/test/integration_test/network/run.sh
+++ b/test/integration_test/network/run.sh
@@ -34,11 +34,18 @@ for ((k=0; k<30; k++)); do
     sleep 1
 done
 
+# Resolve the destination before the five-second fault window starts.
+target_ip=$(kubectl get pod busybox-1 -n busybox -o jsonpath='{.status.podIP}')
+if [ -z "$target_ip" ]; then
+    echo "busybox-1 has no Pod IP"
+    exit 1
+fi
+
 echo "****** test delay chaos ******"
 kubectl apply -f ./delay_chaos.yaml
 
 echo "verification"
-kubectl exec busybox-0 -i -n busybox -- ping -c 10 busybox-1.busybox.busybox.svc > ping.log
+kubectl exec busybox-0 -i -n busybox -- ping -c 10 "$target_ip" > ping.log
 cat ping.log
 
 # the log looks like `64 bytes from 10.244.0.9: seq=0 ttl=63 time=0.240 ms`


### PR DESCRIPTION
## What problem does this PR solve?

A bidirectional NetworkChaos experiment can lose one requested direction when a pod matches both selectors. For example, source pods `{A, O}` and target pods `{O, B}` produce two records for `O`. Each record clears and rebuilds the same experiment's per-pod rules, so the second record removes the first role's filter. All records can then report `Injected` while either `O -> A` or `O -> B` has no requested delay.

Related: #3493 reports problems with overlapping source and target selectors.

## What's changed and how does it work?

For `direction: both`, either record for an overlapping pod rebuilds both roles in one transaction before committing its generation. Keep the existing source/target IP-set names, filters, interface selection, and experiment ownership. Retries reproduce the same complete configuration, and recovery continues to clear both roles using the existing experiment owner.

Regression tests cover both processing orders, matching and differing interface settings, non-overlapping `to`/`from`/`both` experiments, repeated application, acknowledgement, and recovery while another experiment remains on the pod.

Resolve the destination Pod IP before starting the timed network integration test. Keep the five-second duration, ten packets, and requirement for three to six packets with at least 10ms latency, while moving hostname resolution out of the measurement window.

This change is independent of the namespace identity fix in #5090. Experiments using different interfaces also need the separate classifier-chain fix in #5089; these tests verify the intended per-interface controller configuration.

## Validation and reproduction

```sh
go test -mod=readonly ./controllers/chaosimpl/networkchaos/... -count=1
go vet ./controllers/chaosimpl/networkchaos/...
```

All four overlapping-selector cases fail against the base implementation and pass with this change. The NetworkChaos package tests and vet passed with Go 1.25.12. Tests use fake Kubernetes clients and model API-server generations and daemon acknowledgements.

A separate probe passed both processing orders through actual PodNetworkChaos IP-set, iptables, and traffic-control RPC conversion and netem merging, verifying both filter graphs and the requested 200ms delay with a fake daemon. Files were formatted with goimports; revive reports only existing comment warnings. The integration shell script passes `bash -n`. Full containerized checks and live Kubernetes e2e tests were not run locally.

## Downsides

An overlapping pod now retains both requested role filters instead of just the last one. This adds one traffic-control entry and three IP-set entries for that pod. Each overlapping record rebuilds both roles, with additional target-pod reads during initial application or retries.

## Risk and rollback

The change affects NetworkChaos traffic-control actions with overlapping selectors and `direction: both`; partition handling and public APIs are unchanged. The intended effect is that previously missed destinations now receive the configured fault. Reapply existing experiments to rebuild their child configuration. Revert this commit and redeploy the controller to roll back, then reapply experiments if the previous rule layout is needed; a controller rollback alone does not rewrite already acknowledged child resources.

## Related changes

- [ ] This change also requires further updates to the website
- [ ] This change also requires further updates to the UI interface

## Checklist

### CHANGELOG

- [x] I have updated the `CHANGELOG.md`
- [ ] I have labeled this PR with "no-need-update-changelog"

### Tests

- [x] Unit test
- [ ] E2E test
- [ ] Manual test

### Side effects

- [ ] Breaking backward compatibility

## DCO

The commit is signed off.
